### PR TITLE
Detect externally cleared sessions as offloaded

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -187,6 +187,9 @@ function getOffloadedSessions() {
         status: "offloaded",
         idleTs: meta.lastInteractionTs || 0,
         claudeSessionId: meta.claudeSessionId || null,
+        hasSnapshot: fs.existsSync(
+          path.join(OFFLOADED_DIR, dir, "snapshot.log"),
+        ),
       });
     } catch {}
   }
@@ -626,7 +629,12 @@ async function reconcilePool() {
     if (fs.existsSync(pidFile)) {
       const sessionId = fs.readFileSync(pidFile, "utf-8").trim();
       if (sessionId && sessionId !== slot.sessionId) {
+        // Session UUID changed — /clear was run externally. Offload the old session.
+        if (slot.sessionId) {
+          saveExternalClearOffload(slot.sessionId, slot.pid);
+        }
         slot.sessionId = sessionId;
+        slot.status = "fresh";
         changed = true;
       }
     }
@@ -635,10 +643,79 @@ async function reconcilePool() {
   if (changed) writePool(pool);
 }
 
+// Save offload metadata for a session that was cleared externally (no snapshot available).
+function saveExternalClearOffload(oldSessionId, pid) {
+  try {
+    validateSessionId(oldSessionId);
+    const offloadDir = path.join(OFFLOADED_DIR, oldSessionId);
+    if (fs.existsSync(path.join(offloadDir, "meta.json"))) return; // Already offloaded
+    fs.mkdirSync(offloadDir, { recursive: true });
+
+    const cwd = getCwdFromJsonl(oldSessionId);
+    const intentionFile = path.join(INTENTIONS_DIR, `${oldSessionId}.md`);
+    const intentionHeading = fs.existsSync(intentionFile)
+      ? getIntentionHeading(intentionFile)
+      : null;
+
+    // Find git root
+    let gitRoot = null;
+    if (cwd) {
+      let dir = cwd;
+      while (dir !== path.dirname(dir)) {
+        try {
+          if (fs.statSync(path.join(dir, ".git")).isDirectory()) {
+            gitRoot = dir;
+            break;
+          }
+        } catch {}
+        dir = path.dirname(dir);
+      }
+    }
+
+    // Try to read Claude session ID from idle signal
+    const idleSignal = pid ? getIdleSignal(pid) : null;
+
+    const meta = {
+      sessionId: oldSessionId,
+      claudeSessionId: idleSignal?.session_id || null,
+      cwd: cwd || null,
+      gitRoot,
+      intentionHeading,
+      lastInteractionTs: Math.floor(Date.now() / 1000),
+      offloadedAt: new Date().toISOString(),
+      externalClear: true,
+    };
+    fs.writeFileSync(
+      path.join(offloadDir, "meta.json"),
+      JSON.stringify(meta, null, 2),
+    );
+  } catch (err) {
+    console.error("[main] Failed to save external clear offload:", err.message);
+  }
+}
+
 // Sync pool.json slot statuses with live session state.
+// Also detects external /clear by checking if a slot's PID now maps to a different session UUID.
 function syncPoolStatuses(sessions) {
   const pool = readPool();
   if (!pool) return;
+
+  let externalClearDetected = false;
+  for (const slot of pool.slots) {
+    if (!slot.pid || !slot.sessionId || slot.status === "dead") continue;
+    try {
+      const pidFile = path.join(SESSION_PIDS_DIR, String(slot.pid));
+      const currentSessionId = fs.readFileSync(pidFile, "utf-8").trim();
+      if (currentSessionId && currentSessionId !== slot.sessionId) {
+        saveExternalClearOffload(slot.sessionId, slot.pid);
+        slot.sessionId = currentSessionId;
+        slot.status = "fresh";
+        externalClearDetected = true;
+      }
+    } catch {}
+  }
+  if (externalClearDetected) writePool(pool);
+
   const updated = syncStatuses(pool, sessions);
   if (updated) writePool(updated);
 }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -764,7 +764,7 @@ async function showOffloadMenu(session) {
       <div class="offload-menu-subtitle">${escapeHtml(displayPath(session))}</div>
       <div class="offload-menu-actions">
         <button class="offload-menu-btn offload-menu-load">Load Session</button>
-        <button class="offload-menu-btn offload-menu-snapshot">View Snapshot</button>
+        ${session.hasSnapshot !== false ? '<button class="offload-menu-btn offload-menu-snapshot">View Snapshot</button>' : ""}
         <button class="offload-menu-btn offload-menu-cancel">Cancel</button>
       </div>
     </div>
@@ -781,13 +781,14 @@ async function showOffloadMenu(session) {
     menu.remove();
   });
 
-  menu
-    .querySelector(".offload-menu-snapshot")
-    .addEventListener("click", async () => {
+  const snapshotBtn = menu.querySelector(".offload-menu-snapshot");
+  if (snapshotBtn) {
+    snapshotBtn.addEventListener("click", async () => {
       menu.remove();
       const snapshot = await window.api.readOffloadSnapshot(session.sessionId);
       showSnapshotViewer(session, snapshot);
     });
+  }
 
   menu
     .querySelector(".offload-menu-load")


### PR DESCRIPTION
## Summary
- Detect when a pool session's UUID changes (indicating `/clear` was run externally) in both `reconcilePool` (startup) and `syncPoolStatuses` (periodic)
- Save offload metadata (`meta.json` with `externalClear: true`) for the old session — no snapshot since the app didn't capture the buffer
- Add `hasSnapshot` field to offloaded sessions so the UI can conditionally show/hide the "View Snapshot" button
- Guard the snapshot button event listener against `null` when button is hidden

## Test plan
- [x] `npm run build` succeeds
- [x] All 71 tests pass (`npx vitest run`)
- [ ] Manual: run `/clear` in an external terminal for a pool session, verify it appears as offloaded in sidebar
- [ ] Manual: click offloaded session from external clear, verify no "View Snapshot" button shown
- [ ] Manual: click offloaded session from normal offload, verify "View Snapshot" button still works

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)