### PR TITLE
Fix unsafe splice and per-session intention tracking

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1060,12 +1060,12 @@ function readIntention(sessionId) {
   return fs.readFileSync(file, "utf-8");
 }
 
-// Track the last content we wrote so we can detect external changes
-let lastWrittenContent = null;
+// Track the last content we wrote per session so we can detect external changes
+const lastWrittenContent = new Map();
 
 function writeIntention(sessionId, content) {
   fs.mkdirSync(INTENTIONS_DIR, { recursive: true });
-  lastWrittenContent = content;
+  lastWrittenContent.set(sessionId, content);
   fs.writeFileSync(path.join(INTENTIONS_DIR, `${sessionId}.md`), content);
 }
 
@@ -1076,7 +1076,7 @@ function watchIntention(sessionId) {
     fileWatchers.delete("current");
   }
   // Reset change-detection state so we don't suppress notifications for new session
-  lastWrittenContent = null;
+  lastWrittenContent.delete(sessionId);
 
   const file = path.join(INTENTIONS_DIR, `${sessionId}.md`);
   if (!fs.existsSync(file)) {
@@ -1089,8 +1089,8 @@ function watchIntention(sessionId) {
     try {
       const content = fs.readFileSync(file, "utf-8");
       // Skip if this is content we wrote ourselves
-      if (content === lastWrittenContent) return;
-      lastWrittenContent = content;
+      if (content === lastWrittenContent.get(sessionId)) return;
+      lastWrittenContent.set(sessionId, content);
       console.log("[main] External file change detected, sending to renderer");
       if (mainWindow && !mainWindow.isDestroyed()) {
         mainWindow.webContents.send("intention-changed", content);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -465,7 +465,8 @@ async function spawnTerminal(cwd, cmd, args) {
   try {
     await window.api.ptyAttach(termId);
   } catch (err) {
-    terminals.splice(terminals.indexOf(entry), 1);
+    const idx = terminals.indexOf(entry);
+    if (idx !== -1) terminals.splice(idx, 1);
     term.dispose();
     container.remove();
     pendingTerminals.delete(termId);
@@ -524,7 +525,8 @@ async function attachPoolTerminal(poolTermId) {
   try {
     await window.api.ptyAttach(poolTermId);
   } catch (err) {
-    terminals.splice(terminals.indexOf(entry), 1);
+    const idx = terminals.indexOf(entry);
+    if (idx !== -1) terminals.splice(idx, 1);
     term.dispose();
     container.remove();
     pendingTerminals.delete(poolTermId);


### PR DESCRIPTION
## Summary

- **Unsafe splice in renderer.js**: `terminals.indexOf(entry)` can return `-1`, causing `splice(-1, 1)` to remove the last array element. Added guard checks at both call sites.
- **Global lastWrittenContent in main.js**: Changed from a single variable to a `Map` keyed by `sessionId` so simultaneous writes from different sessions don't clobber each other's change-detection state.

## Test plan

- [x] `node -c` syntax check passes for both files
- [x] `npm run build` succeeds
- [x] All 79 tests pass (`npx vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)