### PR TITLE
Setup scripts: Cmd+N → pick script → auto-type into fresh session

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -27,6 +27,7 @@ const DAEMON_PID_FILE = path.join(OPEN_COCKPIT_DIR, "pty-daemon.pid");
 const IDLE_SIGNALS_DIR = path.join(OPEN_COCKPIT_DIR, "idle-signals");
 const OFFLOADED_DIR = path.join(OPEN_COCKPIT_DIR, "offloaded");
 const POOL_FILE = path.join(OPEN_COCKPIT_DIR, "pool.json");
+const SETUP_SCRIPTS_DIR = path.join(OPEN_COCKPIT_DIR, "setup-scripts");
 const API_SOCKET = path.join(OPEN_COCKPIT_DIR, "api.sock");
 const DEFAULT_POOL_SIZE = 5;
 
@@ -1102,6 +1103,9 @@ function handleDaemonMessage(msg) {
 }
 
 app.whenReady().then(async () => {
+  // Ensure setup-scripts directory exists
+  fs.mkdirSync(SETUP_SCRIPTS_DIR, { recursive: true });
+
   // Start daemon connection early
   try {
     await ensureDaemon();
@@ -1208,6 +1212,26 @@ app.whenReady().then(async () => {
   ipcMain.handle("pool-health", () => getPoolHealth());
   ipcMain.handle("pool-read", () => readPool());
   ipcMain.handle("pool-destroy", async () => poolDestroy());
+
+  // Setup scripts
+  ipcMain.handle("list-setup-scripts", () => {
+    try {
+      return fs
+        .readdirSync(SETUP_SCRIPTS_DIR)
+        .filter((f) => !f.startsWith("."))
+        .sort();
+    } catch {
+      return [];
+    }
+  });
+  ipcMain.handle("read-setup-script", (_e, name) => {
+    const filePath = path.join(SETUP_SCRIPTS_DIR, path.basename(name));
+    try {
+      return fs.readFileSync(filePath, "utf-8");
+    } catch {
+      return null;
+    }
+  });
 
   // Poll for a session-pid file to appear for a given PID
   ipcMain.handle("pty-wait-session", (_e, pid) => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -79,6 +79,10 @@ contextBridge.exposeInMainWorld("api", {
   onPtyExit: (callback) =>
     ipcRenderer.on("pty-exit", (_e, termId) => callback(termId)),
 
+  // Setup scripts
+  listSetupScripts: () => ipcRenderer.invoke("list-setup-scripts"),
+  readSetupScript: (name) => ipcRenderer.invoke("read-setup-script", name),
+
   // Menu actions
   onNewTerminalTab: (callback) =>
     ipcRenderer.on("new-terminal-tab", () => callback()),

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1043,6 +1043,100 @@ async function selectSession(session) {
 }
 
 // "+" in sidebar: acquire a fresh slot from the pool (or offload LRU idle)
+// --- Setup script picker ---
+function showSetupScriptPicker(scripts) {
+  return new Promise((resolve) => {
+    const overlay = document.createElement("div");
+    overlay.className = "setup-script-overlay";
+
+    const dialog = document.createElement("div");
+    dialog.className = "setup-script-dialog";
+
+    const title = document.createElement("div");
+    title.className = "setup-script-title";
+    title.textContent = "Setup Script";
+    dialog.appendChild(title);
+
+    const subtitle = document.createElement("div");
+    subtitle.className = "setup-script-subtitle";
+    subtitle.textContent = "Run a script in the new session";
+    dialog.appendChild(subtitle);
+
+    const list = document.createElement("div");
+    list.className = "setup-script-list";
+
+    let selectedIndex = 0;
+    const items = [];
+
+    // "None" option first
+    const allOptions = ["None", ...scripts];
+
+    for (let i = 0; i < allOptions.length; i++) {
+      const item = document.createElement("div");
+      item.className = "setup-script-item";
+      if (i === 0) item.classList.add("selected");
+      item.textContent = allOptions[i];
+      item.addEventListener("click", () => {
+        cleanup();
+        resolve(i === 0 ? null : allOptions[i]);
+      });
+      list.appendChild(item);
+      items.push(item);
+    }
+
+    dialog.appendChild(list);
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+
+    function updateSelection() {
+      items.forEach((el, i) =>
+        el.classList.toggle("selected", i === selectedIndex),
+      );
+      items[selectedIndex].scrollIntoView({ block: "nearest" });
+    }
+
+    function cleanup() {
+      document.removeEventListener("keydown", onKey);
+      overlay.remove();
+    }
+
+    function onKey(e) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        selectedIndex = (selectedIndex + 1) % allOptions.length;
+        updateSelection();
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        selectedIndex =
+          (selectedIndex - 1 + allOptions.length) % allOptions.length;
+        updateSelection();
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        cleanup();
+        resolve(selectedIndex === 0 ? null : allOptions[selectedIndex]);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        cleanup();
+        resolve(null);
+      }
+    }
+
+    document.addEventListener("keydown", onKey);
+    overlay.addEventListener("click", (e) => {
+      if (e.target === overlay) {
+        cleanup();
+        resolve(null);
+      }
+    });
+  });
+}
+
+async function typeSetupScript(termId, scriptContent) {
+  // Each line is typed literally; \r in the text becomes a carriage return
+  const processed = scriptContent.replace(/\\r/g, "\r");
+  await window.api.ptyWrite(termId, processed);
+}
+
 newSessionBtn.addEventListener("click", async () => {
   // Check pool is initialized
   const pool = await window.api.poolRead();
@@ -1058,6 +1152,14 @@ newSessionBtn.addEventListener("click", async () => {
     return;
   }
 
+  // Check for setup scripts before acquiring a slot
+  let selectedScript = null;
+  const scripts = await window.api.listSetupScripts();
+  if (scripts.length > 0) {
+    selectedScript = await showSetupScriptPicker(scripts);
+    // null means "None" or Escape — proceed without script
+  }
+
   const freshSlot = await acquireFreshSlot();
   if (!freshSlot) {
     showNotification(
@@ -1067,6 +1169,21 @@ newSessionBtn.addEventListener("click", async () => {
   }
 
   await selectSession(freshSlot);
+
+  // Type setup script into the session's terminal
+  if (selectedScript) {
+    const content = await window.api.readSetupScript(selectedScript);
+    if (content) {
+      const poolData = await window.api.poolRead();
+      const slot = poolData?.slots.find(
+        (s) => s.sessionId === freshSlot.sessionId,
+      );
+      if (slot) {
+        await typeSetupScript(slot.termId, content);
+      }
+    }
+  }
+
   await loadSessions();
 });
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -585,6 +585,61 @@ body {
   word-break: break-word;
 }
 
+/* Setup script picker */
+.setup-script-overlay {
+  display: flex;
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.5);
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 80px;
+}
+
+.setup-script-dialog {
+  width: 360px;
+  background: #111;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  padding: 16px;
+}
+
+.setup-script-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.setup-script-subtitle {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-bottom: 12px;
+}
+
+.setup-script-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.setup-script-item {
+  padding: 8px 12px;
+  font-size: 13px;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--text);
+}
+
+.setup-script-item:hover,
+.setup-script-item.selected {
+  background: var(--accent-dim);
+}
+
 /* Pool settings */
 .pool-settings-dialog {
   width: 480px;


### PR DESCRIPTION
## Summary

- Adds setup script support: `~/.open-cockpit/setup-scripts/` directory created on startup
- When Cmd+N is pressed and scripts exist, a picker dialog appears (arrow keys + Enter/Escape)
- Selected script content is typed into the Claude TUI after acquiring the pool slot
- Script format: plain text files, `\r` for Enter key
- If no scripts exist, current behavior preserved (direct session open)

## Dependencies

- Depends on #28 (first tab shows Claude TUI). Based on `main` — dependency resolved at merge time.

Closes #33

## Test plan

- [ ] Create `~/.open-cockpit/setup-scripts/test.txt` with content `cd ~/vault\r`
- [ ] Press Cmd+N — picker should appear with "None" and "test.txt"
- [ ] Select "test.txt" — fresh session should open with `cd ~/vault` + Enter typed
- [ ] Select "None" or press Escape — fresh session opens without script
- [ ] Remove all scripts from dir — Cmd+N should skip picker entirely
- [ ] Test arrow key navigation and Enter/Escape in picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)