### PR TITLE
Fix path traversal, JSON injection, and stale state bugs

### DIFF
--- a/bin/cockpit-cli
+++ b/bin/cockpit-cli
@@ -13,8 +13,8 @@ case "$CMD" in
   pool-read)    json="{\"type\":\"pool-read\",\"id\":1}" ;;
   pool-destroy) json="{\"type\":\"pool-destroy\",\"id\":1}" ;;
   get-sessions) json="{\"type\":\"get-sessions\",\"id\":1}" ;;
-  read-intention)  json="{\"type\":\"read-intention\",\"id\":1,\"sessionId\":\"${1:?sessionId required}\"}" ;;
-  write-intention) json="{\"type\":\"write-intention\",\"id\":1,\"sessionId\":\"${1:?sessionId required}\",\"content\":$(printf '%s' "${2:?content required}" | jq -Rs .)}" ;;
+  read-intention)  json="{\"type\":\"read-intention\",\"id\":1,\"sessionId\":$(printf '%s' "${1:?sessionId required}" | jq -Rs .)}" ;;
+  write-intention) json="{\"type\":\"write-intention\",\"id\":1,\"sessionId\":$(printf '%s' "${1:?sessionId required}" | jq -Rs .),\"content\":$(printf '%s' "${2:?content required}" | jq -Rs .)}" ;;
   pty-list)     json="{\"type\":\"pty-list\",\"id\":1}" ;;
   pty-write)    json="{\"type\":\"pty-write\",\"id\":1,\"termId\":${1:?termId required},\"data\":$(printf '%s' "${2:?data required}" | jq -Rs .)}" ;;
   pty-read)     json="{\"type\":\"pty-read\",\"id\":1,\"termId\":${1:?termId required}}" ;;
@@ -44,7 +44,7 @@ esac
 
 # Send via socat (or node if socat unavailable)
 if command -v socat &>/dev/null; then
-  printf '%s\n' "$json" | socat -t0 - UNIX-CONNECT:"$SOCKET" || true
+  printf '%s\n' "$json" | socat -t5 - UNIX-CONNECT:"$SOCKET" || true
 else
   node -e "
     const net = require('net');

--- a/src/main.js
+++ b/src/main.js
@@ -844,6 +844,8 @@ function watchIntention(sessionId) {
     fs.unwatchFile(fileWatchers.get("current"));
     fileWatchers.delete("current");
   }
+  // Reset change-detection state so we don't suppress notifications for new session
+  lastWrittenContent = null;
 
   const file = path.join(INTENTIONS_DIR, `${sessionId}.md`);
   if (!fs.existsSync(file)) {
@@ -1128,13 +1130,18 @@ app.whenReady().then(async () => {
     syncPoolStatuses(sessions);
     return sessions;
   });
-  ipcMain.handle("read-intention", (_e, sessionId) => readIntention(sessionId));
-  ipcMain.handle("write-intention", (_e, sessionId, content) =>
-    writeIntention(sessionId, content),
-  );
-  ipcMain.handle("watch-intention", (_e, sessionId) =>
-    watchIntention(sessionId),
-  );
+  ipcMain.handle("read-intention", (_e, sessionId) => {
+    validateSessionId(sessionId);
+    return readIntention(sessionId);
+  });
+  ipcMain.handle("write-intention", (_e, sessionId, content) => {
+    validateSessionId(sessionId);
+    return writeIntention(sessionId, content);
+  });
+  ipcMain.handle("watch-intention", (_e, sessionId) => {
+    validateSessionId(sessionId);
+    return watchIntention(sessionId);
+  });
 
   // PTY IPC handlers — all forwarded to daemon
 


### PR DESCRIPTION
## Summary

- **Path traversal on IPC handlers**: `read-intention`, `write-intention`, `watch-intention` IPC handlers lacked `validateSessionId()` — added it (API server already had it)
- **JSON injection in cockpit-cli**: `read-intention` and `write-intention` commands interpolated sessionId raw into JSON strings; now escaped via `jq -Rs`
- **socat response timeout**: Changed `-t0` (no wait) to `-t5` so CLI actually receives responses
- **Stale file-change detection**: `lastWrittenContent` wasn't reset on session switch, potentially suppressing external change notifications for the new session

## Related issues filed

- #40 — Race condition: concurrent pool.json read-modify-write in async callbacks
- #41 — PTY daemon string buffer O(n) per data event
- #42 — idle-signal.sh uses macOS-only `stat -f %m`

## Test plan

- [ ] Verify `cockpit-cli read-intention <uuid>` returns content (socat path)
- [ ] Verify `cockpit-cli write-intention <uuid> "text"` works
- [ ] Switch sessions and edit intention externally — confirm change notification appears
- [ ] Attempt invalid sessionId via IPC (e.g., `../foo`) — should throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)