### PR TITLE
Archive dead sessions as offloaded (no snapshot)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -321,6 +321,54 @@ function getSessions() {
   sessions.length = 0;
   sessions.push(...dedupedSessions);
 
+  // Archive dead sessions that have intention files (save as offloaded without snapshot)
+  for (let i = sessions.length - 1; i >= 0; i--) {
+    const s = sessions[i];
+    if (s.status !== "dead") continue;
+    if (!s.hasIntention) continue;
+
+    const offloadDir = path.join(OFFLOADED_DIR, s.sessionId);
+    if (!fs.existsSync(offloadDir)) {
+      // Recover cwd from JSONL since lsof doesn't work on dead processes
+      let cwd = s.cwd || getCwdFromJsonl(s.sessionId);
+      let gitRoot = s.gitRoot;
+      if (cwd && !gitRoot) {
+        let dir = cwd;
+        while (dir !== path.dirname(dir)) {
+          try {
+            if (fs.statSync(path.join(dir, ".git")).isDirectory()) {
+              gitRoot = dir;
+              break;
+            }
+          } catch {}
+          dir = path.dirname(dir);
+        }
+      }
+
+      fs.mkdirSync(offloadDir, { recursive: true });
+      const meta = {
+        sessionId: s.sessionId,
+        claudeSessionId: s.sessionId,
+        cwd: cwd || null,
+        gitRoot: gitRoot || null,
+        intentionHeading: s.intentionHeading,
+        lastInteractionTs: Math.floor(Date.now() / 1000),
+        archivedAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(
+        path.join(offloadDir, "meta.json"),
+        JSON.stringify(meta, null, 2),
+      );
+    }
+
+    // Clean up stale PID file
+    try {
+      fs.unlinkSync(path.join(SESSION_PIDS_DIR, String(s.pid)));
+    } catch {}
+
+    sessions.splice(i, 1);
+  }
+
   // Tag sessions as pool vs external
   const pool = readPool();
   const poolSessionIds = new Set();


### PR DESCRIPTION
## Summary

- When `getSessions()` finds a dead PID with an existing intention file, archives it by writing `meta.json` to `~/.open-cockpit/offloaded/<sessionId>/` (without `snapshot.log`)
- Recovers `cwd` from JSONL files since `lsof` doesn't work on dead processes, and computes `gitRoot` for color grouping
- Cleans up stale PID files from `~/.claude/session-pids/`
- Existing offloaded session display/resume logic picks up archived sessions automatically — "View Snapshot" button hidden since `hasSnapshot` is `false`

Closes #36

## Test plan

- [ ] Kill a Claude session that has an intention file set
- [ ] Verify it appears in the sidebar as an offloaded session (without snapshot button)
- [ ] Click to resume — verify `/resume <uuid>` runs in a pool slot
- [ ] Verify stale PID file is cleaned up from `~/.claude/session-pids/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)