### PR TITLE
Detect externally cleared sessions as offloaded

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -174,6 +174,7 @@ function getOffloadedSessions() {
     try {
       const meta = readOffloadMeta(dir);
       if (!meta) continue;
+      const snapshotFile = path.join(OFFLOADED_DIR, dir, "snapshot.log");
       sessions.push({
         pid: null,
         sessionId: meta.sessionId || dir,
@@ -187,6 +188,7 @@ function getOffloadedSessions() {
         status: "offloaded",
         idleTs: meta.lastInteractionTs || 0,
         claudeSessionId: meta.claudeSessionId || null,
+        hasSnapshot: fs.existsSync(snapshotFile),
       });
     } catch {}
   }
@@ -405,6 +407,48 @@ function validateSessionId(sessionId) {
   if (!/^[a-f0-9-]+$/i.test(sessionId)) {
     throw new Error("Invalid session ID format");
   }
+}
+
+// Save offload metadata for a session that was cleared externally (e.g. /clear in terminal)
+function saveExternalClearOffload(oldSessionId, pid) {
+  validateSessionId(oldSessionId);
+  const offloadDir = path.join(OFFLOADED_DIR, oldSessionId);
+  if (fs.existsSync(offloadDir)) return; // already offloaded
+  fs.mkdirSync(offloadDir, { recursive: true });
+
+  // Gather what metadata we can
+  let cwd = null,
+    gitRoot = null,
+    intentionHeading = null;
+  if (pid) {
+    try {
+      const lsof = execFileSync(
+        "lsof",
+        ["-a", "-p", String(pid), "-d", "cwd", "-F", "n"],
+        { encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] },
+      );
+      const m = lsof.match(/^n(.+)$/m);
+      if (m) cwd = m[1];
+    } catch {}
+  }
+  const intentionFile = path.join(INTENTIONS_DIR, `${oldSessionId}.md`);
+  intentionHeading = fs.existsSync(intentionFile)
+    ? getIntentionHeading(intentionFile)
+    : null;
+
+  const meta = {
+    sessionId: oldSessionId,
+    cwd,
+    gitRoot,
+    intentionHeading,
+    externalClear: true,
+    lastInteractionTs: Math.floor(Date.now() / 1000),
+    offloadedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(
+    path.join(offloadDir, "meta.json"),
+    JSON.stringify(meta, null, 2),
+  );
 }
 
 // Remove offload data for a session (after resume)
@@ -626,7 +670,11 @@ async function reconcilePool() {
     if (fs.existsSync(pidFile)) {
       const sessionId = fs.readFileSync(pidFile, "utf-8").trim();
       if (sessionId && sessionId !== slot.sessionId) {
+        if (slot.sessionId) {
+          saveExternalClearOffload(slot.sessionId, slot.pid);
+        }
         slot.sessionId = sessionId;
+        slot.status = "fresh";
         changed = true;
       }
     }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -764,7 +764,7 @@ async function showOffloadMenu(session) {
       <div class="offload-menu-subtitle">${escapeHtml(displayPath(session))}</div>
       <div class="offload-menu-actions">
         <button class="offload-menu-btn offload-menu-load">Load Session</button>
-        <button class="offload-menu-btn offload-menu-snapshot">View Snapshot</button>
+        ${session.hasSnapshot !== false ? '<button class="offload-menu-btn offload-menu-snapshot">View Snapshot</button>' : ""}
         <button class="offload-menu-btn offload-menu-cancel">Cancel</button>
       </div>
     </div>
@@ -781,13 +781,14 @@ async function showOffloadMenu(session) {
     menu.remove();
   });
 
-  menu
-    .querySelector(".offload-menu-snapshot")
-    .addEventListener("click", async () => {
+  const snapshotBtn = menu.querySelector(".offload-menu-snapshot");
+  if (snapshotBtn) {
+    snapshotBtn.addEventListener("click", async () => {
       menu.remove();
       const snapshot = await window.api.readOffloadSnapshot(session.sessionId);
       showSnapshotViewer(session, snapshot);
     });
+  }
 
   menu
     .querySelector(".offload-menu-load")


### PR DESCRIPTION
## Summary
- Add `saveExternalClearOffload()` to persist metadata when a session is `/clear`ed from an external terminal
- Call it from `reconcilePool()` when a slot's session ID changes unexpectedly
- Add `hasSnapshot` field to offloaded sessions so the renderer can hide "View Snapshot" when no snapshot exists

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)