### PR TITLE
Hide PTY daemon from Dock/app switcher

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -798,7 +798,7 @@ function startDaemon() {
       detached: true,
       stdio: "ignore",
       cwd: os.homedir(), // Don't inherit app cwd — prevents kill-by-cwd from hitting daemon
-      env: { ...process.env },
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
     });
     child.unref();
 


### PR DESCRIPTION
## Summary

- Add `ELECTRON_RUN_AS_NODE: "1"` to the daemon spawn environment in `startDaemon()`, so the PTY daemon runs as plain Node.js instead of a full Electron process — no Dock icon, no Cmd+Tab entry.

Closes #9

## Test plan

- [x] `npm run build` passes
- [x] `npx vitest run` — all 213 tests pass
- [ ] Launch app, verify only one Dock icon appears (no separate daemon icon)
- [ ] Verify terminals still work (daemon still spawns and connects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)