### PR TITLE
Fix idle-signal.sh macOS-only stat -f %m

### DIFF
--- a/hooks/idle-signal.sh
+++ b/hooks/idle-signal.sh
@@ -56,11 +56,11 @@ print(json.dumps(d))
         # Block detection (Stop only): wait, then verify the session didn't continue.
         # Another Stop hook may have blocked → Claude gets re-prompted → not idle.
         if [ "$trigger" = "stop" ] && [ -n "$transcript" ] && [ -f "$transcript" ]; then
-            saved_mtime=$(stat -f %m "$transcript" 2>/dev/null || echo 0)
+            saved_mtime=$(F="$transcript" python3 -c "import os; print(int(os.path.getmtime(os.environ['F'])))" 2>/dev/null || echo 0)
             sleep 1
             # If signal was already cleared by UserPromptSubmit/PostToolUse, stop
             [ -f "$signal_file" ] || exit 0
-            current_mtime=$(stat -f %m "$transcript" 2>/dev/null || echo 0)
+            current_mtime=$(F="$transcript" python3 -c "import os; print(int(os.path.getmtime(os.environ['F'])))" 2>/dev/null || echo 0)
             if [ "$current_mtime" -gt "$saved_mtime" ]; then
                 # JSONL was modified after signal → session continued → not idle
                 rm -f "$signal_file"


### PR DESCRIPTION
## Summary

- Replaced `stat -f %m` (macOS-only) with `python3 -c "import os; print(int(os.path.getmtime(...)))"` for portable file mtime detection
- Uses env var `F` to pass the path, consistent with the script's existing pattern of avoiding shell injection
- Error fallback (`|| echo 0`) preserved

Fixes #42

## Test plan

- [ ] Verify idle detection still works on macOS (stop trigger → signal file created/removed correctly)
- [ ] Test on Linux to confirm portability

🤖 Generated with [Claude Code](https://claude.com/claude-code)