### PR TITLE
Add keyboard shortcuts and command palette

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
       "devDependencies": {
         "electron": "^33.0.0",
         "electron-rebuild": "^3.2.9",
-        "esbuild": "^0.27.3"
+        "esbuild": "^0.27.3",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -896,6 +897,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@lezer/common": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
@@ -1144,6 +1152,356 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -1156,6 +1514,13 @@
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -1192,6 +1557,31 @@
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
@@ -1239,6 +1629,117 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xterm/addon-fit": {
@@ -1356,6 +1857,16 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1553,6 +2064,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2048,6 +2569,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
@@ -2122,6 +2650,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
@@ -2160,6 +2708,24 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -2194,6 +2760,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/gauge": {
       "version": "4.0.4",
@@ -2698,6 +3279,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/make-fetch-happen": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
@@ -2913,6 +3504,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
@@ -3096,6 +3706,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3192,12 +3813,68 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -3368,6 +4045,51 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3462,6 +4184,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -3510,6 +4239,16 @@
         "node": ">= 10"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -3530,6 +4269,20 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -3630,6 +4383,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
@@ -3700,6 +4497,159 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -3730,6 +4680,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wide-align": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "esbuild src/renderer.js --bundle --outfile=dist/renderer.js --platform=browser --format=iife",
     "start": "npm run build && electron .",
-    "dev": "npm run build && electron . --dev"
+    "dev": "npm run build && electron . --dev",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.2",
@@ -25,6 +27,7 @@
   "devDependencies": {
     "electron": "^33.0.0",
     "electron-rebuild": "^3.2.9",
-    "esbuild": "^0.27.3"
+    "esbuild": "^0.27.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -41,6 +41,12 @@
       </div>
     </main>
   </div>
+  <div id="command-palette">
+    <div id="command-palette-dialog">
+      <input id="command-palette-input" type="text" placeholder="Type a command..." autocomplete="off" spellcheck="false">
+      <div id="command-palette-list"></div>
+    </div>
+  </div>
   <script src="../dist/renderer.js"></script>
 </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -45,13 +45,24 @@ function createWindow() {
 
   mainWindow.loadFile(path.join(__dirname, "index.html"));
 
-  // Ctrl+Tab / Ctrl+Shift+Tab — not supported as menu accelerators, handle via input events
+  // Shortcuts not supported as menu accelerators — handle via input events
   mainWindow.webContents.on("before-input-event", (event, input) => {
     if (input.control && input.key === "Tab") {
       event.preventDefault();
       mainWindow.webContents.send(
         input.shift ? "prev-terminal-tab" : "next-terminal-tab",
       );
+    }
+    // Alt+Up / Alt+Down — switch sessions
+    if (input.alt && (input.key === "ArrowUp" || input.key === "ArrowDown")) {
+      event.preventDefault();
+      mainWindow.webContents.send(
+        input.key === "ArrowUp" ? "prev-session" : "next-session",
+      );
+    }
+    // Escape — focus terminal (only when not in command palette)
+    if (input.key === "Escape" && !input.meta && !input.control && !input.alt) {
+      mainWindow.webContents.send("focus-terminal");
     }
   });
 
@@ -476,7 +487,13 @@ app.whenReady().then(async () => {
 
   createWindow();
 
-  // Build menu with Cmd+T shortcut for new terminal tab
+  const send = (channel, ...args) => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send(channel, ...args);
+    }
+  };
+
+  // Build menu with keyboard shortcuts
   const menuTemplate = [
     {
       label: app.name,
@@ -494,54 +511,76 @@ app.whenReady().then(async () => {
       label: "File",
       submenu: [
         {
+          label: "New Claude Session",
+          accelerator: "CmdOrCtrl+N",
+          click: () => send("new-session"),
+        },
+        {
           label: "New Terminal Tab",
           accelerator: "CmdOrCtrl+T",
-          click: () => {
-            if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send("new-terminal-tab");
-            }
-          },
+          click: () => send("new-terminal-tab"),
         },
         {
           label: "Close Terminal Tab",
           accelerator: "CmdOrCtrl+W",
-          click: () => {
-            if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send("close-terminal-tab");
-            }
-          },
+          click: () => send("close-terminal-tab"),
         },
         { type: "separator" },
         {
           label: "Next Tab",
           accelerator: "CmdOrCtrl+Shift+]",
-          click: () => {
-            if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send("next-terminal-tab");
-            }
-          },
+          click: () => send("next-terminal-tab"),
         },
         {
           label: "Previous Tab",
           accelerator: "CmdOrCtrl+Shift+[",
-          click: () => {
-            if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send("prev-terminal-tab");
-            }
-          },
+          click: () => send("prev-terminal-tab"),
         },
         { type: "separator" },
         ...Array.from({ length: 9 }, (_, i) => ({
           label: `Tab ${i + 1}`,
           accelerator: `CmdOrCtrl+${i + 1}`,
-          click: () => {
-            if (mainWindow && !mainWindow.isDestroyed()) {
-              mainWindow.webContents.send("switch-terminal-tab", i);
-            }
-          },
+          click: () => send("switch-terminal-tab", i),
         })),
         { type: "separator" },
         { role: "close" },
+      ],
+    },
+    {
+      label: "Navigate",
+      submenu: [
+        {
+          label: "Next Session",
+          accelerator: "Alt+Down",
+          click: () => send("next-session"),
+        },
+        {
+          label: "Previous Session",
+          accelerator: "Alt+Up",
+          click: () => send("prev-session"),
+        },
+        { type: "separator" },
+        {
+          label: "Toggle Sidebar",
+          accelerator: "CmdOrCtrl+\\",
+          click: () => send("toggle-sidebar"),
+        },
+        {
+          label: "Focus Editor",
+          accelerator: "CmdOrCtrl+E",
+          click: () => send("focus-editor"),
+        },
+        {
+          label: "Focus Terminal",
+          accelerator: "CmdOrCtrl+`",
+          click: () => send("focus-terminal"),
+        },
+        { type: "separator" },
+        {
+          label: "Command Palette",
+          accelerator: "CmdOrCtrl+/",
+          click: () => send("toggle-command-palette"),
+        },
       ],
     },
     {

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,15 +1,25 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
 // Remove stale listeners from previous renderer loads (Cmd+R)
-ipcRenderer.removeAllListeners("intention-changed");
-ipcRenderer.removeAllListeners("pty-data");
-ipcRenderer.removeAllListeners("pty-replay");
-ipcRenderer.removeAllListeners("pty-exit");
-ipcRenderer.removeAllListeners("new-terminal-tab");
-ipcRenderer.removeAllListeners("close-terminal-tab");
-ipcRenderer.removeAllListeners("next-terminal-tab");
-ipcRenderer.removeAllListeners("prev-terminal-tab");
-ipcRenderer.removeAllListeners("switch-terminal-tab");
+const channels = [
+  "intention-changed",
+  "pty-data",
+  "pty-replay",
+  "pty-exit",
+  "new-terminal-tab",
+  "close-terminal-tab",
+  "next-terminal-tab",
+  "prev-terminal-tab",
+  "switch-terminal-tab",
+  "new-session",
+  "next-session",
+  "prev-session",
+  "toggle-sidebar",
+  "focus-editor",
+  "focus-terminal",
+  "toggle-command-palette",
+];
+for (const ch of channels) ipcRenderer.removeAllListeners(ch);
 
 contextBridge.exposeInMainWorld("api", {
   getDirColors: () => ipcRenderer.invoke("get-dir-colors"),
@@ -52,4 +62,16 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.on("prev-terminal-tab", () => callback()),
   onSwitchTerminalTab: (callback) =>
     ipcRenderer.on("switch-terminal-tab", (_e, index) => callback(index)),
+
+  // Navigation actions
+  onNewSession: (callback) => ipcRenderer.on("new-session", () => callback()),
+  onNextSession: (callback) => ipcRenderer.on("next-session", () => callback()),
+  onPrevSession: (callback) => ipcRenderer.on("prev-session", () => callback()),
+  onToggleSidebar: (callback) =>
+    ipcRenderer.on("toggle-sidebar", () => callback()),
+  onFocusEditor: (callback) => ipcRenderer.on("focus-editor", () => callback()),
+  onFocusTerminal: (callback) =>
+    ipcRenderer.on("focus-terminal", () => callback()),
+  onToggleCommandPalette: (callback) =>
+    ipcRenderer.on("toggle-command-palette", () => callback()),
 });

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -354,6 +354,13 @@ const editorMount = document.getElementById("editor-mount");
 const terminalTabList = document.getElementById("terminal-tab-list");
 const newTermBtn = document.getElementById("new-term-btn");
 const terminalMount = document.getElementById("terminal-mount");
+const sidebar = document.getElementById("sidebar");
+const commandPalette = document.getElementById("command-palette");
+const commandPaletteInput = document.getElementById("command-palette-input");
+const commandPaletteList = document.getElementById("command-palette-list");
+
+// Keep a cached copy of sessions for keyboard navigation
+let cachedSessions = [];
 
 let currentSessionId = null;
 let currentSessionCwd = null;
@@ -667,6 +674,7 @@ window.api.onPtyExit((termId) => {
 
 async function loadSessions() {
   const sessions = await window.api.getSessions();
+  cachedSessions = sessions;
   cleanupStaleTerminals(sessions);
   sessionList.innerHTML = "";
 
@@ -851,6 +859,245 @@ window.api.onIntentionChanged((content) => {
   }
 });
 
+// --- Session switching ---
+function switchSession(direction) {
+  if (cachedSessions.length === 0) return;
+  const currentIndex = cachedSessions.findIndex(
+    (s) => s.sessionId === currentSessionId,
+  );
+  let nextIndex;
+  if (currentIndex === -1) {
+    nextIndex = 0;
+  } else {
+    nextIndex =
+      (currentIndex + direction + cachedSessions.length) %
+      cachedSessions.length;
+  }
+  selectSession(cachedSessions[nextIndex]);
+}
+
+// --- Sidebar toggle ---
+function toggleSidebar() {
+  sidebar.classList.toggle("collapsed");
+}
+
+// --- Focus management ---
+function focusTerminal() {
+  if (activeTermIndex >= 0 && terminals[activeTermIndex]) {
+    terminals[activeTermIndex].term.focus();
+  }
+}
+
+function focusEditor() {
+  if (editorView) editorView.focus();
+}
+
+// --- Command palette ---
+const COMMANDS = [
+  {
+    id: "next-session",
+    label: "Next Session",
+    shortcut: "Alt+↓",
+    action: () => switchSession(1),
+  },
+  {
+    id: "prev-session",
+    label: "Previous Session",
+    shortcut: "Alt+↑",
+    action: () => switchSession(-1),
+  },
+  {
+    id: "new-session",
+    label: "New Claude Session",
+    shortcut: "⌘N",
+    action: () => newSessionBtn.click(),
+  },
+  {
+    id: "new-terminal",
+    label: "New Terminal Tab",
+    shortcut: "⌘T",
+    action: () => {
+      if (currentSessionId) spawnTerminal(currentSessionCwd);
+    },
+  },
+  {
+    id: "close-terminal",
+    label: "Close Terminal Tab",
+    shortcut: "⌘W",
+    action: () => {
+      if (activeTermIndex >= 0) closeTerminal(activeTermIndex);
+    },
+  },
+  {
+    id: "next-tab",
+    label: "Next Terminal Tab",
+    shortcut: "⌘⇧]",
+    action: () => {
+      if (terminals.length > 1)
+        switchToTerminal((activeTermIndex + 1) % terminals.length);
+    },
+  },
+  {
+    id: "prev-tab",
+    label: "Previous Terminal Tab",
+    shortcut: "⌘⇧[",
+    action: () => {
+      if (terminals.length > 1)
+        switchToTerminal(
+          (activeTermIndex - 1 + terminals.length) % terminals.length,
+        );
+    },
+  },
+  {
+    id: "toggle-sidebar",
+    label: "Toggle Sidebar",
+    shortcut: "⌘\\",
+    action: toggleSidebar,
+  },
+  {
+    id: "focus-editor",
+    label: "Focus Editor",
+    shortcut: "⌘E",
+    action: focusEditor,
+  },
+  {
+    id: "focus-terminal",
+    label: "Focus Terminal",
+    shortcut: "⌘`",
+    action: focusTerminal,
+  },
+  {
+    id: "refresh",
+    label: "Refresh Sessions",
+    shortcut: "",
+    action: () => {
+      loadDirColors();
+      loadSessions();
+    },
+  },
+  {
+    id: "command-palette",
+    label: "Command Palette",
+    shortcut: "⌘/",
+    action: () => toggleCommandPalette(),
+  },
+];
+
+// Also add Tab 1-9 commands
+for (let i = 0; i < 9; i++) {
+  COMMANDS.push({
+    id: `tab-${i + 1}`,
+    label: `Switch to Tab ${i + 1}`,
+    shortcut: `⌘${i + 1}`,
+    action: () => {
+      if (i < terminals.length) switchToTerminal(i);
+    },
+  });
+}
+
+let paletteSelectedIndex = 0;
+let filteredCommands = [];
+
+function toggleCommandPalette() {
+  if (commandPalette.classList.contains("visible")) {
+    closeCommandPalette();
+  } else {
+    openCommandPalette();
+  }
+}
+
+function openCommandPalette() {
+  commandPalette.classList.add("visible");
+  commandPaletteInput.value = "";
+  paletteSelectedIndex = 0;
+  renderPaletteList("");
+  commandPaletteInput.focus();
+}
+
+function closeCommandPalette() {
+  commandPalette.classList.remove("visible");
+  commandPaletteInput.value = "";
+  // Return focus to terminal
+  focusTerminal();
+}
+
+function renderPaletteList(query) {
+  const q = query.toLowerCase();
+  filteredCommands = q
+    ? COMMANDS.filter(
+        (c) =>
+          c.label.toLowerCase().includes(q) ||
+          c.shortcut.toLowerCase().includes(q),
+      )
+    : COMMANDS.filter((c) => !c.id.startsWith("tab-")); // Hide tab-N from unfiltered list
+
+  paletteSelectedIndex = Math.min(
+    paletteSelectedIndex,
+    Math.max(0, filteredCommands.length - 1),
+  );
+
+  commandPaletteList.innerHTML = "";
+  filteredCommands.forEach((cmd, i) => {
+    const item = document.createElement("div");
+    item.className = `command-palette-item${i === paletteSelectedIndex ? " selected" : ""}`;
+    item.innerHTML = `<span class="command-palette-label">${cmd.label}</span><span class="command-palette-shortcut">${cmd.shortcut}</span>`;
+    item.addEventListener("click", () => {
+      closeCommandPalette();
+      cmd.action();
+    });
+    item.addEventListener("mouseenter", () => updatePaletteSelection(i));
+    commandPaletteList.appendChild(item);
+  });
+}
+
+commandPaletteInput.addEventListener("input", () => {
+  paletteSelectedIndex = 0;
+  renderPaletteList(commandPaletteInput.value);
+});
+
+function updatePaletteSelection(newIndex) {
+  const items = commandPaletteList.children;
+  if (items[paletteSelectedIndex])
+    items[paletteSelectedIndex].classList.remove("selected");
+  paletteSelectedIndex = newIndex;
+  if (items[paletteSelectedIndex]) {
+    items[paletteSelectedIndex].classList.add("selected");
+    items[paletteSelectedIndex].scrollIntoView({ block: "nearest" });
+  }
+}
+
+commandPaletteInput.addEventListener("keydown", (e) => {
+  if (e.key === "Escape") {
+    e.preventDefault();
+    closeCommandPalette();
+    return;
+  }
+  if (e.key === "ArrowDown") {
+    e.preventDefault();
+    updatePaletteSelection(
+      Math.min(paletteSelectedIndex + 1, filteredCommands.length - 1),
+    );
+    return;
+  }
+  if (e.key === "ArrowUp") {
+    e.preventDefault();
+    updatePaletteSelection(Math.max(paletteSelectedIndex - 1, 0));
+    return;
+  }
+  if (e.key === "Enter" && filteredCommands.length > 0) {
+    e.preventDefault();
+    const cmd = filteredCommands[paletteSelectedIndex];
+    closeCommandPalette();
+    cmd.action();
+    return;
+  }
+});
+
+// Click outside palette to close
+commandPalette.addEventListener("click", (e) => {
+  if (e.target === commandPalette) closeCommandPalette();
+});
+
 // Menu keyboard shortcuts
 window.api.onNewTerminalTab(() => {
   if (currentSessionId) spawnTerminal(currentSessionCwd);
@@ -877,6 +1124,18 @@ window.api.onPrevTerminalTab(() => {
 window.api.onSwitchTerminalTab((index) => {
   if (index < terminals.length) switchToTerminal(index);
 });
+
+// Navigation shortcuts
+window.api.onNewSession(() => newSessionBtn.click());
+window.api.onNextSession(() => switchSession(1));
+window.api.onPrevSession(() => switchSession(-1));
+window.api.onToggleSidebar(toggleSidebar);
+window.api.onFocusEditor(focusEditor);
+window.api.onFocusTerminal(() => {
+  // Don't steal focus from command palette (Escape closes it instead)
+  if (!commandPalette.classList.contains("visible")) focusTerminal();
+});
+window.api.onToggleCommandPalette(toggleCommandPalette);
 
 // Reconnect a single PTY from daemon (after app restart or reload)
 async function reconnectTerminal(ptyInfo) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -339,3 +339,86 @@ body {
 #editor-mount .cm-editor {
   height: 100%;
 }
+
+/* Sidebar collapse */
+#sidebar.collapsed {
+  width: 0;
+  min-width: 0;
+  overflow: hidden;
+  border-right: none;
+}
+
+/* Command palette overlay */
+#command-palette {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.5);
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 80px;
+}
+
+#command-palette.visible {
+  display: flex;
+}
+
+#command-palette-dialog {
+  width: 480px;
+  max-height: 400px;
+  background: #111;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+#command-palette-input {
+  width: 100%;
+  padding: 12px 16px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+  font-size: 14px;
+  font-family: inherit;
+  outline: none;
+}
+
+#command-palette-input::placeholder {
+  color: var(--text-dim);
+}
+
+#command-palette-list {
+  overflow-y: auto;
+  max-height: 340px;
+  padding: 4px;
+}
+
+.command-palette-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.command-palette-item:hover,
+.command-palette-item.selected {
+  background: var(--accent-dim);
+}
+
+.command-palette-label {
+  color: var(--text);
+}
+
+.command-palette-shortcut {
+  color: var(--text-dim);
+  font-size: 12px;
+  font-family: "SF Mono", Menlo, monospace;
+}

--- a/test/command-palette-dom.test.js
+++ b/test/command-palette-dom.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const htmlSource = fs.readFileSync(
+  path.join(__dirname, "../src/index.html"),
+  "utf-8",
+);
+
+const cssSource = fs.readFileSync(
+  path.join(__dirname, "../src/styles.css"),
+  "utf-8",
+);
+
+describe("Command palette HTML", () => {
+  it("has the command palette container", () => {
+    expect(htmlSource).toContain('id="command-palette"');
+  });
+
+  it("has the input field", () => {
+    expect(htmlSource).toContain('id="command-palette-input"');
+  });
+
+  it("has the list container", () => {
+    expect(htmlSource).toContain('id="command-palette-list"');
+  });
+
+  it("has the dialog wrapper", () => {
+    expect(htmlSource).toContain('id="command-palette-dialog"');
+  });
+
+  it("input has placeholder text", () => {
+    expect(htmlSource).toContain('placeholder="Type a command..."');
+  });
+
+  it("input has autocomplete and spellcheck disabled", () => {
+    expect(htmlSource).toContain('autocomplete="off"');
+    expect(htmlSource).toContain('spellcheck="false"');
+  });
+});
+
+describe("Command palette CSS", () => {
+  it("palette is hidden by default (display: none)", () => {
+    expect(cssSource).toContain("#command-palette {");
+    expect(cssSource).toContain("display: none;");
+  });
+
+  it("palette shows when .visible class applied", () => {
+    expect(cssSource).toContain("#command-palette.visible {");
+    expect(cssSource).toContain("display: flex;");
+  });
+
+  it("has styling for selected items", () => {
+    expect(cssSource).toContain(".command-palette-item.selected");
+  });
+
+  it("has z-index for overlay", () => {
+    expect(cssSource).toContain("z-index: 1000;");
+  });
+});
+
+describe("Sidebar collapse CSS", () => {
+  it("has collapsed state styles", () => {
+    expect(cssSource).toContain("#sidebar.collapsed");
+    expect(cssSource).toContain("width: 0;");
+    expect(cssSource).toContain("min-width: 0;");
+  });
+});

--- a/test/main-menu.test.js
+++ b/test/main-menu.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+// Parse main.js source to verify menu structure
+const mainSource = fs.readFileSync(
+  path.join(__dirname, "../src/main.js"),
+  "utf-8",
+);
+
+describe("Main process menu", () => {
+  it("has a Navigate menu", () => {
+    expect(mainSource).toContain('label: "Navigate"');
+  });
+
+  it("registers session navigation accelerators", () => {
+    expect(mainSource).toContain('accelerator: "Alt+Down"');
+    expect(mainSource).toContain('accelerator: "Alt+Up"');
+  });
+
+  it("registers sidebar toggle accelerator", () => {
+    expect(mainSource).toContain('accelerator: "CmdOrCtrl+\\\\"');
+  });
+
+  it("registers focus accelerators", () => {
+    expect(mainSource).toContain('accelerator: "CmdOrCtrl+E"');
+    expect(mainSource).toContain('accelerator: "CmdOrCtrl+`"');
+  });
+
+  it("registers command palette accelerator", () => {
+    expect(mainSource).toContain('accelerator: "CmdOrCtrl+/"');
+  });
+
+  it("registers new session accelerator", () => {
+    expect(mainSource).toContain('accelerator: "CmdOrCtrl+N"');
+  });
+
+  it("sends correct IPC messages for navigation", () => {
+    const ipcMessages = [
+      "next-session",
+      "prev-session",
+      "toggle-sidebar",
+      "focus-editor",
+      "focus-terminal",
+      "toggle-command-palette",
+      "new-session",
+    ];
+    for (const msg of ipcMessages) {
+      expect(mainSource, `Missing IPC send for "${msg}"`).toContain(`"${msg}"`);
+    }
+  });
+
+  it("handles Alt+Up/Down in before-input-event", () => {
+    expect(mainSource).toContain("ArrowUp");
+    expect(mainSource).toContain("ArrowDown");
+    expect(mainSource).toContain("input.alt");
+  });
+
+  it("handles Escape for focus-terminal", () => {
+    expect(mainSource).toContain('input.key === "Escape"');
+    expect(mainSource).toContain("focus-terminal");
+  });
+});

--- a/test/preload.test.js
+++ b/test/preload.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+// Verify the preload.js exposes all required IPC channels
+// We parse the source since we can't require it outside Electron
+
+const preloadSource = fs.readFileSync(
+  path.join(__dirname, "../src/preload.js"),
+  "utf-8",
+);
+
+describe("Preload channel registration", () => {
+  // Extract channel names from the removeAllListeners cleanup array
+  const channelArrayMatch = preloadSource.match(
+    /const channels = \[([\s\S]*?)\];/,
+  );
+  const cleanupChannels = channelArrayMatch
+    ? channelArrayMatch[1].match(/"([^"]+)"/g).map((s) => s.replace(/"/g, ""))
+    : [];
+
+  // Extract all ipcRenderer.on("channel-name", ...) registrations
+  const onChannels = [
+    ...preloadSource.matchAll(/ipcRenderer\.on\("([^"]+)"/g),
+  ].map((m) => m[1]);
+
+  it("cleans up all channels that are registered as listeners", () => {
+    for (const ch of onChannels) {
+      expect(
+        cleanupChannels,
+        `Channel "${ch}" is registered but not cleaned up`,
+      ).toContain(ch);
+    }
+  });
+
+  it("has navigation channels registered", () => {
+    const navigationChannels = [
+      "next-session",
+      "prev-session",
+      "new-session",
+      "toggle-sidebar",
+      "focus-editor",
+      "focus-terminal",
+      "toggle-command-palette",
+    ];
+    for (const ch of navigationChannels) {
+      expect(cleanupChannels, `Missing cleanup for ${ch}`).toContain(ch);
+      expect(onChannels, `Missing listener for ${ch}`).toContain(ch);
+    }
+  });
+
+  it("has terminal tab channels registered", () => {
+    const termChannels = [
+      "new-terminal-tab",
+      "close-terminal-tab",
+      "next-terminal-tab",
+      "prev-terminal-tab",
+      "switch-terminal-tab",
+    ];
+    for (const ch of termChannels) {
+      expect(cleanupChannels).toContain(ch);
+      expect(onChannels).toContain(ch);
+    }
+  });
+
+  it("exposes API methods for navigation", () => {
+    const expectedMethods = [
+      "onNewSession",
+      "onNextSession",
+      "onPrevSession",
+      "onToggleSidebar",
+      "onFocusEditor",
+      "onFocusTerminal",
+      "onToggleCommandPalette",
+    ];
+    for (const method of expectedMethods) {
+      expect(preloadSource, `Missing API method: ${method}`).toContain(method);
+    }
+  });
+});

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+
+// --- Extracted logic from renderer.js for testing ---
+
+// Session switching: given current index, direction, and list length, compute next index
+function computeNextSessionIndex(currentId, sessions, direction) {
+  if (sessions.length === 0) return -1;
+  const currentIndex = sessions.findIndex((s) => s.sessionId === currentId);
+  if (currentIndex === -1) return 0;
+  return (currentIndex + direction + sessions.length) % sessions.length;
+}
+
+// Command filtering logic (mirrors renderPaletteList)
+function filterCommands(commands, query) {
+  const q = query.toLowerCase();
+  if (!q) return commands.filter((c) => !c.id.startsWith("tab-"));
+  return commands.filter(
+    (c) =>
+      c.label.toLowerCase().includes(q) || c.shortcut.toLowerCase().includes(q),
+  );
+}
+
+// Sample command list matching renderer.js structure
+const COMMANDS = [
+  { id: "next-session", label: "Next Session", shortcut: "Alt+↓" },
+  { id: "prev-session", label: "Previous Session", shortcut: "Alt+↑" },
+  { id: "new-session", label: "New Claude Session", shortcut: "⌘N" },
+  { id: "new-terminal", label: "New Terminal Tab", shortcut: "⌘T" },
+  { id: "close-terminal", label: "Close Terminal Tab", shortcut: "⌘W" },
+  { id: "next-tab", label: "Next Terminal Tab", shortcut: "⌘⇧]" },
+  { id: "prev-tab", label: "Previous Terminal Tab", shortcut: "⌘⇧[" },
+  { id: "toggle-sidebar", label: "Toggle Sidebar", shortcut: "⌘\\" },
+  { id: "focus-editor", label: "Focus Editor", shortcut: "⌘E" },
+  { id: "focus-terminal", label: "Focus Terminal", shortcut: "⌘`" },
+  { id: "refresh", label: "Refresh Sessions", shortcut: "" },
+  { id: "command-palette", label: "Command Palette", shortcut: "⌘/" },
+  { id: "tab-1", label: "Switch to Tab 1", shortcut: "⌘1" },
+  { id: "tab-2", label: "Switch to Tab 2", shortcut: "⌘2" },
+];
+
+describe("Session switching", () => {
+  const sessions = [{ sessionId: "a" }, { sessionId: "b" }, { sessionId: "c" }];
+
+  it("moves to next session", () => {
+    expect(computeNextSessionIndex("a", sessions, 1)).toBe(1);
+    expect(computeNextSessionIndex("b", sessions, 1)).toBe(2);
+  });
+
+  it("wraps around forward", () => {
+    expect(computeNextSessionIndex("c", sessions, 1)).toBe(0);
+  });
+
+  it("moves to previous session", () => {
+    expect(computeNextSessionIndex("b", sessions, -1)).toBe(0);
+    expect(computeNextSessionIndex("c", sessions, -1)).toBe(1);
+  });
+
+  it("wraps around backward", () => {
+    expect(computeNextSessionIndex("a", sessions, -1)).toBe(2);
+  });
+
+  it("defaults to index 0 when current session not found", () => {
+    expect(computeNextSessionIndex("unknown", sessions, 1)).toBe(0);
+    expect(computeNextSessionIndex(null, sessions, -1)).toBe(0);
+  });
+
+  it("returns -1 for empty session list", () => {
+    expect(computeNextSessionIndex("a", [], 1)).toBe(-1);
+  });
+});
+
+describe("Command palette filtering", () => {
+  it("returns all non-tab commands when query is empty", () => {
+    const result = filterCommands(COMMANDS, "");
+    expect(result.every((c) => !c.id.startsWith("tab-"))).toBe(true);
+    expect(result.length).toBe(12); // All except tab-1, tab-2
+  });
+
+  it("filters by label substring", () => {
+    const result = filterCommands(COMMANDS, "terminal");
+    expect(result.length).toBe(5); // New/Close/Next/Prev Terminal Tab + Focus Terminal
+    expect(
+      result.every((c) => c.label.toLowerCase().includes("terminal")),
+    ).toBe(true);
+  });
+
+  it("filters by shortcut", () => {
+    const result = filterCommands(COMMANDS, "alt");
+    expect(result.length).toBe(2);
+    expect(result[0].id).toBe("next-session");
+    expect(result[1].id).toBe("prev-session");
+  });
+
+  it("is case insensitive", () => {
+    const result = filterCommands(COMMANDS, "SIDEBAR");
+    expect(result.length).toBe(1);
+    expect(result[0].id).toBe("toggle-sidebar");
+  });
+
+  it("includes tab commands when they match query", () => {
+    const result = filterCommands(COMMANDS, "tab 1");
+    expect(result.some((c) => c.id === "tab-1")).toBe(true);
+  });
+
+  it("returns empty array when nothing matches", () => {
+    const result = filterCommands(COMMANDS, "xyznonexistent");
+    expect(result).toEqual([]);
+  });
+
+  it("matches partial label", () => {
+    const result = filterCommands(COMMANDS, "pal");
+    expect(result.length).toBe(1);
+    expect(result[0].id).toBe("command-palette");
+  });
+});
+
+describe("Command list completeness", () => {
+  it("has unique IDs", () => {
+    const ids = COMMANDS.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every command has a label", () => {
+    for (const cmd of COMMANDS) {
+      expect(cmd.label).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Session switching**: Alt+↑/↓ to navigate between sessions in the sidebar
- **New shortcuts**: ⌘N (new session), ⌘\ (toggle sidebar), ⌘E (focus editor), ⌘` (focus terminal), Escape (focus terminal)
- **Command palette**: ⌘/ opens a searchable command palette listing all shortcuts — filter by name or shortcut, execute with Enter
- **Navigate menu**: New menu bar entry grouping all navigation shortcuts
- **DRY menu handlers**: Extract `send()` helper in main process, replacing 12+ boilerplate blocks
- **Tests**: 39 tests with vitest covering session switching logic, palette filtering, preload channels, and menu structure

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` — 39 tests pass (4 test files)
- [ ] Manual: Alt+Up/Down switches sessions in sidebar
- [ ] Manual: ⌘/ opens command palette, type to filter, Enter to execute
- [ ] Manual: ⌘\ toggles sidebar visibility
- [ ] Manual: ⌘E / ⌘` / Escape switch focus between editor and terminal
- [ ] Manual: ⌘N triggers new Claude session flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)