### PR TITLE
Add pool management buttons to settings UI

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1083,6 +1083,28 @@ function writeIntention(sessionId, content) {
   fs.writeFileSync(path.join(INTENTIONS_DIR, `${sessionId}.md`), content);
 }
 
+async function poolClean() {
+  const pool = readPool();
+  if (!pool) throw new Error("Pool not initialized");
+  const sessions = await getSessions();
+  const sessionMap = new Map(sessions.map((s) => [s.sessionId, s]));
+  const idleSlots = pool.slots.filter((s) => {
+    const session = s.sessionId ? sessionMap.get(s.sessionId) : null;
+    return session && session.status === "idle";
+  });
+  let cleaned = 0;
+  for (const slot of idleSlots) {
+    const session = sessionMap.get(slot.sessionId);
+    await offloadSession(slot.sessionId, slot.termId, null, {
+      cwd: session?.cwd,
+      gitRoot: session?.gitRoot,
+      pid: slot.pid,
+    });
+    cleaned++;
+  }
+  return cleaned;
+}
+
 function watchIntention(sessionId) {
   // Clean up previous watcher
   if (fileWatchers.has("current")) {
@@ -1463,6 +1485,7 @@ app.whenReady().then(async () => {
   ipcMain.handle("pool-health", () => getPoolHealth()); // getPoolHealth is async, returns promise — ipcMain.handle awaits it
   ipcMain.handle("pool-read", () => readPool());
   ipcMain.handle("pool-destroy", async () => poolDestroy());
+  ipcMain.handle("pool-clean", () => poolClean());
 
   // Setup scripts
   ipcMain.handle("list-setup-scripts", () => {
@@ -1756,28 +1779,7 @@ app.whenReady().then(async () => {
     },
 
     "pool-clean": async () => {
-      const pool = readPool();
-      if (!pool) throw new Error("Pool not initialized");
-
-      const sessions = await getSessions();
-      const sessionMap = new Map(sessions.map((s) => [s.sessionId, s]));
-
-      const idleSlots = pool.slots.filter((s) => {
-        const session = s.sessionId ? sessionMap.get(s.sessionId) : null;
-        return session && session.status === "idle";
-      });
-
-      let cleaned = 0;
-      for (const slot of idleSlots) {
-        const session = sessionMap.get(slot.sessionId);
-        await offloadSession(slot.sessionId, slot.termId, null, {
-          cwd: session?.cwd,
-          gitRoot: session?.gitRoot,
-          pid: slot.pid,
-        });
-        cleaned++;
-      }
-
+      const cleaned = await poolClean();
       return { type: "cleaned", count: cleaned };
     },
   });

--- a/src/preload.js
+++ b/src/preload.js
@@ -59,6 +59,7 @@ contextBridge.exposeInMainWorld("api", {
   poolHealth: () => ipcRenderer.invoke("pool-health"),
   poolRead: () => ipcRenderer.invoke("pool-read"),
   poolDestroy: () => ipcRenderer.invoke("pool-destroy"),
+  poolClean: () => ipcRenderer.invoke("pool-clean"),
 
   // Terminal (forwarded to PTY daemon via main process)
   ptySpawn: (opts) => ipcRenderer.invoke("pty-spawn", opts),

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1988,6 +1988,9 @@ async function showPoolSettings() {
             </label>
             <button class="offload-menu-btn pool-resize-btn">Resize</button>
             <button class="offload-menu-btn pool-reload-btn">Reload Sessions</button>
+            <button class="offload-menu-btn pool-clean-btn">Clean Idle</button>
+            <button class="offload-menu-btn pool-destroy-btn">Destroy</button>
+            <button class="offload-menu-btn pool-reinit-btn">Reinitialize</button>
           </div>
         `
             : `
@@ -2105,6 +2108,79 @@ async function showPoolSettings() {
       await loadDirColors();
       await loadSessions();
       showNotification("Sessions reloaded");
+    });
+  }
+
+  // Clean idle button
+  const cleanBtn = overlay.querySelector(".pool-clean-btn");
+  if (cleanBtn) {
+    cleanBtn.addEventListener("click", async () => {
+      cleanBtn.textContent = "Cleaning...";
+      cleanBtn.disabled = true;
+      try {
+        const cleaned = await window.api.poolClean();
+        showNotification(
+          `Cleaned ${cleaned} idle session${cleaned !== 1 ? "s" : ""}`,
+        );
+        await loadSessions();
+        showPoolSettings();
+      } catch (err) {
+        cleanBtn.textContent = "Clean Idle";
+        cleanBtn.disabled = false;
+        showNotification(`Error: ${err.message}`);
+      }
+    });
+  }
+
+  // Destroy button
+  const destroyBtn = overlay.querySelector(".pool-destroy-btn");
+  if (destroyBtn) {
+    destroyBtn.addEventListener("click", async () => {
+      destroyBtn.textContent = "Destroying...";
+      destroyBtn.disabled = true;
+      try {
+        await window.api.poolDestroy();
+        showNotification("Pool destroyed");
+        await loadSessions();
+        showPoolSettings();
+      } catch (err) {
+        destroyBtn.textContent = "Destroy";
+        destroyBtn.disabled = false;
+        showNotification(`Error: ${err.message}`);
+      }
+    });
+  }
+
+  // Reinitialize button (destroy + init)
+  const reinitBtn = overlay.querySelector(".pool-reinit-btn");
+  if (reinitBtn) {
+    reinitBtn.addEventListener("click", async () => {
+      const size = parseInt(
+        overlay.querySelector(".pool-size-input").value,
+        10,
+      );
+      if (isNaN(size) || size < 1 || size > 20) {
+        showNotification("Pool size must be between 1 and 20");
+        return;
+      }
+      reinitBtn.textContent = "Reinitializing...";
+      reinitBtn.disabled = true;
+      try {
+        await window.api.poolDestroy();
+      } catch (err) {
+        reinitBtn.textContent = "Reinitialize";
+        reinitBtn.disabled = false;
+        showNotification(`Destroy failed: ${err.message}`);
+        return;
+      }
+      try {
+        await window.api.poolInit(size);
+        showNotification(`Pool reinitialized (${size} slots)`);
+      } catch (err) {
+        showNotification(`Pool destroyed but re-init failed: ${err.message}`);
+      }
+      await loadSessions();
+      showPoolSettings();
     });
   }
 }


### PR DESCRIPTION
## Summary

- Adds **Clean Idle**, **Destroy**, and **Reinitialize** buttons to the pool settings dialog
- These operations were previously CLI-only — now accessible from the UI
- Extracts shared `poolClean()` function to deduplicate logic between IPC and API handlers
- Reinitialize handles partial failure gracefully (destroy succeeds but init fails → clear message)

## Test plan

- [ ] Open pool settings with an initialized pool → verify all 3 new buttons appear
- [ ] Click "Clean Idle" with idle sessions → verify they get offloaded
- [ ] Click "Destroy" → verify pool is torn down and UI shows init state
- [ ] Click "Reinitialize" → verify pool is destroyed and re-created
- [ ] Verify CLI `cockpit-cli pool clean` still works (shared function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)