### PR TITLE
refactor: extract duplicate patterns into helpers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -42,8 +42,9 @@ const DEFAULT_POOL_SIZE = 5;
 // Returns the truthy value, or throws on timeout.
 async function poll(
   checkFn,
-  { interval = 1000, timeout = 300000, label = "poll" } = {},
+  { interval = 1000, timeout = 300000, initialDelay = 0, label = "poll" } = {},
 ) {
+  if (initialDelay > 0) await new Promise((r) => setTimeout(r, initialDelay));
   const start = Date.now();
   while (true) {
     const result = await checkFn();
@@ -1562,6 +1563,7 @@ app.whenReady().then(async () => {
       },
       {
         interval: 1000,
+        initialDelay: 1000,
         timeout: timeoutMs,
         label: "waiting for session to become idle",
       },
@@ -1720,6 +1722,7 @@ app.whenReady().then(async () => {
         },
         {
           interval: 1000,
+          initialDelay: 1000,
           timeout,
           label: "waiting for session to become idle",
         },


### PR DESCRIPTION
## Summary

- Extract `poll()` helper — replaces 3 hand-rolled polling loops (`pollForSessionId`, `waitForSessionIdle`, inline `pool-wait` handler)
- Extract `sendCommandToTerminal()` — consolidates the Escape → Ctrl-U → command pattern from `offloadSession` and `sendPromptToTerminal`
- Extract `createFreshIdleSignal()` — deduplicates idle signal JSON creation in `poolInit` and `reconcilePool`

Pure refactor, net -22 lines. No behavior changes.

## Test plan

- [x] `node -c src/main.js` — syntax OK
- [x] `npx vitest run` — all 79 tests pass
- [x] `npm run build` — builds successfully
- [x] Reviewed diff for missed callers, broken error handling, changed behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)