### PR TITLE
Add sub-claude-compatible CLI commands for pool interaction

### DIFF
--- a/bin/cockpit-cli
+++ b/bin/cockpit-cli
@@ -2,56 +2,245 @@
 set -euo pipefail
 
 SOCKET="$HOME/.open-cockpit/api.sock"
-CMD="${1:-ping}"
+
+# Send JSON to API socket. Args: <json> [timeout_seconds]
+send_api() {
+  local json="$1"
+  local timeout="${2:-5}"
+
+  if command -v socat &>/dev/null; then
+    printf '%s\n' "$json" | socat -t"$timeout" - UNIX-CONNECT:"$SOCKET"
+  else
+    node -e "
+      const net = require('net');
+      const sock = net.createConnection(process.argv[1]);
+      sock.on('connect', () => { sock.write(process.argv[2] + '\n'); });
+      sock.on('data', (d) => { process.stdout.write(d); sock.destroy(); process.exit(0); });
+      sock.on('error', (e) => { console.error(e.message); process.exit(1); });
+      setTimeout(() => { console.error('timeout'); process.exit(1); }, ${timeout}000);
+    " "$SOCKET" "$json"
+  fi
+}
+
+# Extract a field from JSON response (requires jq)
+json_field() {
+  echo "$1" | jq -r ".$2"
+}
+
+# Check for errors in API response
+check_error() {
+  local resp="$1"
+  local err
+  err=$(echo "$resp" | jq -r '.error // empty' 2>/dev/null) || true
+  if [[ -n "$err" ]]; then
+    echo "Error: $err" >&2
+    exit 1
+  fi
+}
+
+CMD="${1:-help}"
 shift 2>/dev/null || true
 
-# Build JSON from command + args
 case "$CMD" in
-  pool-init)    json="{\"type\":\"pool-init\",\"id\":1,\"size\":${1:-5}}" ;;
-  pool-resize)  json="{\"type\":\"pool-resize\",\"id\":1,\"size\":${1:?size required}}" ;;
-  pool-health)  json="{\"type\":\"pool-health\",\"id\":1}" ;;
-  pool-read)    json="{\"type\":\"pool-read\",\"id\":1}" ;;
-  pool-destroy) json="{\"type\":\"pool-destroy\",\"id\":1}" ;;
-  get-sessions) json="{\"type\":\"get-sessions\",\"id\":1}" ;;
-  read-intention)  json="{\"type\":\"read-intention\",\"id\":1,\"sessionId\":\"${1:?sessionId required}\"}" ;;
-  write-intention) json="{\"type\":\"write-intention\",\"id\":1,\"sessionId\":\"${1:?sessionId required}\",\"content\":$(printf '%s' "${2:?content required}" | jq -Rs .)}" ;;
-  pty-list)     json="{\"type\":\"pty-list\",\"id\":1}" ;;
-  pty-write)    json="{\"type\":\"pty-write\",\"id\":1,\"termId\":${1:?termId required},\"data\":$(printf '%s' "${2:?data required}" | jq -Rs .)}" ;;
-  pty-read)     json="{\"type\":\"pty-read\",\"id\":1,\"termId\":${1:?termId required}}" ;;
-  pty-spawn)    json="{\"type\":\"pty-spawn\",\"id\":1,\"cwd\":\"${1:?cwd required}\",\"cmd\":\"${2:?cmd required}\",\"args\":[$(printf '%s' "${3:-}" | jq -Rs .)]}" ;;
-  pty-kill)     json="{\"type\":\"pty-kill\",\"id\":1,\"termId\":${1:?termId required}}" ;;
-  ping)         json="{\"type\":\"ping\",\"id\":1}" ;;
-  *)            echo "Unknown command: $CMD" >&2
-                echo "Usage: cockpit-cli <command> [args...]" >&2
-                echo "" >&2
-                echo "Commands:" >&2
-                echo "  ping                         Health check" >&2
-                echo "  get-sessions                 List all sessions" >&2
-                echo "  pool-init [size]             Initialize pool (default: 5)" >&2
-                echo "  pool-resize <size>           Resize pool" >&2
-                echo "  pool-health                  Pool health report" >&2
-                echo "  pool-read                    Read pool.json" >&2
-                echo "  pool-destroy                 Destroy pool" >&2
-                echo "  read-intention <sessionId>   Read intention file" >&2
-                echo "  write-intention <id> <text>  Write intention file" >&2
-                echo "  pty-list                     List terminals" >&2
-                echo "  pty-write <termId> <data>    Write to terminal" >&2
-                echo "  pty-read <termId>            Read terminal buffer" >&2
-                echo "  pty-spawn <cwd> <cmd> [args] Spawn terminal" >&2
-                echo "  pty-kill <termId>            Kill terminal" >&2
-                exit 1 ;;
-esac
 
-# Send via socat (or node if socat unavailable)
-if command -v socat &>/dev/null; then
-  printf '%s\n' "$json" | socat -t0 - UNIX-CONNECT:"$SOCKET" || true
-else
-  node -e "
-    const net = require('net');
-    const sock = net.createConnection('$SOCKET');
-    sock.on('connect', () => { sock.write(JSON.stringify($json) + '\n'); });
-    sock.on('data', (d) => { process.stdout.write(d); sock.destroy(); process.exit(0); });
-    sock.on('error', (e) => { console.error(e.message); process.exit(1); });
-    setTimeout(() => { console.error('timeout'); process.exit(1); }, 5000);
-  "
-fi
+  # --- Sub-claude compatible commands ---
+
+  start)
+    BLOCK=false
+    PROMPT=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --block) BLOCK=true; shift ;;
+        *) PROMPT="$1"; shift ;;
+      esac
+    done
+    if [[ -z "$PROMPT" ]]; then
+      echo "Usage: cockpit-cli start <prompt> [--block]" >&2
+      exit 1
+    fi
+
+    PROMPT_JSON=$(printf '%s' "$PROMPT" | jq -Rs .)
+    json="{\"type\":\"pool-start\",\"id\":1,\"prompt\":$PROMPT_JSON}"
+    RESULT=$(send_api "$json")
+    check_error "$RESULT"
+    SESSION_ID=$(json_field "$RESULT" "sessionId")
+
+    if $BLOCK; then
+      echo "$SESSION_ID" >&2
+      wait_json="{\"type\":\"pool-wait\",\"id\":1,\"sessionId\":\"$SESSION_ID\",\"timeout\":300000}"
+      WAIT_RESULT=$(send_api "$wait_json" 310)
+      check_error "$WAIT_RESULT"
+      json_field "$WAIT_RESULT" "buffer"
+    else
+      echo "$SESSION_ID"
+    fi
+    ;;
+
+  followup)
+    SESSION_ID="${1:?sessionId required}"
+    shift
+    BLOCK=false
+    PROMPT=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --block) BLOCK=true; shift ;;
+        *) PROMPT="$1"; shift ;;
+      esac
+    done
+    if [[ -z "$PROMPT" ]]; then
+      echo "Usage: cockpit-cli followup <id> <prompt> [--block]" >&2
+      exit 1
+    fi
+
+    PROMPT_JSON=$(printf '%s' "$PROMPT" | jq -Rs .)
+    json="{\"type\":\"pool-followup\",\"id\":1,\"sessionId\":\"$SESSION_ID\",\"prompt\":$PROMPT_JSON}"
+    RESULT=$(send_api "$json")
+    check_error "$RESULT"
+    SID=$(json_field "$RESULT" "sessionId")
+
+    if $BLOCK; then
+      echo "$SID" >&2
+      wait_json="{\"type\":\"pool-wait\",\"id\":1,\"sessionId\":\"$SID\",\"timeout\":300000}"
+      WAIT_RESULT=$(send_api "$wait_json" 310)
+      check_error "$WAIT_RESULT"
+      json_field "$WAIT_RESULT" "buffer"
+    else
+      echo "$SID"
+    fi
+    ;;
+
+  wait)
+    if [[ $# -gt 0 ]]; then
+      SESSION_ID="$1"
+      json="{\"type\":\"pool-wait\",\"id\":1,\"sessionId\":\"$SESSION_ID\",\"timeout\":300000}"
+    else
+      json="{\"type\":\"pool-wait\",\"id\":1,\"timeout\":300000}"
+    fi
+    RESULT=$(send_api "$json" 310)
+    check_error "$RESULT"
+    json_field "$RESULT" "buffer"
+    ;;
+
+  capture)
+    SESSION_ID="${1:?sessionId required}"
+    json="{\"type\":\"pool-capture\",\"id\":1,\"sessionId\":\"$SESSION_ID\"}"
+    RESULT=$(send_api "$json")
+    check_error "$RESULT"
+    json_field "$RESULT" "buffer"
+    ;;
+
+  result)
+    SESSION_ID="${1:?sessionId required}"
+    json="{\"type\":\"pool-result\",\"id\":1,\"sessionId\":\"$SESSION_ID\"}"
+    RESULT=$(send_api "$json")
+    check_error "$RESULT"
+    json_field "$RESULT" "buffer"
+    ;;
+
+  input)
+    SESSION_ID="${1:?sessionId required}"
+    TEXT="${2:?text required}"
+    DATA_JSON=$(printf '%s' "$TEXT" | jq -Rs .)
+    json="{\"type\":\"pool-input\",\"id\":1,\"sessionId\":\"$SESSION_ID\",\"data\":$DATA_JSON}"
+    RESULT=$(send_api "$json")
+    check_error "$RESULT"
+    ;;
+
+  clean)
+    json="{\"type\":\"pool-clean\",\"id\":1}"
+    RESULT=$(send_api "$json" 60)
+    check_error "$RESULT"
+    COUNT=$(json_field "$RESULT" "count")
+    echo "Cleaned $COUNT session(s)"
+    ;;
+
+  # --- Pool management subcommand ---
+
+  pool)
+    SUBCMD="${1:?subcommand required (init|status|resize|destroy)}"
+    shift
+    case "$SUBCMD" in
+      init)
+        SIZE="${1:-5}"
+        json="{\"type\":\"pool-init\",\"id\":1,\"size\":$SIZE}"
+        send_api "$json" 120
+        ;;
+      status)
+        json="{\"type\":\"pool-health\",\"id\":1}"
+        send_api "$json"
+        ;;
+      resize)
+        SIZE="${1:?size required}"
+        json="{\"type\":\"pool-resize\",\"id\":1,\"size\":$SIZE}"
+        send_api "$json" 120
+        ;;
+      destroy)
+        json="{\"type\":\"pool-destroy\",\"id\":1}"
+        send_api "$json" 30
+        ;;
+      *)
+        echo "Unknown pool subcommand: $SUBCMD" >&2
+        echo "Available: init, status, resize, destroy" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+
+  # --- Legacy flat commands (backward compatible) ---
+
+  pool-init)    json="{\"type\":\"pool-init\",\"id\":1,\"size\":${1:-5}}"; send_api "$json" 120 ;;
+  pool-resize)  json="{\"type\":\"pool-resize\",\"id\":1,\"size\":${1:?size required}}"; send_api "$json" 120 ;;
+  pool-health)  json="{\"type\":\"pool-health\",\"id\":1}"; send_api "$json" ;;
+  pool-read)    json="{\"type\":\"pool-read\",\"id\":1}"; send_api "$json" ;;
+  pool-destroy) json="{\"type\":\"pool-destroy\",\"id\":1}"; send_api "$json" 30 ;;
+  get-sessions) json="{\"type\":\"get-sessions\",\"id\":1}"; send_api "$json" ;;
+  read-intention)  json="{\"type\":\"read-intention\",\"id\":1,\"sessionId\":\"${1:?sessionId required}\"}"; send_api "$json" ;;
+  write-intention) json="{\"type\":\"write-intention\",\"id\":1,\"sessionId\":\"${1:?sessionId required}\",\"content\":$(printf '%s' "${2:?content required}" | jq -Rs .)}"; send_api "$json" ;;
+  pty-list)     json="{\"type\":\"pty-list\",\"id\":1}"; send_api "$json" ;;
+  pty-write)    json="{\"type\":\"pty-write\",\"id\":1,\"termId\":${1:?termId required},\"data\":$(printf '%s' "${2:?data required}" | jq -Rs .)}"; send_api "$json" ;;
+  pty-read)     json="{\"type\":\"pty-read\",\"id\":1,\"termId\":${1:?termId required}}"; send_api "$json" ;;
+  pty-spawn)    json="{\"type\":\"pty-spawn\",\"id\":1,\"cwd\":\"${1:?cwd required}\",\"cmd\":\"${2:?cmd required}\",\"args\":[$(printf '%s' "${3:-}" | jq -Rs .)]}"; send_api "$json" ;;
+  pty-kill)     json="{\"type\":\"pty-kill\",\"id\":1,\"termId\":${1:?termId required}}"; send_api "$json" ;;
+  ping)         json="{\"type\":\"ping\",\"id\":1}"; send_api "$json" ;;
+
+  help|*)
+    [[ "$CMD" != "help" ]] && echo "Unknown command: $CMD" >&2
+    cat >&2 <<'USAGE'
+Usage: cockpit-cli <command> [args...]
+
+Session commands (sub-claude compatible):
+  start <prompt> [--block]     Send prompt to fresh slot, return session ID
+  followup <id> <prompt> [--block]  Follow up on idle session
+  wait [id]                    Wait for session to finish, print output
+  capture <id>                 Show live terminal content
+  result <id>                  Print output (error if still running)
+  input <id> <text>            Send raw input to terminal
+  clean                        Free slots occupied by finished sessions
+
+Pool management:
+  pool init [size]             Initialize pool (default: 5)
+  pool status                  Pool health report
+  pool resize <size>           Resize pool
+  pool destroy                 Destroy pool
+
+Low-level:
+  ping                         Health check
+  get-sessions                 List all sessions
+  read-intention <sessionId>   Read intention file
+  write-intention <id> <text>  Write intention file
+  pty-list                     List terminals
+  pty-write <termId> <data>    Write to terminal
+  pty-read <termId>            Read terminal buffer
+  pty-spawn <cwd> <cmd> [args] Spawn terminal
+  pty-kill <termId>            Kill terminal
+
+Output contract:
+  start:         session ID to stdout
+  start --block: output to stdout, session ID to stderr
+  wait:          terminal output to stdout
+  capture:       live terminal content to stdout
+USAGE
+    [[ "$CMD" != "help" ]] && exit 1
+    exit 0
+    ;;
+esac

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,13 +5,30 @@ Unix socket API at `~/.open-cockpit/api.sock` for external process control. Prot
 ## CLI Helper
 
 ```bash
+# Session commands (sub-claude compatible)
+bin/cockpit-cli start "fix the login bug"          # returns session ID
+bin/cockpit-cli start "fix the login bug" --block   # waits, prints output
+bin/cockpit-cli followup <id> "also add tests"      # follow up on idle session
+bin/cockpit-cli wait <id>                            # wait for session to finish
+bin/cockpit-cli wait                                 # wait for any session
+bin/cockpit-cli capture <id>                         # live terminal content
+bin/cockpit-cli result <id>                          # output (errors if running)
+bin/cockpit-cli input <id> "y"                       # send raw input
+bin/cockpit-cli clean                                # offload finished sessions
+
+# Pool management
+bin/cockpit-cli pool init 5
+bin/cockpit-cli pool status
+bin/cockpit-cli pool resize 8
+bin/cockpit-cli pool destroy
+
+# Low-level (legacy)
 bin/cockpit-cli ping
 bin/cockpit-cli get-sessions
-bin/cockpit-cli pool-init 5
 bin/cockpit-cli pty-list
 ```
 
-Requires `socat` or falls back to `node`.
+Requires `jq` for session commands. Uses `socat` or falls back to `node` for socket transport.
 
 ## Protocol
 
@@ -37,6 +54,23 @@ Send JSON with `type` and optional `id`. Response echoes `id` back.
 | `pool-health` | — | `{ type: "health", health }` |
 | `pool-read` | — | `{ type: "pool", pool }` |
 | `pool-destroy` | — | `{ type: "ok" }` |
+
+### Pool Interaction (sub-claude compatible)
+| Command | Fields | Response |
+|---------|--------|----------|
+| `pool-start` | `prompt` | `{ type: "started", sessionId, termId, slotIndex }` |
+| `pool-followup` | `sessionId`, `prompt` | `{ type: "started", sessionId, termId, slotIndex }` |
+| `pool-wait` | `sessionId` (optional), `timeout` (optional, ms, default 300000) | `{ type: "result", sessionId, buffer }` |
+| `pool-capture` | `sessionId` | `{ type: "buffer", sessionId, buffer }` |
+| `pool-result` | `sessionId` | `{ type: "result", sessionId, buffer }` — errors if still running |
+| `pool-input` | `sessionId`, `data` | `{ type: "ok" }` |
+| `pool-clean` | — | `{ type: "cleaned", count }` |
+
+`pool-start` acquires the first fresh slot, sends the prompt, and marks the slot busy.
+`pool-followup` sends a follow-up to an idle session (errors if not idle).
+`pool-wait` long-polls until the session (or any busy session if no ID) becomes idle.
+`pool-result` returns the buffer only if the session is not running.
+`pool-clean` offloads all idle sessions to free their slots.
 
 ### Sessions
 | Command | Fields | Response |

--- a/src/main.js
+++ b/src/main.js
@@ -1243,6 +1243,67 @@ app.whenReady().then(async () => {
 
   createWindow();
 
+  // --- Pool interaction helpers (used by API commands) ---
+
+  function findSlotBySessionId(sessionId) {
+    validateSessionId(sessionId);
+    const pool = readPool();
+    if (!pool) throw new Error("Pool not initialized");
+    const slot = pool.slots.find((s) => s.sessionId === sessionId);
+    if (!slot) throw new Error(`No slot found for session ${sessionId}`);
+    return { pool, slot };
+  }
+
+  async function getTerminalBuffer(termId) {
+    const resp = await daemonRequest({ type: "list" });
+    const pty = resp.ptys.find((p) => p.termId === termId);
+    return pty ? pty.buffer || "" : "";
+  }
+
+  async function sendPromptToTerminal(termId, prompt) {
+    daemonSend({ type: "write", termId, data: "\x1b" });
+    await new Promise((r) => setTimeout(r, 200));
+    daemonSend({ type: "write", termId, data: "\x15" });
+    await new Promise((r) => setTimeout(r, 100));
+    daemonSend({ type: "write", termId, data: prompt + "\r" });
+  }
+
+  function getEffectiveSlotStatus(slot) {
+    const sessions = getSessions();
+    const session = sessions.find((s) => s.sessionId === slot.sessionId);
+    if (!session) return slot.status;
+    if (session.status === "idle") return "idle";
+    if (session.status === "processing") return "busy";
+    if (session.status === "fresh") return "fresh";
+    return slot.status;
+  }
+
+  function waitForSessionIdle(sessionId, timeoutMs = 300000) {
+    return new Promise((resolve, reject) => {
+      let elapsed = 0;
+      const interval = 1000;
+      const check = () => {
+        const sessions = getSessions();
+        const session = sessions.find((s) => s.sessionId === sessionId);
+        if (session && session.status === "idle") {
+          resolve();
+          return;
+        }
+        if (session && !session.alive) {
+          reject(new Error("Session process died"));
+          return;
+        }
+        elapsed += interval;
+        if (elapsed >= timeoutMs) {
+          reject(new Error("Timeout waiting for session to become idle"));
+          return;
+        }
+        setTimeout(check, interval);
+      };
+      setTimeout(check, interval);
+    });
+  }
+
   // --- Programmatic API server (Unix socket) ---
   const apiServer = createApiServer(API_SOCKET, {
     ping: async () => ({ type: "pong" }),
@@ -1307,6 +1368,155 @@ app.whenReady().then(async () => {
       const resp = await daemonRequest({ type: "list" });
       const p = resp.ptys.find((p) => p.termId === msg.termId);
       return { type: "buffer", buffer: p ? p.buffer : null };
+    },
+
+    // --- Pool interaction commands (sub-claude compatible) ---
+
+    "pool-start": async (msg) => {
+      if (!msg.prompt) throw new Error("prompt required");
+      const pool = readPool();
+      if (!pool) throw new Error("Pool not initialized");
+
+      const sessions = getSessions();
+      const sessionMap = new Map(sessions.map((s) => [s.sessionId, s]));
+
+      // Find first fresh slot
+      const slot = pool.slots.find((s) => {
+        if (s.status === "fresh") return true;
+        const session = s.sessionId ? sessionMap.get(s.sessionId) : null;
+        return session && session.status === "fresh";
+      });
+      if (!slot) throw new Error("No fresh slots available");
+
+      await sendPromptToTerminal(slot.termId, msg.prompt);
+      slot.status = "busy";
+      writePool(pool);
+
+      return {
+        type: "started",
+        sessionId: slot.sessionId,
+        termId: slot.termId,
+        slotIndex: slot.index,
+      };
+    },
+
+    "pool-followup": async (msg) => {
+      if (!msg.sessionId) throw new Error("sessionId required");
+      if (!msg.prompt) throw new Error("prompt required");
+      const { pool, slot } = findSlotBySessionId(msg.sessionId);
+
+      const status = getEffectiveSlotStatus(slot);
+      if (status !== "idle")
+        throw new Error(`Session is ${status}, expected idle`);
+
+      await sendPromptToTerminal(slot.termId, msg.prompt);
+      slot.status = "busy";
+      writePool(pool);
+
+      return {
+        type: "started",
+        sessionId: slot.sessionId,
+        termId: slot.termId,
+        slotIndex: slot.index,
+      };
+    },
+
+    "pool-wait": async (msg) => {
+      const timeout = msg.timeout || 300000;
+
+      if (msg.sessionId) {
+        validateSessionId(msg.sessionId);
+        const { slot } = findSlotBySessionId(msg.sessionId);
+        await waitForSessionIdle(msg.sessionId, timeout);
+        const buffer = await getTerminalBuffer(slot.termId);
+        return { type: "result", sessionId: msg.sessionId, buffer };
+      }
+
+      // No sessionId: wait for any busy session to become idle
+      const pool = readPool();
+      if (!pool) throw new Error("Pool not initialized");
+      const busySlots = pool.slots.filter((s) => s.status === "busy");
+      if (busySlots.length === 0)
+        throw new Error("No busy sessions to wait for");
+
+      const finished = await new Promise((resolve, reject) => {
+        let elapsed = 0;
+        const interval = 1000;
+        const check = () => {
+          const sessions = getSessions();
+          for (const s of busySlots) {
+            const session = sessions.find(
+              (sess) => sess.sessionId === s.sessionId,
+            );
+            if (session && session.status === "idle") {
+              resolve(s);
+              return;
+            }
+          }
+          elapsed += interval;
+          if (elapsed >= timeout) {
+            reject(new Error("Timeout waiting for session to become idle"));
+            return;
+          }
+          setTimeout(check, interval);
+        };
+        setTimeout(check, interval);
+      });
+
+      const buffer = await getTerminalBuffer(finished.termId);
+      return { type: "result", sessionId: finished.sessionId, buffer };
+    },
+
+    "pool-capture": async (msg) => {
+      if (!msg.sessionId) throw new Error("sessionId required");
+      const { slot } = findSlotBySessionId(msg.sessionId);
+      const buffer = await getTerminalBuffer(slot.termId);
+      return { type: "buffer", sessionId: msg.sessionId, buffer };
+    },
+
+    "pool-result": async (msg) => {
+      if (!msg.sessionId) throw new Error("sessionId required");
+      const { slot } = findSlotBySessionId(msg.sessionId);
+      const status = getEffectiveSlotStatus(slot);
+      if (status === "busy" || status === "processing") {
+        throw new Error("Session is still running");
+      }
+      const buffer = await getTerminalBuffer(slot.termId);
+      return { type: "result", sessionId: msg.sessionId, buffer };
+    },
+
+    "pool-input": async (msg) => {
+      if (!msg.sessionId) throw new Error("sessionId required");
+      if (msg.data === undefined) throw new Error("data required");
+      const { slot } = findSlotBySessionId(msg.sessionId);
+      daemonSend({ type: "write", termId: slot.termId, data: msg.data });
+      return { type: "ok" };
+    },
+
+    "pool-clean": async () => {
+      const pool = readPool();
+      if (!pool) throw new Error("Pool not initialized");
+
+      const sessions = getSessions();
+      const sessionMap = new Map(sessions.map((s) => [s.sessionId, s]));
+
+      const idleSlots = pool.slots.filter((s) => {
+        const session = s.sessionId ? sessionMap.get(s.sessionId) : null;
+        return session && session.status === "idle";
+      });
+
+      let cleaned = 0;
+      for (const slot of idleSlots) {
+        const session = sessionMap.get(slot.sessionId);
+        await offloadSession(slot.sessionId, slot.termId, null, {
+          cwd: session?.cwd,
+          gitRoot: session?.gitRoot,
+          pid: slot.pid,
+        });
+        cleaned++;
+      }
+
+      return { type: "cleaned", count: cleaned };
     },
   });
 


### PR DESCRIPTION
## Summary

- 7 new API commands: `pool-start`, `pool-followup`, `pool-wait`, `pool-capture`, `pool-result`, `pool-input`, `pool-clean`
- New CLI commands matching sub-claude's interface: `start`, `followup`, `wait`, `capture`, `result`, `input`, `clean`
- Pool management reorganized under `pool` subcommand (init/status/resize/teardown)
- `--block` mode for `start`/`followup` (waits for completion, output to stdout, session ID to stderr)
- Long-poll `pool-wait` with configurable timeout (default 5 min)
- Legacy flat commands preserved for backward compatibility
- Updated docs/api.md with new commands and CLI examples

## Test plan

- [ ] `cockpit-cli start "hello"` returns session ID
- [ ] `cockpit-cli start "hello" --block` waits and prints output
- [ ] `cockpit-cli followup <id> "continue"` sends follow-up to idle session
- [ ] `cockpit-cli wait <id>` blocks until session finishes
- [ ] `cockpit-cli wait` (no ID) waits for any busy session
- [ ] `cockpit-cli capture <id>` shows terminal buffer
- [ ] `cockpit-cli result <id>` errors if session still running
- [ ] `cockpit-cli input <id> "y"` sends raw input
- [ ] `cockpit-cli clean` offloads idle sessions
- [ ] Pool subcommands (init, status, resize, etc.) work
- [ ] Legacy flat commands still work

Closes #27

Generated with Claude Code