### PR TITLE
Improve sidebar update performance

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -75,23 +75,41 @@ const gitRootCache = new Map();
 // Cache hasUserInput results (transcript -> true, once true stays true)
 const userInputCache = new Map();
 
-// Detect session origin by reading process environment via ps eww (macOS)
-async function detectOrigin(pid) {
-  if (originCache.has(String(pid))) return originCache.get(String(pid));
-  let origin = "ext";
-  try {
-    const { stdout } = await execFileAsync("ps", ["eww", "-p", String(pid)], {
-      encoding: "utf-8",
-      timeout: 3000,
-    });
-    if (/\bOPEN_COCKPIT_POOL=1\b/.test(stdout)) {
-      origin = "pool";
-    } else if (/\bSUB_CLAUDE=1\b/.test(stdout)) {
-      origin = "sub-claude";
+const { parseOrigins } = require("./parse-origins");
+
+// Detect session origin by reading process environment via ps eww (macOS).
+// Batched: resolves all uncached PIDs in a single subprocess call.
+async function batchDetectOrigins(pids) {
+  const results = new Map();
+  const uncached = [];
+  for (const pid of pids) {
+    const key = String(pid);
+    if (originCache.has(key)) {
+      results.set(key, originCache.get(key));
+    } else {
+      uncached.push(key);
     }
-  } catch {}
-  originCache.set(String(pid), origin);
-  return origin;
+  }
+  if (uncached.length > 0) {
+    try {
+      const { stdout } = await execFileAsync(
+        "ps",
+        ["eww", "-p", uncached.join(",")],
+        { encoding: "utf-8", timeout: 3000 },
+      );
+      const parsed = parseOrigins(stdout, uncached);
+      for (const [pid, origin] of parsed) {
+        originCache.set(pid, origin);
+        results.set(pid, origin);
+      }
+    } catch {
+      for (const pid of uncached) {
+        originCache.set(pid, "ext");
+        results.set(pid, "ext");
+      }
+    }
+  }
+  return results;
 }
 
 // --- PTY Daemon Client ---
@@ -467,11 +485,16 @@ async function getSessionsUncached() {
       if (slot.sessionId) poolSessionIds.add(slot.sessionId);
     }
   }
+  // Batch detect origins for all alive non-pool sessions in one ps call
+  const needOriginPids = sessions
+    .filter((s) => s.alive && !poolSessionIds.has(s.sessionId))
+    .map((s) => s.pid);
+  const originMap = await batchDetectOrigins(needOriginPids);
   for (const s of sessions) {
     if (poolSessionIds.has(s.sessionId)) {
       s.origin = "pool";
     } else if (s.alive) {
-      s.origin = await detectOrigin(s.pid);
+      s.origin = originMap.get(String(s.pid)) || "ext";
     } else {
       s.origin = "ext";
     }
@@ -493,17 +516,78 @@ async function getSessionsUncached() {
 // duplicate subprocesses. Second caller reuses the first's result.
 let sessionsInFlight = null;
 
+// Lightweight fingerprint: PID files + idle signal mtimes + offloaded dir.
+// Avoids expensive subprocess calls when nothing changed.
+let lastDirFingerprint = null;
+let lastFullRefreshTs = 0;
+const MAX_FINGERPRINT_AGE = 30000; // Force full refresh every 30s for liveness checks
+
+function computeDirFingerprint() {
+  try {
+    const parts = [];
+    // PID files (session-pids dir)
+    if (fs.existsSync(SESSION_PIDS_DIR)) {
+      const files = fs.readdirSync(SESSION_PIDS_DIR).sort();
+      for (const f of files) {
+        try {
+          const st = fs.statSync(path.join(SESSION_PIDS_DIR, f));
+          parts.push(`p:${f}:${st.mtimeMs}`);
+        } catch {}
+      }
+    }
+    // Idle signal files
+    if (fs.existsSync(IDLE_SIGNALS_DIR)) {
+      const files = fs.readdirSync(IDLE_SIGNALS_DIR).sort();
+      for (const f of files) {
+        try {
+          const st = fs.statSync(path.join(IDLE_SIGNALS_DIR, f));
+          parts.push(`i:${f}:${st.mtimeMs}`);
+        } catch {}
+      }
+    }
+    // Offloaded dir mtime (catches new archives)
+    try {
+      const st = fs.statSync(OFFLOADED_DIR);
+      parts.push(`o:${st.mtimeMs}`);
+    } catch {}
+    // Pool state changes (new slots, killed sessions)
+    try {
+      const st = fs.statSync(POOL_FILE);
+      parts.push(`pool:${st.mtimeMs}`);
+    } catch {}
+    return parts.join("|");
+  } catch {
+    return null; // Force refresh on error
+  }
+}
+
 async function getSessions() {
   const now = Date.now();
   if (sessionsCache && now - sessionsCacheTs < SESSIONS_CACHE_TTL) {
     return sessionsCache;
   }
+
+  // Fast path: if directory state hasn't changed and not too stale, extend cache.
+  // Max age ensures dead processes are detected even when their PID files remain.
+  const fp = computeDirFingerprint();
+  if (
+    sessionsCache &&
+    fp &&
+    fp === lastDirFingerprint &&
+    now - lastFullRefreshTs < MAX_FINGERPRINT_AGE
+  ) {
+    sessionsCacheTs = now;
+    return sessionsCache;
+  }
+
   // Deduplicate concurrent calls
   if (sessionsInFlight) return sessionsInFlight;
   sessionsInFlight = getSessionsUncached()
     .then((result) => {
       sessionsCache = result;
       sessionsCacheTs = Date.now();
+      lastFullRefreshTs = Date.now();
+      lastDirFingerprint = computeDirFingerprint();
       return result;
     })
     .finally(() => {
@@ -516,6 +600,8 @@ async function getSessions() {
 function invalidateSessionsCache() {
   sessionsCache = null;
   sessionsCacheTs = 0;
+  lastDirFingerprint = null;
+  lastFullRefreshTs = 0;
 }
 
 // Read the terminal buffer for a single PTY (lightweight alternative to list)
@@ -1499,6 +1585,28 @@ app.whenReady().then(async () => {
     await reconcilePool();
   } catch (err) {
     console.error("[main] Pool reconciliation failed:", err.message);
+  }
+
+  // Watch session-pids and idle-signals dirs for changes → push updates to renderer.
+  // Debounced: fs.watch fires multiple events per operation.
+  let watchDebounce = null;
+  function onDirChange() {
+    if (watchDebounce) clearTimeout(watchDebounce);
+    watchDebounce = setTimeout(() => {
+      watchDebounce = null;
+      invalidateSessionsCache();
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send("sessions-changed");
+      }
+    }, 200);
+  }
+  for (const dir of [SESSION_PIDS_DIR, IDLE_SIGNALS_DIR]) {
+    fs.mkdirSync(dir, { recursive: true });
+    try {
+      fs.watch(dir, { persistent: false }, onDirChange);
+    } catch (err) {
+      console.error(`[main] fs.watch failed on ${dir}:`, err.message);
+    }
   }
 
   ipcMain.handle("get-dir-colors", () => {

--- a/src/parse-origins.js
+++ b/src/parse-origins.js
@@ -1,0 +1,21 @@
+// Parse ps eww output to detect session origins for given PIDs.
+function parseOrigins(psOutput, pids) {
+  const results = new Map();
+  const lines = psOutput.split("\n");
+  for (const pid of pids) {
+    // ps right-aligns PIDs with variable whitespace
+    const pidLine = lines.find((l) => new RegExp(`^\\s*${pid}\\s`).test(l));
+    let origin = "ext";
+    if (pidLine) {
+      if (/\bOPEN_COCKPIT_POOL=1\b/.test(pidLine)) {
+        origin = "pool";
+      } else if (/\bSUB_CLAUDE=1\b/.test(pidLine)) {
+        origin = "sub-claude";
+      }
+    }
+    results.set(pid, origin);
+  }
+  return results;
+}
+
+module.exports = { parseOrigins };

--- a/src/preload.js
+++ b/src/preload.js
@@ -3,6 +3,7 @@ const { contextBridge, ipcRenderer } = require("electron");
 // Remove stale listeners from previous renderer loads (Cmd+R)
 const channels = [
   "intention-changed",
+  "sessions-changed",
   "pty-data",
   "pty-replay",
   "pty-exit",
@@ -32,6 +33,8 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.invoke("watch-intention", sessionId),
   onIntentionChanged: (callback) =>
     ipcRenderer.on("intention-changed", (_e, content) => callback(content)),
+  onSessionsChanged: (callback) =>
+    ipcRenderer.on("sessions-changed", () => callback()),
 
   // External terminal focus
   focusExternalTerminal: (pid) =>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -2288,8 +2288,13 @@ COMMANDS.push({
 
 loadDirColors().then(async () => {
   await reconnectAllPtys();
-  let sessionPollInterval = setInterval(loadSessions, 10000);
+  const POLL_INTERVAL = 5000;
+  let sessionPollInterval = setInterval(loadSessions, POLL_INTERVAL);
   loadSessions();
+
+  // Event-driven refresh: main process pushes (already debounced) when
+  // idle-signals/session-pids change.
+  window.api.onSessionsChanged(() => loadSessions());
 
   // Pause polling when window is hidden to save CPU
   document.addEventListener("visibilitychange", () => {
@@ -2299,7 +2304,7 @@ loadDirColors().then(async () => {
     } else {
       if (!sessionPollInterval) {
         loadSessions();
-        sessionPollInterval = setInterval(loadSessions, 10000);
+        sessionPollInterval = setInterval(loadSessions, POLL_INTERVAL);
       }
     }
   });

--- a/test/parse-origins.test.js
+++ b/test/parse-origins.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { parseOrigins } from "../src/parse-origins.js";
+
+// Realistic ps eww output (macOS right-aligns PIDs with variable whitespace)
+const PS_OUTPUT = `  PID   TT  STAT      TIME COMMAND
+12345   ??  S      0:01.23 /usr/bin/claude --some-flag OPEN_COCKPIT_POOL=1 OTHER=stuff
+23456   ??  S      0:00.50 /usr/bin/claude --flag SUB_CLAUDE=1 PATH=/usr/bin
+34567   ??  S      0:02.00 /usr/bin/claude --flag PATH=/usr/bin HOME=/Users/test`;
+
+// Short PIDs are right-aligned with leading spaces
+const PS_SHORT_PIDS = `  PID   TT  STAT      TIME COMMAND
+    1   ??  Ss    91:57.04 /sbin/launchd OPEN_COCKPIT_POOL=1
+  456   ??  S      0:00.50 /usr/bin/claude SUB_CLAUDE=1`;
+
+describe("parseOrigins", () => {
+  it("detects pool origin from OPEN_COCKPIT_POOL=1", () => {
+    const result = parseOrigins(PS_OUTPUT, ["12345"]);
+    expect(result.get("12345")).toBe("pool");
+  });
+
+  it("detects sub-claude origin from SUB_CLAUDE=1", () => {
+    const result = parseOrigins(PS_OUTPUT, ["23456"]);
+    expect(result.get("23456")).toBe("sub-claude");
+  });
+
+  it("defaults to ext when no env markers found", () => {
+    const result = parseOrigins(PS_OUTPUT, ["34567"]);
+    expect(result.get("34567")).toBe("ext");
+  });
+
+  it("defaults to ext when PID not found in output", () => {
+    const result = parseOrigins(PS_OUTPUT, ["99999"]);
+    expect(result.get("99999")).toBe("ext");
+  });
+
+  it("handles multiple PIDs in one call", () => {
+    const result = parseOrigins(PS_OUTPUT, ["12345", "23456", "34567"]);
+    expect(result.get("12345")).toBe("pool");
+    expect(result.get("23456")).toBe("sub-claude");
+    expect(result.get("34567")).toBe("ext");
+  });
+
+  it("handles empty output", () => {
+    const result = parseOrigins("", ["12345"]);
+    expect(result.get("12345")).toBe("ext");
+  });
+
+  it("handles empty PID list", () => {
+    const result = parseOrigins(PS_OUTPUT, []);
+    expect(result.size).toBe(0);
+  });
+
+  it("does not false-match partial PID", () => {
+    // PID 1234 should not match a line starting with 12345
+    const result = parseOrigins(PS_OUTPUT, ["1234"]);
+    expect(result.get("1234")).toBe("ext");
+  });
+
+  it("handles right-aligned short PIDs with leading spaces", () => {
+    const result = parseOrigins(PS_SHORT_PIDS, ["1", "456"]);
+    expect(result.get("1")).toBe("pool");
+    expect(result.get("456")).toBe("sub-claude");
+  });
+});


### PR DESCRIPTION
## Summary

- **Batch origin detection**: Replace N sequential `ps eww -p <PID>` calls with a single batched call, eliminating the biggest per-refresh bottleneck
- **Directory fingerprinting**: Short-circuit expensive `getSessionsUncached()` when PID files, idle signals, pool state, and offloaded dir haven't changed (with 30s max staleness to ensure liveness checks still run)
- **Event-driven updates**: `fs.watch` on `session-pids/` and `idle-signals/` dirs pushes `sessions-changed` to renderer for near-instant sidebar updates on state changes
- **Reduced poll interval**: 10s → 5s (safe now that most polls hit the fingerprint fast-path)
- **Extracted `parseOrigins`** into testable module with 9 tests covering macOS `ps` output format quirks

## Test plan

- [x] All 88 tests pass (9 new for `parseOrigins`)
- [ ] Manual: Launch app, verify sidebar updates within ~1s when a session changes state (idle → processing → idle)
- [ ] Manual: Verify dead sessions still get detected and archived (fingerprint staleness bound)
- [ ] Manual: Pool init/destroy reflected in sidebar promptly

🤖 Generated with [Claude Code](https://claude.com/claude-code)