### PR TITLE
Pool settings: click slot to open terminal popup

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -645,6 +645,7 @@ function cleanupStaleTerminals(liveSessions) {
 // Find a terminal entry across all sessions (active + cached)
 // Temporary lookup for terminals being reconnected (before they're in sessionTerminals)
 const pendingTerminals = new Map(); // termId -> entry
+const popupTerminals = new Map(); // termId -> { term, ... } for slot terminal popups
 
 function findTerminalEntry(termId) {
   const active = terminals.find((t) => t.termId === termId);
@@ -660,17 +661,25 @@ function findTerminalEntry(termId) {
 window.api.onPtyData((termId, data) => {
   const entry = findTerminalEntry(termId);
   if (entry) entry.term.write(data);
+  // Also forward to popup terminal if open (may be same or different entry)
+  const popup = popupTerminals.get(termId);
+  if (popup && popup !== entry) popup.term.write(data);
 });
 
 window.api.onPtyReplay((termId, data) => {
   const entry = findTerminalEntry(termId);
   // Skip if buffer was already written directly during reconnect
   if (entry && !entry.skipReplay) entry.term.write(data);
+  // Popup always receives replay (it never has skipReplay)
+  const popup = popupTerminals.get(termId);
+  if (popup && popup !== entry) popup.term.write(data);
 });
 
 window.api.onPtyExit((termId) => {
   const entry = findTerminalEntry(termId);
   if (entry) entry.term.write("\r\n[Process exited]\r\n");
+  const popup = popupTerminals.get(termId);
+  if (popup && popup !== entry) popup.term.write("\r\n[Process exited]\r\n");
 });
 
 const STATUS_CLASSES = {
@@ -1528,6 +1537,98 @@ refreshBtn.addEventListener("click", async () => {
   loadSessions();
 });
 
+// --- Slot Terminal Popup ---
+async function openSlotTerminalPopup(slot) {
+  // Don't open popup for dead/unknown slots — no terminal to attach to
+  const status = slot.healthStatus || slot.status;
+  if (status === "dead" || !slot.termId) {
+    showNotification("Cannot open terminal for dead slot");
+    return;
+  }
+
+  // Close existing popup if any (run its cleanup)
+  const existingPopup = document.getElementById("slot-terminal-popup");
+  if (existingPopup && existingPopup._cleanup) existingPopup._cleanup();
+  else if (existingPopup) existingPopup.remove();
+
+  const overlay = document.createElement("div");
+  overlay.id = "slot-terminal-popup";
+  overlay.className = "offload-menu-overlay";
+
+  const label =
+    slot.intentionHeading ||
+    slot.sessionId?.slice(0, 8) ||
+    `slot-${slot.index}`;
+
+  overlay.innerHTML = `
+    <div class="slot-terminal-dialog">
+      <div class="slot-terminal-header">
+        <span class="slot-terminal-title">${label} <span class="slot-terminal-readonly">read-only</span></span>
+        <button class="snapshot-close slot-terminal-close">\u2715</button>
+      </div>
+      <div class="slot-terminal-mount"></div>
+    </div>
+  `;
+
+  document.body.appendChild(overlay);
+
+  const mountEl = overlay.querySelector(".slot-terminal-mount");
+  const closeBtn = overlay.querySelector(".slot-terminal-close");
+
+  const term = new Terminal({
+    theme: TERM_THEME,
+    fontFamily: "'SF Mono', Menlo, monospace",
+    fontSize: 13,
+    cursorBlink: false,
+    disableStdin: true,
+  });
+
+  const fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.open(mountEl);
+
+  // Register in popupTerminals so global data handlers can route data here.
+  // Data is forwarded to both the main terminal entry (if any) and the popup entry.
+  const popupEntry = { termId: slot.termId, term, fitAddon };
+  popupTerminals.set(slot.termId, popupEntry);
+
+  try {
+    await window.api.ptyAttach(slot.termId);
+  } catch (err) {
+    showNotification(`Failed to attach: ${err.message}`);
+    popupTerminals.delete(slot.termId);
+    term.dispose();
+    overlay.remove();
+    return;
+  }
+
+  // Fit after a frame so dimensions are correct
+  requestAnimationFrame(() => fitAddon.fit());
+
+  const resizeObserver = new ResizeObserver(() => fitAddon.fit());
+  resizeObserver.observe(mountEl);
+
+  // Cleanup function — also stored on overlay for programmatic close
+  const cleanup = () => {
+    resizeObserver.disconnect();
+    popupTerminals.delete(slot.termId);
+    // Only detach if there's no other terminal entry still using this termId
+    // (i.e. the session might be open in the main view)
+    const otherEntry = findTerminalEntry(slot.termId);
+    if (!otherEntry) {
+      window.api.ptyDetach(slot.termId).catch(() => {});
+    }
+    term.dispose();
+    overlay.remove();
+  };
+  overlay._cleanup = cleanup;
+
+  closeBtn.addEventListener("click", cleanup);
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay) cleanup();
+  });
+}
+
 // --- Pool Settings Panel ---
 const poolSettingsBtn = document.getElementById("pool-settings-btn");
 
@@ -1558,7 +1659,7 @@ async function showPoolSettings() {
           slot.sessionId?.slice(0, 8) ||
           `slot-${slot.index}`;
         const cwdDisplay = slot.cwd || "";
-        return `<div class="pool-slot-row">
+        return `<div class="pool-slot-row pool-slot-clickable" data-slot-index="${slot.index}">
           ${statusDot(status)}
           <span class="pool-slot-label">${label}</span>
           <span class="pool-slot-status">${status}</span>
@@ -1615,6 +1716,15 @@ async function showPoolSettings() {
   overlay
     .querySelector(".pool-close")
     .addEventListener("click", () => overlay.remove());
+
+  // Slot row click → open terminal popup
+  for (const row of overlay.querySelectorAll(".pool-slot-clickable")) {
+    row.addEventListener("click", () => {
+      const slotIndex = parseInt(row.dataset.slotIndex, 10);
+      const slot = health.slots.find((s) => s.index === slotIndex);
+      if (slot) openSlotTerminalPopup(slot);
+    });
+  }
 
   // Init button
   const initBtn = overlay.querySelector(".pool-init-btn");

--- a/src/styles.css
+++ b/src/styles.css
@@ -686,3 +686,64 @@ body {
   outline: none;
   border-color: var(--accent);
 }
+
+/* Clickable pool slot rows */
+.pool-slot-clickable {
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.pool-slot-clickable:hover {
+  background: var(--accent-dim);
+}
+
+/* Slot terminal popup */
+.slot-terminal-dialog {
+  width: 80vw;
+  height: 70vh;
+  max-width: 1000px;
+  background: #111;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.slot-terminal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.slot-terminal-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.slot-terminal-readonly {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+  background: var(--border);
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+
+.slot-terminal-mount {
+  flex: 1;
+  min-height: 0;
+  padding: 4px;
+}
+
+.slot-terminal-mount .xterm {
+  height: 100%;
+}


### PR DESCRIPTION
## Summary

- Pool slot rows in the settings dialog are now clickable — opens a read-only terminal popup showing the slot's live output
- Uses xterm.js with `disableStdin: true` for safe read-only viewing
- Attaches to the daemon terminal, replays buffer, and streams live data
- Properly detaches on close without affecting the main session view if the terminal is also open there
- Only one popup at a time — opening a new one closes the previous

## Implementation details

- `popupTerminals` Map tracks popup terminal entries separately from session terminals
- Global `onPtyData`/`onPtyReplay`/`onPtyExit` handlers forward data to both the main entry and the popup entry
- Cleanup stored on overlay element (`_cleanup`) for programmatic close when switching slots
- Dead slots show a notification instead of opening an empty popup

## Test plan

- [ ] Open pool settings, click a slot row — terminal popup appears with live output
- [ ] Verify output streams in real-time (send a command if idle)
- [ ] Verify read-only: typing in the popup does nothing
- [ ] Close popup with X button or clicking outside
- [ ] Open a slot that's also visible in the main session view — both show data
- [ ] Click a dead slot — notification appears, no popup
- [ ] Click different slots rapidly — previous popup closes cleanly

Closes #26

Generated with [Claude Code](https://claude.com/claude-code)