### PR TITLE
Add persistent terminals via PTY daemon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,8 @@ Electron app + Claude Code plugin for session intention tracking.
 
 ## Architecture
 
-- `src/main.js` — Main process: window, IPC, file watching, session discovery
+- `src/pty-daemon.js` — **PTY daemon**: standalone process managing all terminals ([docs/pty-daemon.md](docs/pty-daemon.md))
+- `src/main.js` — Main process: window, IPC, daemon client, session discovery
 - `src/preload.js` — Context bridge (`api` object)
 - `src/renderer.js` — CodeMirror 6 live preview editor + session sidebar
 - `src/index.html` + `src/styles.css` — Layout, neon red dark theme
@@ -16,6 +17,8 @@ Electron app + Claude Code plugin for session intention tracking.
 - `~/.claude/session-pids/<PID>` — Session ID (written by plugin hook)
 - `~/.open-cockpit/intentions/<session_id>.md` — Intention files (created by app on first open)
 - `~/.open-cockpit/colors.json` — Directory color overrides ([docs/theme.md](docs/theme.md))
+- `~/.open-cockpit/pty-daemon.sock` — PTY daemon Unix socket
+- `~/.open-cockpit/pty-daemon.pid` — PTY daemon PID file
 
 ## Dev
 
@@ -35,27 +38,31 @@ npm run build   # Bundle renderer only (esbuild)
 
 Multiple Claude sessions may work on different worktrees simultaneously. Electron processes inherit the `cwd` of the worktree — use `lsof` to identify and kill only yours.
 
-**Launch:** `npm run dev &`
+**Always use this command to launch** (kills any existing instance first — safe even on first launch):
+```bash
+DAEMON_PID=$(cat ~/.open-cockpit/pty-daemon.pid 2>/dev/null || echo NONE); lsof -c Electron 2>/dev/null | awk -v dir="$(pwd)" '/cwd/ && $NF == dir {print $2}' | grep -v "^${DAEMON_PID}$" | sort -u | xargs kill 2>/dev/null; sleep 0.5; nohup npm run dev > /dev/null 2>&1 &
+```
+
+> ⚠️ `npm run dev` exits immediately while Electron stays running in the background.
+> It will *look* like it died — it didn't. Always kill-before-launch to avoid stacking instances.
+> The daemon PID is excluded so terminals survive restarts.
 
 **Kill only YOUR worktree's instance:**
 ```bash
-lsof -c Electron 2>/dev/null | grep "cwd.*$(pwd)" | awk '{print $2}' | sort -u | xargs kill 2>/dev/null
+DAEMON_PID=$(cat ~/.open-cockpit/pty-daemon.pid 2>/dev/null || echo NONE); lsof -c Electron 2>/dev/null | awk -v dir="$(pwd)" '/cwd/ && $NF == dir {print $2}' | grep -v "^${DAEMON_PID}$" | sort -u | xargs kill 2>/dev/null
 ```
 
-**Restart (kill + relaunch):**
-```bash
-lsof -c Electron 2>/dev/null | grep "cwd.*$(pwd)" | awk '{print $2}' | sort -u | xargs kill 2>/dev/null; sleep 0.5; npm run dev &
-```
-
-**NEVER** use `pkill -f electron` or `killall Electron` — this kills other sessions' instances and the production app.
+**NEVER** use `pkill -f electron`, `killall Electron`, or `grep "cwd.*$(pwd)"` (substring match) — these can kill other sessions' instances or the production app. Always use exact `$NF == dir` matching as shown above.
 
 ## Reloading after changes
 
-- **Renderer changes** (`renderer.js`, `styles.css`, `index.html`): `npm run build`, then Cmd+R in the dev window.
-- **Main process changes** (`main.js`, `preload.js`): kill and restart your dev instance (see commands above).
+- **Renderer changes** (`renderer.js`, `styles.css`, `index.html`): `npm run build`, then Cmd+R in the dev window. Terminals survive (daemon keeps them alive).
+- **Main process changes** (`main.js`, `preload.js`): kill and restart your dev instance (see commands above). Terminals survive (daemon keeps them alive).
+- **Daemon changes** (`pty-daemon.js`): kill daemon (`kill $(cat ~/.open-cockpit/pty-daemon.pid)`), then restart app. This kills all terminals.
 
 ## Further docs
 
+- [docs/pty-daemon.md](docs/pty-daemon.md) — PTY daemon architecture, protocol, debugging
 - [docs/theme.md](docs/theme.md) — Color scheme, directory color coding, user overrides
 - [docs/hooks.md](docs/hooks.md) — Plugin hooks
 

--- a/docs/pty-daemon.md
+++ b/docs/pty-daemon.md
@@ -1,0 +1,73 @@
+# PTY Daemon
+
+Terminals are managed by a standalone daemon process (`src/pty-daemon.js`) that runs independently of any Electron window. This means:
+
+- Terminals survive app restarts, Cmd+R reloads, and dev instance cycling
+- Multiple Electron instances (dev + production) can display the same terminals simultaneously
+- Input from any attached client goes to the same PTY
+
+## Architecture
+
+```
+Electron (any instance)          PTY Daemon
+┌──────────────┐         ┌──────────────────┐
+│  renderer.js  │         │  pty-daemon.js    │
+│  (xterm.js)   │◄──IPC──►│                  │
+│               │         │  node-pty procs   │
+│  main.js      │◄─socket─►│  output buffers   │
+│  (client)     │         │  session mapping  │
+└──────────────┘         └──────────────────┘
+```
+
+## Socket protocol
+
+Unix domain socket at `~/.open-cockpit/pty-daemon.sock`. Newline-delimited JSON.
+
+### Client → Daemon
+
+| Command | Fields | Response |
+|---------|--------|----------|
+| `spawn` | `cwd, cmd, args, sessionId` | `spawned` with `termId, pid` |
+| `write` | `termId, data` | (none) |
+| `resize` | `termId, cols, rows` | (none) |
+| `kill` | `termId` | `killed` |
+| `list` | — | `list-result` with `ptys[]` |
+| `attach` | `termId` | `attached` + `replay` with buffered output |
+| `detach` | `termId` | (none) |
+| `set-session` | `termId, sessionId` | `session-set` |
+| `ping` | — | `pong` |
+
+### Daemon → Client (push events)
+
+| Event | Fields | When |
+|-------|--------|------|
+| `data` | `termId, data` | PTY output (only to attached clients) |
+| `exit` | `termId, exitCode` | PTY process exited |
+| `replay` | `termId, data` | Buffered output sent on attach |
+
+## Lifecycle
+
+- **Auto-start**: Electron's main process spawns the daemon if not running
+- **PID file**: `~/.open-cockpit/pty-daemon.pid`
+- **Auto-exit**: 30 minutes after last terminal closes and last client disconnects
+- **Signals**: SIGTERM/SIGINT → clean shutdown (kills all PTYs, removes socket)
+
+## Output buffering
+
+Each terminal buffers the last 100KB of output. On `attach`, this buffer is replayed to the client, restoring terminal content after app restart.
+
+## Debugging
+
+```bash
+# Check if daemon is running
+cat ~/.open-cockpit/pty-daemon.pid && kill -0 $(cat ~/.open-cockpit/pty-daemon.pid) && echo "alive" || echo "dead"
+
+# View daemon logs (stderr)
+# Daemon runs detached with stdio ignored — redirect in pty-daemon.js if needed
+
+# List active terminals via socat
+echo '{"type":"list","id":1}' | socat - UNIX-CONNECT:$HOME/.open-cockpit/pty-daemon.sock
+
+# Kill daemon manually
+kill $(cat ~/.open-cockpit/pty-daemon.pid)
+```

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,8 @@ const { app, BrowserWindow, ipcMain, Menu } = require("electron");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
-const pty = require("node-pty");
+const net = require("net");
+const { spawn: spawnChild } = require("child_process");
 
 const IS_DEV = process.argv.includes("--dev");
 const OPEN_COCKPIT_DIR = path.join(os.homedir(), ".open-cockpit");
@@ -10,14 +11,19 @@ const INTENTIONS_DIR = path.join(OPEN_COCKPIT_DIR, "intentions");
 const COLORS_FILE = path.join(OPEN_COCKPIT_DIR, "colors.json");
 const SESSION_PIDS_DIR = path.join(os.homedir(), ".claude", "session-pids");
 const CLAUDE_PROJECTS_DIR = path.join(os.homedir(), ".claude", "projects");
+const DAEMON_SOCKET = path.join(OPEN_COCKPIT_DIR, "pty-daemon.sock");
+const DAEMON_SCRIPT = path.join(__dirname, "pty-daemon.js");
+const DAEMON_PID_FILE = path.join(OPEN_COCKPIT_DIR, "pty-daemon.pid");
 
 // Track file watchers and which session each window is viewing
 const fileWatchers = new Map();
 let mainWindow = null;
 
-// PTY management
-const ptyProcesses = new Map(); // termId -> pty process
-let nextTermId = 1;
+// --- PTY Daemon Client ---
+let daemonSocket = null;
+let daemonConnecting = null; // Promise while connection in progress
+let daemonReqId = 0;
+const pendingRequests = new Map(); // reqId -> { resolve, reject }
 
 function createWindow() {
   if (IS_DEV) {
@@ -39,6 +45,16 @@ function createWindow() {
 
   mainWindow.loadFile(path.join(__dirname, "index.html"));
 
+  // Ctrl+Tab / Ctrl+Shift+Tab — not supported as menu accelerators, handle via input events
+  mainWindow.webContents.on("before-input-event", (event, input) => {
+    if (input.control && input.key === "Tab") {
+      event.preventDefault();
+      mainWindow.webContents.send(
+        input.shift ? "prev-terminal-tab" : "next-terminal-tab",
+      );
+    }
+  });
+
   mainWindow.webContents.on("console-message", (_e, level, message) => {
     console.log(`[renderer] ${message}`);
   });
@@ -46,14 +62,17 @@ function createWindow() {
 
 function getCwdFromJsonl(sessionId) {
   try {
-    const { execSync } = require("child_process");
-    const jsonlPath = execSync(
-      `find ${JSON.stringify(CLAUDE_PROJECTS_DIR)} -name "${sessionId}.jsonl" 2>/dev/null | head -1`,
-      { encoding: "utf-8" },
-    ).trim();
+    const { execFileSync } = require("child_process");
+    const jsonlPath = execFileSync(
+      "find",
+      [CLAUDE_PROJECTS_DIR, "-name", `${sessionId}.jsonl`],
+      { encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] },
+    )
+      .split("\n")[0]
+      .trim();
     if (!jsonlPath) return null;
 
-    const tail = execSync(`tail -100 ${JSON.stringify(jsonlPath)}`, {
+    const tail = execFileSync("tail", ["-100", jsonlPath], {
       encoding: "utf-8",
     });
     let cwd = "";
@@ -210,18 +229,157 @@ function watchIntention(sessionId) {
 
 const pendingPolls = new Set();
 
-function killAllPty() {
-  for (const p of ptyProcesses.values()) {
-    try {
-      p.kill();
-    } catch {}
+// --- Daemon client helpers ---
+
+function isDaemonRunning() {
+  try {
+    const pid = parseInt(fs.readFileSync(DAEMON_PID_FILE, "utf-8").trim(), 10);
+    process.kill(pid, 0); // signal 0 = check if alive
+    return true;
+  } catch {
+    return false;
   }
-  ptyProcesses.clear();
-  for (const entry of pendingPolls) entry.cancel();
-  pendingPolls.clear();
 }
 
-app.whenReady().then(() => {
+function startDaemon() {
+  return new Promise((resolve, reject) => {
+    if (isDaemonRunning()) return resolve();
+
+    const child = spawnChild(process.execPath, [DAEMON_SCRIPT], {
+      detached: true,
+      stdio: "ignore",
+      cwd: os.homedir(), // Don't inherit app cwd — prevents kill-by-cwd from hitting daemon
+      env: { ...process.env },
+    });
+    child.unref();
+
+    // Wait for socket to appear
+    let attempts = 0;
+    const check = () => {
+      if (fs.existsSync(DAEMON_SOCKET)) return resolve();
+      if (++attempts > 40) return reject(new Error("Daemon failed to start"));
+      setTimeout(check, 100);
+    };
+    setTimeout(check, 50);
+  });
+}
+
+function connectToDaemon() {
+  if (daemonSocket && !daemonSocket.destroyed) return Promise.resolve();
+  if (daemonConnecting) return daemonConnecting;
+
+  daemonConnecting = new Promise((resolve, reject) => {
+    const sock = net.createConnection(DAEMON_SOCKET);
+    let buf = "";
+    let settled = false;
+
+    sock.on("connect", () => {
+      if (settled) return; // error already fired
+      settled = true;
+      daemonSocket = sock;
+      daemonConnecting = null;
+      resolve();
+    });
+
+    sock.on("data", (chunk) => {
+      buf += chunk.toString();
+      let idx;
+      while ((idx = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, idx);
+        buf = buf.slice(idx + 1);
+        if (!line.trim()) continue;
+        try {
+          handleDaemonMessage(JSON.parse(line));
+        } catch (err) {
+          console.error("[main] Daemon parse error:", err.message);
+        }
+      }
+    });
+
+    sock.on("close", () => {
+      daemonSocket = null;
+      daemonConnecting = null;
+      // Reject all pending requests
+      for (const [, { reject: rej }] of pendingRequests) {
+        rej(new Error("Daemon disconnected"));
+      }
+      pendingRequests.clear();
+    });
+
+    sock.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        daemonConnecting = null;
+        reject(err);
+      }
+      // After connection established, errors trigger close — handled there
+    });
+  });
+
+  return daemonConnecting;
+}
+
+async function ensureDaemon() {
+  if (daemonSocket && !daemonSocket.destroyed) return;
+  await startDaemon();
+  await connectToDaemon();
+}
+
+function daemonSend(msg) {
+  if (daemonSocket && !daemonSocket.destroyed) {
+    daemonSocket.write(JSON.stringify(msg) + "\n");
+  }
+}
+
+async function daemonRequest(msg) {
+  await ensureDaemon();
+  return new Promise((resolve, reject) => {
+    const id = ++daemonReqId;
+    msg.id = id;
+    pendingRequests.set(id, { resolve, reject });
+    daemonSend(msg);
+    // Timeout after 10s
+    setTimeout(() => {
+      if (pendingRequests.has(id)) {
+        pendingRequests.delete(id);
+        reject(new Error("Daemon request timeout"));
+      }
+    }, 10000);
+  });
+}
+
+function handleDaemonMessage(msg) {
+  // Handle response to a request
+  if (msg.id && pendingRequests.has(msg.id)) {
+    const { resolve } = pendingRequests.get(msg.id);
+    pendingRequests.delete(msg.id);
+    resolve(msg);
+    return;
+  }
+
+  // Handle push events (data, exit, replay)
+  if (msg.type === "data" && mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send("pty-data", msg.termId, msg.data);
+    return;
+  }
+  if (msg.type === "exit" && mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send("pty-exit", msg.termId);
+    return;
+  }
+  if (msg.type === "replay" && mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send("pty-replay", msg.termId, msg.data);
+    return;
+  }
+}
+
+app.whenReady().then(async () => {
+  // Start daemon connection early
+  try {
+    await ensureDaemon();
+  } catch (err) {
+    console.error("[main] Failed to start daemon:", err.message);
+  }
+
   ipcMain.handle("get-dir-colors", () => {
     try {
       return JSON.parse(fs.readFileSync(COLORS_FILE, "utf-8"));
@@ -238,54 +396,50 @@ app.whenReady().then(() => {
     watchIntention(sessionId),
   );
 
-  // PTY IPC handlers
-  const ALLOWED_SHELLS = new Set(["/bin/zsh", "/bin/bash", "/bin/sh"]);
+  // PTY IPC handlers — all forwarded to daemon
 
-  ipcMain.handle("pty-spawn", (_e, { cwd, cmd, args }) => {
-    const shell =
-      cmd && ALLOWED_SHELLS.has(cmd) ? cmd : process.env.SHELL || "/bin/zsh";
-    const shellArgs = args || [];
-    const termId = nextTermId++;
-
-    // Strip Claude session env vars so spawned Claude doesn't think it's nested
-    const cleanEnv = { ...process.env, TERM: "xterm-256color" };
-    delete cleanEnv.CLAUDECODE;
-    delete cleanEnv.CLAUDE_CODE_SESSION_ID;
-
-    const p = pty.spawn(shell, shellArgs, {
-      name: "xterm-256color",
-      cols: 80,
-      rows: 24,
-      cwd: cwd || os.homedir(),
-      env: cleanEnv,
+  ipcMain.handle("pty-spawn", async (_e, { cwd, cmd, args, sessionId }) => {
+    const resp = await daemonRequest({
+      type: "spawn",
+      cwd,
+      cmd,
+      args,
+      sessionId,
     });
-
-    ptyProcesses.set(termId, p);
-
-    p.onData((data) => {
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send("pty-data", termId, data);
-      }
-    });
-
-    p.onExit(() => {
-      ptyProcesses.delete(termId);
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send("pty-exit", termId);
-      }
-    });
-
-    return { termId, pid: p.pid };
+    return { termId: resp.termId, pid: resp.pid };
   });
 
-  ipcMain.handle("pty-write", (_e, termId, data) => {
-    const p = ptyProcesses.get(termId);
-    if (p) p.write(data);
+  ipcMain.handle("pty-write", async (_e, termId, data) => {
+    await ensureDaemon();
+    daemonSend({ type: "write", termId, data });
   });
 
-  ipcMain.handle("pty-resize", (_e, termId, cols, rows) => {
-    const p = ptyProcesses.get(termId);
-    if (p) p.resize(cols, rows);
+  ipcMain.handle("pty-resize", async (_e, termId, cols, rows) => {
+    await ensureDaemon();
+    daemonSend({ type: "resize", termId, cols, rows });
+  });
+
+  ipcMain.handle("pty-kill", async (_e, termId) => {
+    await daemonRequest({ type: "kill", termId });
+  });
+
+  ipcMain.handle("pty-list", async () => {
+    const resp = await daemonRequest({ type: "list" });
+    return resp.ptys;
+  });
+
+  ipcMain.handle("pty-attach", async (_e, termId) => {
+    const resp = await daemonRequest({ type: "attach", termId });
+    return resp;
+  });
+
+  ipcMain.handle("pty-detach", async (_e, termId) => {
+    await ensureDaemon();
+    daemonSend({ type: "detach", termId });
+  });
+
+  ipcMain.handle("pty-set-session", async (_e, termId, sessionId) => {
+    await daemonRequest({ type: "set-session", termId, sessionId });
   });
 
   // Poll for a session-pid file to appear for a given PID
@@ -318,14 +472,6 @@ app.whenReady().then(() => {
       };
       check();
     });
-  });
-
-  ipcMain.handle("pty-kill", (_e, termId) => {
-    const p = ptyProcesses.get(termId);
-    if (p) {
-      p.kill();
-      ptyProcesses.delete(termId);
-    }
   });
 
   createWindow();
@@ -365,6 +511,35 @@ app.whenReady().then(() => {
             }
           },
         },
+        { type: "separator" },
+        {
+          label: "Next Tab",
+          accelerator: "CmdOrCtrl+Shift+]",
+          click: () => {
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              mainWindow.webContents.send("next-terminal-tab");
+            }
+          },
+        },
+        {
+          label: "Previous Tab",
+          accelerator: "CmdOrCtrl+Shift+[",
+          click: () => {
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              mainWindow.webContents.send("prev-terminal-tab");
+            }
+          },
+        },
+        { type: "separator" },
+        ...Array.from({ length: 9 }, (_, i) => ({
+          label: `Tab ${i + 1}`,
+          accelerator: `CmdOrCtrl+${i + 1}`,
+          click: () => {
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              mainWindow.webContents.send("switch-terminal-tab", i);
+            }
+          },
+        })),
         { type: "separator" },
         { role: "close" },
       ],
@@ -411,10 +586,19 @@ app.whenReady().then(() => {
   });
 });
 
-app.on("before-quit", killAllPty);
+app.on("before-quit", () => {
+  // Disconnect from daemon (daemon keeps PTYs alive)
+  if (daemonSocket && !daemonSocket.destroyed) {
+    daemonSocket.destroy();
+  }
+  for (const entry of pendingPolls) entry.cancel();
+  pendingPolls.clear();
+});
 
 app.on("window-all-closed", () => {
   for (const file of fileWatchers.values()) fs.unwatchFile(file);
-  killAllPty();
+  if (daemonSocket && !daemonSocket.destroyed) {
+    daemonSocket.destroy();
+  }
   if (process.platform !== "darwin") app.quit();
 });

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,5 +1,16 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
+// Remove stale listeners from previous renderer loads (Cmd+R)
+ipcRenderer.removeAllListeners("intention-changed");
+ipcRenderer.removeAllListeners("pty-data");
+ipcRenderer.removeAllListeners("pty-replay");
+ipcRenderer.removeAllListeners("pty-exit");
+ipcRenderer.removeAllListeners("new-terminal-tab");
+ipcRenderer.removeAllListeners("close-terminal-tab");
+ipcRenderer.removeAllListeners("next-terminal-tab");
+ipcRenderer.removeAllListeners("prev-terminal-tab");
+ipcRenderer.removeAllListeners("switch-terminal-tab");
+
 contextBridge.exposeInMainWorld("api", {
   getDirColors: () => ipcRenderer.invoke("get-dir-colors"),
   getSessions: () => ipcRenderer.invoke("get-sessions"),
@@ -11,15 +22,22 @@ contextBridge.exposeInMainWorld("api", {
   onIntentionChanged: (callback) =>
     ipcRenderer.on("intention-changed", (_e, content) => callback(content)),
 
-  // Terminal
+  // Terminal (forwarded to PTY daemon via main process)
   ptySpawn: (opts) => ipcRenderer.invoke("pty-spawn", opts),
   ptyWrite: (termId, data) => ipcRenderer.invoke("pty-write", termId, data),
   ptyResize: (termId, cols, rows) =>
     ipcRenderer.invoke("pty-resize", termId, cols, rows),
   ptyKill: (termId) => ipcRenderer.invoke("pty-kill", termId),
+  ptyList: () => ipcRenderer.invoke("pty-list"),
+  ptyAttach: (termId) => ipcRenderer.invoke("pty-attach", termId),
+  ptyDetach: (termId) => ipcRenderer.invoke("pty-detach", termId),
+  ptySetSession: (termId, sessionId) =>
+    ipcRenderer.invoke("pty-set-session", termId, sessionId),
   ptyWaitSession: (pid) => ipcRenderer.invoke("pty-wait-session", pid),
   onPtyData: (callback) =>
     ipcRenderer.on("pty-data", (_e, termId, data) => callback(termId, data)),
+  onPtyReplay: (callback) =>
+    ipcRenderer.on("pty-replay", (_e, termId, data) => callback(termId, data)),
   onPtyExit: (callback) =>
     ipcRenderer.on("pty-exit", (_e, termId) => callback(termId)),
 
@@ -28,4 +46,10 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.on("new-terminal-tab", () => callback()),
   onCloseTerminalTab: (callback) =>
     ipcRenderer.on("close-terminal-tab", () => callback()),
+  onNextTerminalTab: (callback) =>
+    ipcRenderer.on("next-terminal-tab", () => callback()),
+  onPrevTerminalTab: (callback) =>
+    ipcRenderer.on("prev-terminal-tab", () => callback()),
+  onSwitchTerminalTab: (callback) =>
+    ipcRenderer.on("switch-terminal-tab", (_e, index) => callback(index)),
 });

--- a/src/pty-daemon.js
+++ b/src/pty-daemon.js
@@ -1,0 +1,342 @@
+#!/usr/bin/env node
+/**
+ * PTY Daemon — manages terminal processes independently of any Electron window.
+ *
+ * Communicates over a Unix domain socket using newline-delimited JSON.
+ * Multiple clients (Electron instances) can attach to the same terminals.
+ * Terminals survive client disconnects and app restarts.
+ *
+ * Socket: ~/.open-cockpit/pty-daemon.sock
+ */
+
+const net = require("net");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const pty = require("node-pty");
+
+const OPEN_COCKPIT_DIR = path.join(os.homedir(), ".open-cockpit");
+const SOCKET_PATH = path.join(OPEN_COCKPIT_DIR, "pty-daemon.sock");
+const BUFFER_SIZE = 100_000; // bytes of output to buffer per terminal for replay
+const IDLE_TIMEOUT_MS = 30 * 60 * 1000; // exit after 30 min with no terminals and no clients
+const ALLOWED_SHELLS = new Set(["/bin/zsh", "/bin/bash", "/bin/sh"]);
+
+// --- State ---
+let nextTermId = 1;
+const terminals = new Map(); // termId -> { proc, meta, buffer, clients: Set<socket> }
+const clients = new Set(); // all connected sockets
+let idleTimer = null;
+
+// --- Helpers ---
+
+function broadcast(termId, msg) {
+  const entry = terminals.get(termId);
+  if (!entry) return;
+  const line = JSON.stringify(msg) + "\n";
+  for (const client of entry.clients) {
+    client.write(line);
+  }
+}
+
+function sendTo(socket, msg) {
+  if (!socket.destroyed) {
+    socket.write(JSON.stringify(msg) + "\n");
+  }
+}
+
+function resetIdleTimer() {
+  if (idleTimer) clearTimeout(idleTimer);
+  idleTimer = null;
+  if (terminals.size === 0 && clients.size === 0) {
+    idleTimer = setTimeout(() => {
+      console.log("[pty-daemon] Idle timeout, exiting");
+      cleanup();
+      process.exit(0);
+    }, IDLE_TIMEOUT_MS);
+  }
+}
+
+function cleanup() {
+  for (const [, entry] of terminals) {
+    try {
+      entry.proc.kill();
+    } catch {}
+  }
+  terminals.clear();
+  try {
+    fs.unlinkSync(SOCKET_PATH);
+  } catch {}
+}
+
+// --- Command handlers ---
+
+function handleSpawn(socket, msg) {
+  const shell =
+    msg.cmd && ALLOWED_SHELLS.has(msg.cmd)
+      ? msg.cmd
+      : process.env.SHELL || "/bin/zsh";
+  const args = msg.args || [];
+  const cwd = msg.cwd || os.homedir();
+  const termId = nextTermId++;
+
+  // Strip Claude session env vars
+  const cleanEnv = { ...process.env, TERM: "xterm-256color" };
+  delete cleanEnv.CLAUDECODE;
+  delete cleanEnv.CLAUDE_CODE_SESSION_ID;
+
+  const proc = pty.spawn(shell, args, {
+    name: "xterm-256color",
+    cols: msg.cols || 80,
+    rows: msg.rows || 24,
+    cwd,
+    env: cleanEnv,
+  });
+
+  const entry = {
+    proc,
+    meta: {
+      termId,
+      sessionId: msg.sessionId || null,
+      cwd,
+      pid: proc.pid,
+      exited: false,
+    },
+    buffer: "",
+    clients: new Set(),
+  };
+  terminals.set(termId, entry);
+
+  proc.onData((data) => {
+    // Buffer for replay
+    entry.buffer += data;
+    if (entry.buffer.length > BUFFER_SIZE) {
+      entry.buffer = entry.buffer.slice(entry.buffer.length - BUFFER_SIZE);
+    }
+    broadcast(termId, { type: "data", termId, data });
+  });
+
+  proc.onExit(({ exitCode }) => {
+    entry.meta.exited = true;
+    entry.meta.exitCode = exitCode;
+    broadcast(termId, { type: "exit", termId, exitCode });
+    // Keep the entry around so clients can still see the buffer and exit status.
+    // It gets cleaned up when all clients detach or via kill.
+    resetIdleTimer();
+  });
+
+  if (idleTimer) {
+    clearTimeout(idleTimer);
+    idleTimer = null;
+  }
+
+  sendTo(socket, {
+    type: "spawned",
+    id: msg.id,
+    termId,
+    pid: proc.pid,
+  });
+}
+
+function handleWrite(msg) {
+  const entry = terminals.get(msg.termId);
+  if (entry && !entry.meta.exited) {
+    entry.proc.write(msg.data);
+  }
+}
+
+function handleResize(msg) {
+  const entry = terminals.get(msg.termId);
+  if (entry && !entry.meta.exited) {
+    entry.proc.resize(msg.cols, msg.rows);
+  }
+}
+
+function handleKill(socket, msg) {
+  const entry = terminals.get(msg.termId);
+  if (entry) {
+    if (!entry.meta.exited) {
+      try {
+        entry.proc.kill();
+      } catch {}
+    }
+    terminals.delete(msg.termId);
+  }
+  sendTo(socket, { type: "killed", id: msg.id, termId: msg.termId });
+  resetIdleTimer();
+}
+
+function handleList(socket, msg) {
+  const ptys = [];
+  for (const [, entry] of terminals) {
+    ptys.push({
+      ...entry.meta,
+      buffer: entry.buffer,
+      clientCount: entry.clients.size,
+    });
+  }
+  sendTo(socket, { type: "list-result", id: msg.id, ptys });
+}
+
+function handleAttach(socket, msg) {
+  const entry = terminals.get(msg.termId);
+  if (!entry) {
+    sendTo(socket, {
+      type: "attach-error",
+      id: msg.id,
+      termId: msg.termId,
+      error: "not found",
+    });
+    return;
+  }
+  entry.clients.add(socket);
+
+  // Send response first (resolves the pending request in main.js)
+  sendTo(socket, { type: "attached", id: msg.id, termId: msg.termId });
+
+  // Then replay buffered output (no id — goes through push event path)
+  if (entry.buffer) {
+    sendTo(socket, { type: "replay", termId: msg.termId, data: entry.buffer });
+  }
+  if (entry.meta.exited) {
+    sendTo(socket, {
+      type: "exit",
+      termId: msg.termId,
+      exitCode: entry.meta.exitCode,
+    });
+  }
+}
+
+function handleDetach(socket, msg) {
+  const entry = terminals.get(msg.termId);
+  if (entry) {
+    entry.clients.delete(socket);
+    // Clean up exited terminals with no attached clients
+    if (entry.meta.exited && entry.clients.size === 0) {
+      terminals.delete(msg.termId);
+      resetIdleTimer();
+    }
+  }
+}
+
+function handleSetSession(socket, msg) {
+  const entry = terminals.get(msg.termId);
+  if (entry) {
+    entry.meta.sessionId = msg.sessionId;
+  }
+  sendTo(socket, {
+    type: "session-set",
+    id: msg.id,
+    termId: msg.termId,
+  });
+}
+
+// --- Socket server ---
+
+function handleMessage(socket, msg) {
+  switch (msg.type) {
+    case "spawn":
+      return handleSpawn(socket, msg);
+    case "write":
+      return handleWrite(msg);
+    case "resize":
+      return handleResize(msg);
+    case "kill":
+      return handleKill(socket, msg);
+    case "list":
+      return handleList(socket, msg);
+    case "attach":
+      return handleAttach(socket, msg);
+    case "detach":
+      return handleDetach(socket, msg);
+    case "set-session":
+      return handleSetSession(socket, msg);
+    case "ping":
+      return sendTo(socket, { type: "pong", id: msg.id });
+    default:
+      sendTo(socket, {
+        type: "error",
+        id: msg.id,
+        error: `unknown command: ${msg.type}`,
+      });
+  }
+}
+
+function startServer() {
+  fs.mkdirSync(OPEN_COCKPIT_DIR, { recursive: true });
+
+  // Remove stale socket
+  try {
+    fs.unlinkSync(SOCKET_PATH);
+  } catch {}
+
+  const server = net.createServer((socket) => {
+    clients.add(socket);
+    resetIdleTimer();
+
+    let buf = "";
+    socket.on("data", (chunk) => {
+      buf += chunk.toString();
+      let idx;
+      while ((idx = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, idx);
+        buf = buf.slice(idx + 1);
+        if (!line.trim()) continue;
+        try {
+          handleMessage(socket, JSON.parse(line));
+        } catch (err) {
+          console.error("[pty-daemon] Parse error:", err.message);
+        }
+      }
+    });
+
+    socket.on("close", () => {
+      clients.delete(socket);
+      // Remove this socket from all terminal client sets; reap exited terminals
+      for (const [termId, entry] of terminals) {
+        entry.clients.delete(socket);
+        if (entry.meta.exited && entry.clients.size === 0) {
+          terminals.delete(termId);
+        }
+      }
+      resetIdleTimer();
+    });
+
+    socket.on("error", () => {
+      clients.delete(socket);
+      for (const [termId, entry] of terminals) {
+        entry.clients.delete(socket);
+        if (entry.meta.exited && entry.clients.size === 0) {
+          terminals.delete(termId);
+        }
+      }
+    });
+  });
+
+  server.listen(SOCKET_PATH, () => {
+    // Restrict socket to owner only
+    fs.chmodSync(SOCKET_PATH, 0o600);
+    console.log(`[pty-daemon] Listening on ${SOCKET_PATH}`);
+    // Write PID file so clients can check if daemon is alive
+    fs.writeFileSync(
+      path.join(OPEN_COCKPIT_DIR, "pty-daemon.pid"),
+      String(process.pid),
+    );
+    resetIdleTimer();
+  });
+
+  server.on("error", (err) => {
+    console.error("[pty-daemon] Server error:", err);
+    process.exit(1);
+  });
+
+  process.on("SIGTERM", () => {
+    cleanup();
+    process.exit(0);
+  });
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(0);
+  });
+}
+
+startServer();

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -371,7 +371,7 @@ let activeTermIndex = -1;
 // Generation counter to detect stale async operations after session switches
 let sessionGeneration = 0;
 
-// Sync current terminals into the session cache
+// Sync current terminals into the session cache (renderer + main process)
 function syncSessionCache() {
   if (!currentSessionId) return;
   if (terminals.length === 0) {
@@ -382,6 +382,10 @@ function syncSessionCache() {
       activeTermIndex,
       lastAccessed: Date.now(),
     });
+    // Keep main process metadata in sync
+    for (const t of terminals) {
+      window.api.ptySetSession(t.termId, currentSessionId);
+    }
   }
 }
 
@@ -423,11 +427,42 @@ async function spawnTerminal(cwd, cmd, args) {
   term.loadAddon(fitAddon);
   term.open(container);
 
-  const { termId, pid } = await window.api.ptySpawn({
-    cwd: cwd || undefined,
-    cmd: cmd || undefined,
-    args: args || undefined,
-  });
+  let termId, pid;
+  try {
+    ({ termId, pid } = await window.api.ptySpawn({
+      cwd: cwd || undefined,
+      cmd: cmd || undefined,
+      args: args || undefined,
+      sessionId: currentSessionId || undefined,
+    }));
+  } catch (err) {
+    term.dispose();
+    container.remove();
+    throw err;
+  }
+
+  const entry = {
+    termId,
+    pid,
+    term,
+    fitAddon,
+    resizeObserver: null,
+    container,
+  };
+  terminals.push(entry);
+
+  // Register before attach so replay/data can find this terminal
+  pendingTerminals.set(termId, entry);
+  try {
+    await window.api.ptyAttach(termId);
+  } catch (err) {
+    terminals.splice(terminals.indexOf(entry), 1);
+    term.dispose();
+    container.remove();
+    pendingTerminals.delete(termId);
+    throw err;
+  }
+  pendingTerminals.delete(termId);
 
   term.onData((data) => window.api.ptyWrite(termId, data));
 
@@ -438,9 +473,7 @@ async function spawnTerminal(cwd, cmd, args) {
     }
   });
   resizeObserver.observe(terminalMount);
-
-  const entry = { termId, pid, term, fitAddon, resizeObserver, container };
-  terminals.push(entry);
+  entry.resizeObserver = resizeObserver;
 
   renderTerminalTabs();
   switchToTerminal(terminals.length - 1);
@@ -471,6 +504,7 @@ async function closeTerminal(index) {
   if (index < 0 || index >= terminals.length) return;
 
   const entry = terminals[index];
+  await window.api.ptyDetach(entry.termId).catch(() => {});
   await window.api.ptyKill(entry.termId);
   entry.resizeObserver.disconnect();
   entry.term.dispose();
@@ -559,6 +593,7 @@ function destroySessionTerminals(sessionId) {
   const cached = sessionTerminals.get(sessionId);
   if (!cached) return;
   for (const entry of cached.terminals) {
+    window.api.ptyDetach(entry.termId).catch(() => {});
     window.api.ptyKill(entry.termId).catch(() => {});
     entry.resizeObserver.disconnect();
     entry.term.dispose();
@@ -600,6 +635,9 @@ function cleanupStaleTerminals(liveSessions) {
 }
 
 // Find a terminal entry across all sessions (active + cached)
+// Temporary lookup for terminals being reconnected (before they're in sessionTerminals)
+const pendingTerminals = new Map(); // termId -> entry
+
 function findTerminalEntry(termId) {
   const active = terminals.find((t) => t.termId === termId);
   if (active) return active;
@@ -607,13 +645,19 @@ function findTerminalEntry(termId) {
     const entry = cached.terminals.find((t) => t.termId === termId);
     if (entry) return entry;
   }
-  return null;
+  return pendingTerminals.get(termId) || null;
 }
 
-// Wire PTY output from main process
+// Wire PTY output from daemon (via main process)
 window.api.onPtyData((termId, data) => {
   const entry = findTerminalEntry(termId);
   if (entry) entry.term.write(data);
+});
+
+window.api.onPtyReplay((termId, data) => {
+  const entry = findTerminalEntry(termId);
+  // Skip if buffer was already written directly during reconnect
+  if (entry && !entry.skipReplay) entry.term.write(data);
 });
 
 window.api.onPtyExit((termId) => {
@@ -748,6 +792,10 @@ newSessionBtn.addEventListener("click", async () => {
       if (gen !== sessionGeneration) return;
       currentSessionId = newSession.sessionId;
       currentSessionCwd = newSession.cwd;
+      // Update main process PTY metadata with the new session ID
+      for (const t of terminals) {
+        window.api.ptySetSession(t.termId, newSession.sessionId);
+      }
       syncSessionCache();
 
       editorPane.classList.remove("hidden");
@@ -803,7 +851,7 @@ window.api.onIntentionChanged((content) => {
   }
 });
 
-// Menu keyboard shortcuts (Cmd+T, Cmd+W)
+// Menu keyboard shortcuts
 window.api.onNewTerminalTab(() => {
   if (currentSessionId) spawnTerminal(currentSessionCwd);
 });
@@ -812,11 +860,147 @@ window.api.onCloseTerminalTab(() => {
   if (activeTermIndex >= 0) closeTerminal(activeTermIndex);
 });
 
+window.api.onNextTerminalTab(() => {
+  if (terminals.length > 1) {
+    switchToTerminal((activeTermIndex + 1) % terminals.length);
+  }
+});
+
+window.api.onPrevTerminalTab(() => {
+  if (terminals.length > 1) {
+    switchToTerminal(
+      (activeTermIndex - 1 + terminals.length) % terminals.length,
+    );
+  }
+});
+
+window.api.onSwitchTerminalTab((index) => {
+  if (index < terminals.length) switchToTerminal(index);
+});
+
+// Reconnect a single PTY from daemon (after app restart or reload)
+async function reconnectTerminal(ptyInfo) {
+  const container = document.createElement("div");
+  container.style.cssText = "width:100%;height:100%;display:none;";
+  terminalMount.appendChild(container);
+
+  const term = new Terminal({
+    theme: TERM_THEME,
+    fontFamily: "'SF Mono', Menlo, monospace",
+    fontSize: 13,
+    cursorBlink: true,
+  });
+
+  const fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.open(container);
+
+  const entry = {
+    termId: ptyInfo.termId,
+    pid: ptyInfo.pid,
+    term,
+    fitAddon,
+    resizeObserver: null,
+    container,
+  };
+
+  // Write buffered output directly (already available from ptyList response)
+  if (ptyInfo.buffer) {
+    term.write(ptyInfo.buffer);
+    entry.skipReplay = true; // Suppress duplicate daemon replay
+  }
+
+  // Register before attach so any new data arriving can find this terminal
+  pendingTerminals.set(ptyInfo.termId, entry);
+
+  // Attach to daemon for future data
+  await window.api.ptyAttach(ptyInfo.termId);
+
+  pendingTerminals.delete(ptyInfo.termId);
+
+  if (ptyInfo.exited) term.write("\r\n[Process exited]\r\n");
+
+  term.onData((data) => window.api.ptyWrite(ptyInfo.termId, data));
+
+  const resizeObserver = new ResizeObserver(() => {
+    if (container.style.display !== "none") {
+      fitAddon.fit();
+      window.api.ptyResize(ptyInfo.termId, term.cols, term.rows);
+    }
+  });
+  resizeObserver.observe(terminalMount);
+  entry.resizeObserver = resizeObserver;
+
+  return entry;
+}
+
+// On app start: reconnect to any PTYs that survived from previous instance
+async function reconnectAllPtys() {
+  const ptys = await window.api.ptyList();
+  if (ptys.length === 0) return;
+
+  // Group by sessionId
+  const bySession = new Map();
+  for (const p of ptys) {
+    const sid = p.sessionId || "__none__";
+    if (!bySession.has(sid)) bySession.set(sid, []);
+    bySession.get(sid).push(p);
+  }
+
+  // Reconnect each session's terminals (skip orphaned terminals with no session)
+  for (const [sid, sessionPtys] of bySession) {
+    if (sid === "__none__") {
+      // Detach orphaned terminals — they have no session to display under
+      for (const p of sessionPtys) {
+        window.api.ptyDetach(p.termId).catch(() => {});
+      }
+      continue;
+    }
+    const entries = [];
+    for (const p of sessionPtys) {
+      entries.push(await reconnectTerminal(p));
+    }
+    sessionTerminals.set(sid, {
+      terminals: entries,
+      activeTermIndex: 0,
+      lastAccessed: Date.now(),
+    });
+  }
+
+  // Restore the most recent alive session that has terminals
+  const sessions = await window.api.getSessions();
+  const lastActive = sessions.find(
+    (s) => s.alive && sessionTerminals.has(s.sessionId),
+  );
+  if (lastActive) {
+    currentSessionId = lastActive.sessionId;
+    currentSessionCwd = lastActive.cwd;
+
+    terminals = sessionTerminals.get(lastActive.sessionId).terminals;
+    activeTermIndex = 0;
+
+    emptyState.classList.add("hidden");
+    sessionView.classList.remove("hidden");
+    editorPane.classList.remove("hidden");
+    editorProject.textContent = lastActive.project
+      ? `${lastActive.project} — ${lastActive.cwd.replace(lastActive.home, "~")}`
+      : lastActive.sessionId;
+
+    const content = await window.api.readIntention(lastActive.sessionId);
+    createEditor(content);
+    await window.api.watchIntention(lastActive.sessionId);
+
+    renderTerminalTabs();
+    switchToTerminal(0);
+  }
+}
+
 refreshBtn.addEventListener("click", async () => {
   await loadDirColors();
   loadSessions();
 });
-loadDirColors().then(() => {
+loadDirColors().then(async () => {
+  await reconnectAllPtys();
   setInterval(loadSessions, 10000);
   loadSessions();
 });


### PR DESCRIPTION
## Summary

- **PTY daemon** (`src/pty-daemon.js`): standalone process managing all terminals over Unix socket, independent of any Electron window
- Terminals survive app restarts, Cmd+R reloads, and dev instance cycling
- Multiple Electron instances (dev + prod) can display the same terminals simultaneously
- 100KB output buffer per terminal replayed on reconnect
- Session-aware: terminals tagged with sessionId, restored when switching sessions
- Tab shortcuts: Cmd+T, Cmd+W, Ctrl+Tab, Cmd+Shift+]/[, Cmd+1-9

## Security & reliability fixes
- Shell injection in `getCwdFromJsonl` → `execFileSync` with array args
- Daemon socket permissions restricted to owner (0o600)
- Connection race condition guarded with `settled` flag
- Listener stacking on Cmd+R fixed with `removeAllListeners`
- Duplicate replay suppressed with `skipReplay` flag

## Test plan
- [ ] Open session, run commands, close app (red X), reopen → output restored
- [ ] Open session, run commands, Cmd+Q, reopen → output restored
- [ ] Open second terminal tab (Cmd+T), close/reopen → both tabs restored
- [ ] Switch between sessions → terminals cached, not re-spawned
- [ ] Cmd+R reload → terminals survive, no duplicate output
- [ ] Tab switching shortcuts work (Ctrl+Tab, Cmd+Shift+], Cmd+1-9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)