### PR TITLE
Fix pool init: resolve claude path, restart dead slots

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -440,6 +440,24 @@ function readOffloadMeta(sessionId) {
 
 // --- Pool Management ---
 
+function resolveClaudePath() {
+  try {
+    return execFileSync("which", ["claude"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+    }).trim();
+  } catch {}
+  const candidates = [
+    path.join(os.homedir(), ".claude", "local", "bin", "claude"),
+    "/usr/local/bin/claude",
+    path.join(os.homedir(), ".local", "bin", "claude"),
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) return p;
+  }
+  throw new Error("Claude binary not found");
+}
+
 function readPool() {
   return readPoolFile(POOL_FILE);
 }
@@ -450,11 +468,12 @@ function writePool(pool) {
 
 // Spawn a single Claude session via the PTY daemon. Returns a slot object.
 async function spawnPoolSlot(index) {
+  const claudePath = resolveClaudePath();
   const resp = await daemonRequest({
     type: "spawn",
     cwd: os.homedir(),
-    cmd: "/bin/zsh",
-    args: ["-ic", "exec c"],
+    cmd: claudePath,
+    args: ["--dangerously-skip-permissions"],
   });
   return createSlot(index, resp.termId, resp.pid);
 }
@@ -607,10 +626,33 @@ async function reconcilePool() {
   for (const slot of pool.slots) {
     const pty = daemonPtys.get(slot.termId);
     if (!pty || pty.exited) {
-      // Terminal died — mark slot as dead
       if (slot.status !== "dead") {
         slot.status = "dead";
         changed = true;
+      }
+      // Auto-restart dead slot
+      try {
+        const newSlot = await spawnPoolSlot(slot.index);
+        slot.termId = newSlot.termId;
+        slot.pid = newSlot.pid;
+        slot.status = "starting";
+        slot.sessionId = null;
+        changed = true;
+        pollForSessionId(slot.pid, 60000).then((sessionId) => {
+          const p = readPool();
+          if (!p) return;
+          const s = p.slots.find((x) => x.index === slot.index);
+          if (s) {
+            s.sessionId = sessionId;
+            s.status = sessionId ? "fresh" : "error";
+            writePool(p);
+          }
+        });
+      } catch (err) {
+        console.error(
+          `[main] Failed to restart slot ${slot.index}:`,
+          err.message,
+        );
       }
       continue;
     }
@@ -641,6 +683,19 @@ function syncPoolStatuses(sessions) {
   if (!pool) return;
   const updated = syncStatuses(pool, sessions);
   if (updated) writePool(updated);
+}
+
+async function poolDestroy() {
+  const pool = readPool();
+  if (!pool) return;
+  for (const slot of pool.slots) {
+    try {
+      await daemonRequest({ type: "kill", termId: slot.termId });
+    } catch {}
+  }
+  try {
+    fs.unlinkSync(POOL_FILE);
+  } catch {}
 }
 
 function readIntention(sessionId) {
@@ -1027,6 +1082,7 @@ app.whenReady().then(async () => {
   ipcMain.handle("pool-resize", async (_e, newSize) => poolResize(newSize));
   ipcMain.handle("pool-health", () => getPoolHealth());
   ipcMain.handle("pool-read", () => readPool());
+  ipcMain.handle("pool-destroy", async () => poolDestroy());
 
   // Poll for a session-pid file to appear for a given PID
   ipcMain.handle("pty-wait-session", (_e, pid) => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -58,6 +58,7 @@ contextBridge.exposeInMainWorld("api", {
   poolResize: (newSize) => ipcRenderer.invoke("pool-resize", newSize),
   poolHealth: () => ipcRenderer.invoke("pool-health"),
   poolRead: () => ipcRenderer.invoke("pool-read"),
+  poolDestroy: () => ipcRenderer.invoke("pool-destroy"),
 
   // Terminal (forwarded to PTY daemon via main process)
   ptySpawn: (opts) => ipcRenderer.invoke("pty-spawn", opts),

--- a/src/pty-daemon.js
+++ b/src/pty-daemon.js
@@ -20,6 +20,25 @@ const SOCKET_PATH = path.join(OPEN_COCKPIT_DIR, "pty-daemon.sock");
 const BUFFER_SIZE = 100_000; // bytes of output to buffer per terminal for replay
 const IDLE_TIMEOUT_MS = 30 * 60 * 1000; // exit after 30 min with no terminals and no clients
 const ALLOWED_SHELLS = new Set(["/bin/zsh", "/bin/bash", "/bin/sh"]);
+const EXTRA_PATH_DIRS = [
+  path.join(os.homedir(), ".claude", "local", "bin"),
+  path.join(os.homedir(), ".local", "bin"),
+  "/usr/local/bin",
+];
+
+function isAllowedCmd(cmd) {
+  if (ALLOWED_SHELLS.has(cmd)) return true;
+  // Allow absolute paths to existing executables
+  if (path.isAbsolute(cmd)) {
+    try {
+      fs.accessSync(cmd, fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
 
 // --- State ---
 let nextTermId = 1;
@@ -72,7 +91,7 @@ function cleanup() {
 
 function handleSpawn(socket, msg) {
   const shell =
-    msg.cmd && ALLOWED_SHELLS.has(msg.cmd)
+    msg.cmd && isAllowedCmd(msg.cmd)
       ? msg.cmd
       : process.env.SHELL || "/bin/zsh";
   const args = msg.args || [];
@@ -83,6 +102,7 @@ function handleSpawn(socket, msg) {
   const cleanEnv = { ...process.env, TERM: "xterm-256color" };
   delete cleanEnv.CLAUDECODE;
   delete cleanEnv.CLAUDE_CODE_SESSION_ID;
+  cleanEnv.PATH = [...EXTRA_PATH_DIRS, process.env.PATH || ""].join(":");
 
   const proc = pty.spawn(shell, args, {
     name: "xterm-256color",


### PR DESCRIPTION
## Summary

- Resolve the `claude` binary via `which` + known candidate paths instead of relying on the `c` shell alias (which doesn't resolve in daemon PTY environments, especially when launched from Dock)
- Update the PTY daemon's command validation (`isAllowedCmd`) to accept absolute paths to executables, not just whitelisted shells
- Augment `PATH` in daemon-spawned environments with common Claude install directories
- Auto-restart dead pool slots during `reconcilePool()` instead of just marking them dead
- Add `pool-destroy` IPC handler for tearing down all pool slots

## Test plan

- [x] `npm run build` succeeds
- [x] `npx vitest run` — all 71 tests pass
- [ ] Manual: launch app from Dock, verify pool slots start successfully
- [ ] Manual: kill a pool slot's process, verify it auto-restarts on next reconcile

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)