### PR TITLE
Fix external sessions stuck as 'processing' after Claude finishes

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -40,10 +40,6 @@ Detects when sessions become idle (waiting for user input) or start processing. 
 | `UserPromptSubmit` | — | clear | User submitted a prompt |
 | `SessionStart` | `clear` | clear | Session was cleared (`/clear`) |
 
-### Block detection
-
-The Stop hook waits 1s then checks if the JSONL transcript was modified — if so, another hook blocked and the session continued (not idle). The signal is removed.
-
 ### Signal file format
 
 ```json

--- a/hooks/idle-signal.sh
+++ b/hooks/idle-signal.sh
@@ -49,20 +49,6 @@ case "${1:-}" in
         # Write signal file as JSON
         printf '{"cwd":"%s","session_id":"%s","transcript":"%s","ts":%d,"trigger":"%s"}\n' \
             "$(json_esc "$(pwd)")" "$(json_esc "$session_id")" "$(json_esc "$transcript")" "$(date +%s)" "$(json_esc "$trigger")" > "$signal_file"
-
-        # Block detection (Stop only): wait, then verify the session didn't continue.
-        # Another Stop hook may have blocked → Claude gets re-prompted → not idle.
-        if [ "$trigger" = "stop" ] && [ -n "$transcript" ] && [ -f "$transcript" ]; then
-            saved_mtime=$(stat -f '%m' "$transcript" 2>/dev/null || echo 0)
-            sleep 1
-            # If signal was already cleared by UserPromptSubmit/PostToolUse, stop
-            [ -f "$signal_file" ] || exit 0
-            current_mtime=$(stat -f '%m' "$transcript" 2>/dev/null || echo 0)
-            if [ "$current_mtime" -gt "$saved_mtime" ]; then
-                # JSONL was modified after signal → session continued → not idle
-                rm -f "$signal_file"
-            fi
-        fi
         ;;
     clear)
         rm -f "$signal_file"


### PR DESCRIPTION
## Summary

- Removed the block detection heuristic from `hooks/idle-signal.sh` that was falsely removing valid idle signals
- Updated `docs/hooks.md` to remove the now-deleted block detection section

## Root cause

The Stop hook wrote an idle signal, then waited 1 second and checked if the JSONL transcript's mtime changed. If it did, the signal was removed (assuming Claude continued after a hook block).

However, Claude Code writes `stop_hook_summary` and `turn_duration` entries to the transcript **after** Stop hooks complete. These writes changed the mtime, causing the block detection to falsely remove the signal. The session would then show as "processing" permanently even though Claude was idle.

External sessions were most visibly affected because pool sessions have additional signal management from `createFreshIdleSignal()` during pool init.

## Fix

Remove the block detection entirely. The existing hook lifecycle already handles the blocked-Stop case naturally:
- If Claude continues after a block → `PostToolUse` fires → signal cleared → shows "processing"
- If Claude truly stopped → signal persists → shows "idle"

## Test plan

- [ ] Start an external Claude session, give it a task, wait for completion — should show "idle" in sidebar
- [ ] Verify pool sessions still transition correctly: fresh → processing → idle
- [ ] Check that sessions show "processing" while Claude is actively generating

🤖 Generated with [Claude Code](https://claude.com/claude-code)