### PR TITLE
Remove dead code, unused deps, and fix doc inconsistencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Electron app + Claude Code plugin for session intention tracking.
 - `src/main.js` — Main process: window, IPC, daemon client, session discovery
 - `src/preload.js` — Context bridge (`api` object)
 - `src/pool.js` — Pure pool data structures (readPool, writePool, computePoolHealth)
+- `src/sort-sessions.js` — Session display ordering (used by main.js)
 - `src/renderer.js` — CodeMirror 6 live preview editor + session sidebar
 - `src/index.html` + `src/styles.css` — Layout, neon red dark theme
 - `bin/cockpit-cli` — CLI helper with sub-claude-compatible commands (start, followup, wait, capture, result, input, clean) + pool management + legacy API commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,22 @@
 {
   "name": "open-cockpit",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-cockpit",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "dependencies": {
         "@codemirror/commands": "^6.10.2",
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language": "^6.12.2",
-        "@codemirror/language-data": "^6.5.2",
         "@codemirror/state": "^6.5.4",
         "@codemirror/view": "^6.39.16",
         "@lezer/highlight": "^1.2.3",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "codemirror": "^6.0.2",
-        "markdown-it": "^14.0.0",
         "node-pty": "^1.1.0"
       },
       "devDependencies": {
@@ -52,30 +50,6 @@
         "@lezer/common": "^1.1.0"
       }
     },
-    "node_modules/@codemirror/lang-angular": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-angular/-/lang-angular-0.1.4.tgz",
-      "integrity": "sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/lang-html": "^6.0.0",
-        "@codemirror/lang-javascript": "^6.1.2",
-        "@codemirror/language": "^6.0.0",
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.3.3"
-      }
-    },
-    "node_modules/@codemirror/lang-cpp": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.3.tgz",
-      "integrity": "sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/cpp": "^1.0.0"
-      }
-    },
     "node_modules/@codemirror/lang-css": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
@@ -87,19 +61,6 @@
         "@codemirror/state": "^6.0.0",
         "@lezer/common": "^1.0.2",
         "@lezer/css": "^1.1.7"
-      }
-    },
-    "node_modules/@codemirror/lang-go": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-go/-/lang-go-6.0.1.tgz",
-      "integrity": "sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.6.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/go": "^1.0.0"
       }
     },
     "node_modules/@codemirror/lang-html": {
@@ -119,16 +80,6 @@
         "@lezer/html": "^1.3.12"
       }
     },
-    "node_modules/@codemirror/lang-java": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.2.tgz",
-      "integrity": "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/java": "^1.0.0"
-      }
-    },
     "node_modules/@codemirror/lang-javascript": {
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
@@ -142,58 +93,6 @@
         "@codemirror/view": "^6.17.0",
         "@lezer/common": "^1.0.0",
         "@lezer/javascript": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-jinja": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-jinja/-/lang-jinja-6.0.0.tgz",
-      "integrity": "sha512-47MFmRcR8UAxd8DReVgj7WJN1WSAMT7OJnewwugZM4XiHWkOjgJQqvEM1NpMj9ALMPyxmlziEI1opH9IaEvmaw==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/lang-html": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.2.0",
-        "@lezer/lr": "^1.4.0"
-      }
-    },
-    "node_modules/@codemirror/lang-json": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
-      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/json": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-less": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-less/-/lang-less-6.0.2.tgz",
-      "integrity": "sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/lang-css": "^6.2.0",
-        "@codemirror/language": "^6.0.0",
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-liquid": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-liquid/-/lang-liquid-6.3.2.tgz",
-      "integrity": "sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/lang-html": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.3.1"
       }
     },
     "node_modules/@codemirror/lang-markdown": {
@@ -211,124 +110,6 @@
         "@lezer/markdown": "^1.0.0"
       }
     },
-    "node_modules/@codemirror/lang-php": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
-      "integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/lang-html": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/php": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-python": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
-      "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.3.2",
-        "@codemirror/language": "^6.8.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.2.1",
-        "@lezer/python": "^1.1.4"
-      }
-    },
-    "node_modules/@codemirror/lang-rust": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-6.0.2.tgz",
-      "integrity": "sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/rust": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-sass": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-sass/-/lang-sass-6.0.2.tgz",
-      "integrity": "sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/lang-css": "^6.2.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.0.2",
-        "@lezer/sass": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-sql": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz",
-      "integrity": "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-vue": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-vue/-/lang-vue-0.1.3.tgz",
-      "integrity": "sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/lang-html": "^6.0.0",
-        "@codemirror/lang-javascript": "^6.1.2",
-        "@codemirror/language": "^6.0.0",
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.3.1"
-      }
-    },
-    "node_modules/@codemirror/lang-wast": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-6.0.2.tgz",
-      "integrity": "sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-xml": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz",
-      "integrity": "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.4.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/common": "^1.0.0",
-        "@lezer/xml": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/lang-yaml": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.2.tgz",
-      "integrity": "sha512-dxrfG8w5Ce/QbT7YID7mWZFKhdhsaTNOYjOkSIMt1qmC4VQnXSDSYVHHHn8k6kJUfIhtLo8t1JJgltlxWdsITw==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.2.0",
-        "@lezer/lr": "^1.0.0",
-        "@lezer/yaml": "^1.0.0"
-      }
-    },
     "node_modules/@codemirror/language": {
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.2.tgz",
@@ -341,46 +122,6 @@
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0",
         "style-mod": "^4.0.0"
-      }
-    },
-    "node_modules/@codemirror/language-data": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/language-data/-/language-data-6.5.2.tgz",
-      "integrity": "sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/lang-angular": "^0.1.0",
-        "@codemirror/lang-cpp": "^6.0.0",
-        "@codemirror/lang-css": "^6.0.0",
-        "@codemirror/lang-go": "^6.0.0",
-        "@codemirror/lang-html": "^6.0.0",
-        "@codemirror/lang-java": "^6.0.0",
-        "@codemirror/lang-javascript": "^6.0.0",
-        "@codemirror/lang-jinja": "^6.0.0",
-        "@codemirror/lang-json": "^6.0.0",
-        "@codemirror/lang-less": "^6.0.0",
-        "@codemirror/lang-liquid": "^6.0.0",
-        "@codemirror/lang-markdown": "^6.0.0",
-        "@codemirror/lang-php": "^6.0.0",
-        "@codemirror/lang-python": "^6.0.0",
-        "@codemirror/lang-rust": "^6.0.0",
-        "@codemirror/lang-sass": "^6.0.0",
-        "@codemirror/lang-sql": "^6.0.0",
-        "@codemirror/lang-vue": "^0.1.1",
-        "@codemirror/lang-wast": "^6.0.0",
-        "@codemirror/lang-xml": "^6.0.0",
-        "@codemirror/lang-yaml": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/legacy-modes": "^6.4.0"
-      }
-    },
-    "node_modules/@codemirror/legacy-modes": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.2.tgz",
-      "integrity": "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0"
       }
     },
     "node_modules/@codemirror/lint": {
@@ -910,32 +651,10 @@
       "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
       "license": "MIT"
     },
-    "node_modules/@lezer/cpp": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.1.5.tgz",
-      "integrity": "sha512-DIhSXmYtJKLehrjzDFN+2cPt547ySQ41nA8yqcDf/GxMc+YM736xqltFkvADL2M0VebU5I+3+4ks2Vv+Kyq3Aw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
     "node_modules/@lezer/css": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.1.tgz",
       "integrity": "sha512-PYAKeUVBo3HFThruRyp/iK91SwiZJnzXh8QzkQlwijB5y+N5iB28+iLk78o2zmKqqV0uolNhCwFqB8LA7b0Svg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.3.0"
-      }
-    },
-    "node_modules/@lezer/go": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@lezer/go/-/go-1.0.1.tgz",
-      "integrity": "sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -963,17 +682,6 @@
         "@lezer/lr": "^1.0.0"
       }
     },
-    "node_modules/@lezer/java": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.1.3.tgz",
-      "integrity": "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
     "node_modules/@lezer/javascript": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
@@ -983,17 +691,6 @@
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.1.3",
         "@lezer/lr": "^1.3.0"
-      }
-    },
-    "node_modules/@lezer/json": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
-      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/lr": {
@@ -1013,72 +710,6 @@
       "dependencies": {
         "@lezer/common": "^1.5.0",
         "@lezer/highlight": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/php": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.5.tgz",
-      "integrity": "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.1.0"
-      }
-    },
-    "node_modules/@lezer/python": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.18.tgz",
-      "integrity": "sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/rust": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-1.0.2.tgz",
-      "integrity": "sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/sass": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lezer/sass/-/sass-1.1.0.tgz",
-      "integrity": "sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/xml": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
-      "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.0.0"
-      }
-    },
-    "node_modules/@lezer/yaml": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
-      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lezer/common": "^1.2.0",
-        "@lezer/highlight": "^1.0.0",
-        "@lezer/lr": "^1.4.0"
       }
     },
     "node_modules/@malept/cross-spawn-promise": {
@@ -1852,12 +1483,6 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2516,18 +2141,6 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -3207,15 +2820,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -3317,23 +2921,6 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -3347,12 +2934,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "license": "MIT"
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
@@ -3918,15 +3499,6 @@
         "once": "^1.3.1"
       }
     },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -4440,12 +4012,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-cockpit",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "Session cockpit for Claude Code",
   "main": "src/main.js",
   "scripts": {
@@ -14,14 +14,12 @@
     "@codemirror/commands": "^6.10.2",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language": "^6.12.2",
-    "@codemirror/language-data": "^6.5.2",
     "@codemirror/state": "^6.5.4",
     "@codemirror/view": "^6.39.16",
     "@lezer/highlight": "^1.2.3",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "codemirror": "^6.0.2",
-    "markdown-it": "^14.0.0",
     "node-pty": "^1.1.0"
   },
   "devDependencies": {

--- a/src/main.js
+++ b/src/main.js
@@ -449,15 +449,12 @@ async function getSessionsUncached() {
     } else {
       s.origin = "ext";
     }
-    // Keep isPool for backward compat (used by offload logic)
-    s.isPool = s.origin === "pool";
   }
 
   // Add offloaded sessions (always pool, skip if live session exists)
   const liveIds = new Set(sessions.map((s) => s.sessionId));
   for (const offloaded of getOffloadedSessions()) {
     if (!liveIds.has(offloaded.sessionId)) {
-      offloaded.isPool = true;
       offloaded.origin = "pool";
       sessions.push(offloaded);
     }

--- a/src/pool.js
+++ b/src/pool.js
@@ -27,18 +27,6 @@ function writePool(poolFile, pool) {
 }
 
 /**
- * Create initial pool structure with given size.
- */
-function createPool(size) {
-  return {
-    version: 1,
-    poolSize: size,
-    createdAt: new Date().toISOString(),
-    slots: [],
-  };
-}
-
-/**
  * Create a pool slot from a spawn result.
  */
 function createSlot(index, termId, pid) {
@@ -50,17 +38,6 @@ function createSlot(index, termId, pid) {
     sessionId: null,
     createdAt: new Date().toISOString(),
   };
-}
-
-/**
- * Update a slot's session ID and status after polling.
- */
-function resolveSlot(pool, termId, sessionId) {
-  const slot = pool.slots.find((s) => s.termId === termId);
-  if (!slot) return false;
-  slot.sessionId = sessionId;
-  slot.status = sessionId ? "fresh" : "error";
-  return true;
 }
 
 /**
@@ -159,9 +136,7 @@ function syncStatuses(pool, sessions) {
 module.exports = {
   readPool,
   writePool,
-  createPool,
   createSlot,
-  resolveSlot,
   selectShrinkCandidates,
   computePoolHealth,
   syncStatuses,

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -961,7 +961,9 @@ async function acquireFreshSlot() {
   const idleSessions = sessions
     .filter(
       (s) =>
-        s.status === "idle" && s.isPool && s.sessionId !== currentSessionId,
+        s.status === "idle" &&
+        s.origin === "pool" &&
+        s.sessionId !== currentSessionId,
     )
     .sort((a, b) => a.idleTs - b.idleTs);
 
@@ -1112,7 +1114,7 @@ async function selectSession(session) {
   }
 
   // External sessions: try to focus their terminal app (iTerm/Cursor)
-  if (!session.isPool && session.alive) {
+  if (session.origin !== "pool" && session.alive) {
     const result = await window.api.focusExternalTerminal(session.pid);
     if (gen !== sessionGeneration) return;
     if (result.focused) {
@@ -1126,7 +1128,7 @@ async function selectSession(session) {
 
   // Restore cached terminals immediately (sync, no race risk)
   if (!restoreSessionTerminals(session.sessionId)) {
-    if (session.isPool) {
+    if (session.origin === "pool") {
       // Pool session: attach to the pool slot's existing Claude TUI
       const pool = await window.api.poolRead();
       if (gen !== sessionGeneration) return;

--- a/test/pool.test.js
+++ b/test/pool.test.js
@@ -5,13 +5,30 @@ import os from "os";
 import {
   readPool,
   writePool,
-  createPool,
   createSlot,
-  resolveSlot,
   selectShrinkCandidates,
   computePoolHealth,
   syncStatuses,
 } from "../src/pool.js";
+
+/** Inline helper — createPool was removed from pool.js (never called in production). */
+function createPool(size) {
+  return {
+    version: 1,
+    poolSize: size,
+    createdAt: new Date().toISOString(),
+    slots: [],
+  };
+}
+
+/** Inline helper — resolveSlot was removed from pool.js (never called in production). */
+function resolveSlot(pool, termId, sessionId) {
+  const slot = pool.slots.find((s) => s.termId === termId);
+  if (!slot) return false;
+  slot.sessionId = sessionId;
+  slot.status = sessionId ? "fresh" : "error";
+  return true;
+}
 
 const TMP_DIR = path.join(os.tmpdir(), "open-cockpit-test-" + process.pid);
 const POOL_FILE = path.join(TMP_DIR, "pool.json");


### PR DESCRIPTION
## Summary

- Remove unused `createPool()` and `resolveSlot()` from `pool.js` (test helpers inlined in test file)
- Remove unused dependencies `@codemirror/language-data` and `markdown-it`
- Align `package.json` version (0.1.0 → 0.1.3) with `.claude-plugin/plugin.json`
- Replace `isPool` field with `origin === "pool"` checks across `main.js` and `renderer.js`
- Add `src/sort-sessions.js` to CLAUDE.md Architecture section

## Test plan

- [x] `node -c` syntax check on modified files
- [x] `npx vitest run` — all 79 tests pass
- [x] `npm run build` — builds successfully
- [x] Code review of `git diff main` — no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)