### PR TITLE
Add session origin tags: pool, sub-claude, ext

### DIFF
--- a/.orchestration-plan.md
+++ b/.orchestration-plan.md
@@ -1,0 +1,24 @@
+# Orchestration Plan
+
+## Wave 1 — Independent issues (parallel)
+- [ ] #34 — pool-destroy: kill by PID (small fix)
+- [ ] #35 — Pool settings auto-refresh (small fix)
+- [ ] #29 — Poll terminal for trust prompt (medium)
+- [ ] #32 — Session origin tags (medium)
+- [ ] #28 — First tab shows Claude TUI (medium-large)
+- [ ] #26 — Pool settings: click slot for terminal popup (medium)
+- [ ] Self-containment audit agent
+- [ ] Code quality / bug-finding agents
+
+## Wave 2 — Depends on Wave 1
+- [ ] #33 — Setup scripts (depends on #28)
+- [ ] #27 — CLI: sub-claude-compatible commands (large, independent but save for wave 2 to reduce merge conflicts)
+
+## Wave 3 — Review & merge
+- [ ] Code review on all PRs
+- [ ] Merge PRs into main
+- [ ] Resolve conflicts
+
+## Wave 4 — Testing & new issue discovery
+- [ ] Manual testing
+- [ ] Fix any discovered issues

--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,28 @@ const DEFAULT_POOL_SIZE = 5;
 const fileWatchers = new Map();
 let mainWindow = null;
 
+// Cache origin per PID (never changes during a process's lifetime)
+const originCache = new Map();
+
+// Detect session origin by reading process environment via ps eww (macOS)
+function detectOrigin(pid) {
+  if (originCache.has(String(pid))) return originCache.get(String(pid));
+  let origin = "ext";
+  try {
+    const out = execFileSync("ps", ["eww", "-p", String(pid)], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+    if (/\bOPEN_COCKPIT_POOL=1\b/.test(out)) {
+      origin = "pool";
+    } else if (/\bSUB_CLAUDE=1\b/.test(out)) {
+      origin = "sub-claude";
+    }
+  } catch {}
+  originCache.set(String(pid), origin);
+  return origin;
+}
+
 // --- PTY Daemon Client ---
 let daemonSocket = null;
 let daemonConnecting = null; // Promise while connection in progress
@@ -369,7 +391,7 @@ function getSessions() {
     sessions.splice(i, 1);
   }
 
-  // Tag sessions as pool vs external
+  // Tag sessions with origin: pool, sub-claude, or ext
   const pool = readPool();
   const poolSessionIds = new Set();
   if (pool) {
@@ -378,7 +400,15 @@ function getSessions() {
     }
   }
   for (const s of sessions) {
-    s.isPool = poolSessionIds.has(s.sessionId);
+    if (poolSessionIds.has(s.sessionId)) {
+      s.origin = "pool";
+    } else if (s.alive) {
+      s.origin = detectOrigin(s.pid);
+    } else {
+      s.origin = "ext";
+    }
+    // Keep isPool for backward compat (used by offload logic)
+    s.isPool = s.origin === "pool";
   }
 
   // Add offloaded sessions (always pool, skip if live session exists)
@@ -386,6 +416,7 @@ function getSessions() {
   for (const offloaded of getOffloadedSessions()) {
     if (!liveIds.has(offloaded.sessionId)) {
       offloaded.isPool = true;
+      offloaded.origin = "pool";
       sessions.push(offloaded);
     }
   }
@@ -637,6 +668,7 @@ async function spawnPoolSlot(index) {
     cwd: os.homedir(),
     cmd: claudePath,
     args: ["--dangerously-skip-permissions"],
+    env: { OPEN_COCKPIT_POOL: "1" },
   });
   return createSlot(index, resp.termId, resp.pid);
 }

--- a/src/pty-daemon.js
+++ b/src/pty-daemon.js
@@ -104,6 +104,11 @@ function handleSpawn(socket, msg) {
   delete cleanEnv.CLAUDE_CODE_SESSION_ID;
   cleanEnv.PATH = [...EXTRA_PATH_DIRS, process.env.PATH || ""].join(":");
 
+  // Merge caller-provided env overrides (e.g. OPEN_COCKPIT_POOL for origin tagging)
+  if (msg.env && typeof msg.env === "object") {
+    Object.assign(cleanEnv, msg.env);
+  }
+
   const proc = pty.spawn(shell, args, {
     name: "xterm-256color",
     cols: msg.cols || 80,

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -724,14 +724,16 @@ function createSessionItem(s) {
   const indicatorStyle = dirColor
     ? `background: ${dirColor}; box-shadow: 0 0 4px ${dirColor}`
     : "background: transparent";
-  const extTag = s.isPool ? "" : '<span class="session-ext-tag">ext</span>';
+  const originTag = s.origin
+    ? `<span class="session-origin-tag session-origin-${s.origin}">${s.origin}</span>`
+    : "";
   li.innerHTML = `
     <div class="session-dir-indicator" style="${indicatorStyle}"></div>
     <div class="session-item-content">
       <div class="session-project">
         <span class="session-status ${STATUS_CLASSES[s.status] || "dead"}"></span>
         ${escapeHtml(heading)}
-        ${extTag}
+        ${originTag}
       </div>
       <div class="session-cwd">${escapeHtml(dp)}</div>
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -199,16 +199,29 @@ body {
   cursor: default;
 }
 
-.session-ext-tag {
+.session-origin-tag {
   font-size: 9px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--text-dim);
-  background: var(--border);
   padding: 1px 4px;
   border-radius: 3px;
   margin-left: 4px;
   vertical-align: middle;
+}
+
+.session-origin-pool {
+  color: var(--green);
+  background: rgba(0, 255, 65, 0.1);
+}
+
+.session-origin-sub-claude {
+  color: var(--mauve);
+  background: rgba(255, 0, 255, 0.1);
+}
+
+.session-origin-ext {
+  color: var(--text-dim);
+  background: var(--border);
 }
 
 .session-cwd {


### PR DESCRIPTION
## Summary
- Sessions in the sidebar now show colored origin tags (pool/sub-claude/ext) instead of the binary ext tag
- Pool origin detected via pool.json; sub-claude detected via `SUB_CLAUDE=1` env var using `ps eww`; everything else is ext
- PTY daemon now accepts `env` overrides in spawn messages; pool slots are spawned with `OPEN_COCKPIT_POOL=1`
- Origin detection is cached per PID for performance

## Test plan
- [ ] Init a pool, verify sessions show green "pool" tags
- [ ] Start a Claude session externally, verify it shows gray "ext" tag
- [ ] Start a sub-claude session (from within a Claude agent), verify it shows purple "sub-claude" tag
- [ ] Verify offloaded sessions show "pool" tag
- [ ] Check that the offload (Cmd+N) flow still works (uses `isPool` internally)

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)