### PR TITLE
Deduplicate session-pids by UUID to fix /resume collision

### DIFF
--- a/hooks/session-pid-map.sh
+++ b/hooks/session-pid-map.sh
@@ -25,4 +25,18 @@ for f in "$SESSION_DIR"/*; do
     kill -0 "$pid" 2>/dev/null || rm -f "$f"
 done
 
+# Deduplicate: if another alive PID maps to same session_id, remove the older file
+for f in "$SESSION_DIR"/*; do
+    [ -f "$f" ] || continue
+    pid=$(basename "$f")
+    [ "$pid" = "$PPID" ] && continue
+    kill -0 "$pid" 2>/dev/null || continue
+    other_sid=$(cat "$f" 2>/dev/null) || continue
+    if [ "$other_sid" = "$session_id" ]; then
+        if [ "$f" -ot "$SESSION_DIR/$PPID" ]; then
+            rm -f "$f"
+        fi
+    fi
+done
+
 exit 0

--- a/src/main.js
+++ b/src/main.js
@@ -290,6 +290,33 @@ function getSessions() {
     }
   }
 
+  // Deduplicate: if multiple PIDs map to the same sessionId, keep the best one
+  // (prefer alive over dead, then highest PID). Remove dominated PID files from disk.
+  const bySessionId = new Map();
+  for (const s of sessions) {
+    const existing = bySessionId.get(s.sessionId);
+    if (!existing) {
+      bySessionId.set(s.sessionId, s);
+      continue;
+    }
+    // Determine winner: alive beats dead, then highest PID wins
+    let dominated;
+    if (existing.alive !== s.alive) {
+      dominated = existing.alive ? s : existing;
+    } else {
+      dominated = Number(existing.pid) >= Number(s.pid) ? s : existing;
+    }
+    const winner = dominated === s ? existing : s;
+    bySessionId.set(s.sessionId, winner);
+    // Remove dominated PID file from disk
+    try {
+      fs.unlinkSync(path.join(SESSION_PIDS_DIR, String(dominated.pid)));
+    } catch {}
+  }
+  const dedupedSessions = [...bySessionId.values()];
+  sessions.length = 0;
+  sessions.push(...dedupedSessions);
+
   // Tag sessions as pool vs external
   const pool = readPool();
   const poolSessionIds = new Set();


### PR DESCRIPTION
## Summary

- **Shell-side dedup** (`hooks/session-pid-map.sh`): After dead-PID cleanup, removes older PID files when another alive PID maps to the same session UUID
- **JS-side dedup** (`src/main.js` `getSessions()`): Before pool tagging, deduplicates sessions by `sessionId` — prefers alive over dead, then highest PID — and removes dominated PID files from disk

Closes #11

## Test plan

- [ ] `/resume` a session → verify only one PID entry exists in `~/.claude/session-pids/` for that UUID
- [ ] Confirm sidebar shows no duplicate sessions after resume
- [ ] `npm run build` and `npx vitest run` pass (213/213 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)