### PR TITLE
Fix terminal selection colors + worktree auto-setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,15 @@ Bumps version in `.claude-plugin/plugin.json` and `EliasSchlie/claude-plugins` m
 - Both can run simultaneously
 - Multiple Claude sessions may run dev instances concurrently from different worktrees
 
+## Worktree setup
+
+A `post-checkout` git hook auto-runs `npm install` + `npm run build` when creating worktrees. No manual setup needed — just `git worktree add` and it's ready.
+
 ## Managing dev instances (multi-session safe)
 
 Multiple Claude sessions may work on different worktrees simultaneously. Electron processes inherit the `cwd` of the worktree — use `lsof` to identify and kill only yours.
+
+> ⚠️ **CRITICAL: You MUST `cd` into your worktree/project directory before running the kill/launch command.** The command uses `$(pwd)` to scope which Electron process to kill. Running it from `~` or any other directory risks killing the **production instance** if it was launched from that directory.
 
 **Always use this command to launch** (kills any existing instance first — safe even on first launch):
 ```bash

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -264,7 +264,8 @@ const TERM_THEME = {
   background: "#0a0a0a",
   cursor: "#ff1a1a",
   cursorAccent: "#0a0a0a",
-  selectionBackground: "#1a0808",
+  selectionBackground: "rgba(255, 26, 26, 0.25)",
+  selectionForeground: "#ffffff",
 };
 
 // --- Directory color coding ---


### PR DESCRIPTION
## Summary
- **Selection fix**: `selectionBackground` changed from opaque near-black (`#1a0808`) to translucent red (`rgba(255, 26, 26, 0.25)`) + added `selectionForeground: #ffffff` — selected text is now readable
- **Worktree docs**: Added safety warning about kill command cwd, documented `post-checkout` hook auto-setup

## Note
The `post-checkout` git hook (`.git/hooks/post-checkout`) auto-runs `npm install` + `npm run build` on worktree creation. It lives in `.git/hooks/` so it's not part of this PR — it's already installed locally.

## Test plan
- [ ] Select text in terminal — should show translucent red highlight with white text
- [ ] Create a worktree (`git worktree add .wt/test`) — should auto-install deps and build

🤖 Generated with [Claude Code](https://claude.com/claude-code)