### PR TITLE
Add test step to CI auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -23,6 +23,16 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies and run tests
+        run: |
+          npm ci
+          npm test
+
       - name: Bump patch version
         id: bump
         run: |


### PR DESCRIPTION
## Summary

- Adds a Node.js 22 setup + `npm ci` / `npm test` step to the auto-release workflow
- Runs **before** the version bump, so broken code can't ship to the marketplace
- No impact on the `[skip ci]` commit logic

## Test plan

- [ ] Verify workflow YAML is valid (GitHub Actions tab)
- [ ] Push a commit with passing tests → release proceeds normally
- [ ] Push a commit with failing tests → workflow stops before version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)