### PR TITLE
Auto-accept trust prompt in pool slots + fix CLI exit code

### DIFF
--- a/bin/cockpit-cli
+++ b/bin/cockpit-cli
@@ -44,7 +44,7 @@ esac
 
 # Send via socat (or node if socat unavailable)
 if command -v socat &>/dev/null; then
-  echo "$json" | socat -t5 - UNIX-CONNECT:"$SOCKET"
+  echo "$json" | socat -t1 - UNIX-CONNECT:"$SOCKET"
 else
   node -e "
     const net = require('net');

--- a/src/main.js
+++ b/src/main.js
@@ -574,6 +574,15 @@ async function poolInit(size) {
   );
   pool.slots = slots;
 
+  // Accept trust prompts: Claude shows "Do you trust this folder?" even with --dangerously-skip-permissions
+  // Wait for prompt to appear, then send Enter to accept
+  await new Promise((r) => setTimeout(r, 3000));
+  for (const slot of pool.slots) {
+    daemonSend({ type: "write", termId: slot.termId, data: "\n" });
+  }
+  // Give Claude time to start after trust acceptance
+  await new Promise((r) => setTimeout(r, 2000));
+
   writePool(pool);
 
   // Wait for each slot to get a session ID (Claude starts and hooks write PID mapping).
@@ -711,6 +720,10 @@ async function reconcilePool() {
         slot.status = "starting";
         slot.sessionId = null;
         changed = true;
+        // Accept trust prompt after spawning
+        setTimeout(() => {
+          daemonSend({ type: "write", termId: newSlot.termId, data: "\n" });
+        }, 3000);
         pollForSessionId(slot.pid, 60000).then((sessionId) => {
           const p = readPool();
           if (!p) return;


### PR DESCRIPTION
## Summary
- 🔐 **Trust prompt fix**: Pool slots (both `poolInit` and `reconcilePool`) now auto-accept the "Do you trust this folder?" prompt by sending Enter after spawning Claude sessions
- ⏱️ **CLI exit code fix**: Reduced socat timeout from `-t5` to `-t1` so `cockpit-cli` exits promptly after receiving a response

Closes #24

## Test plan
- [ ] `cockpit-cli pool-init 2` — slots should reach "fresh" status without getting stuck on trust prompt
- [ ] `cockpit-cli ping` — should exit with code 0 within ~1s
- [ ] Kill a pool slot's PTY, wait for reconcile, verify restarted slot also passes trust prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)