### PR TITLE
Fix false idle status when Stop hooks re-prompt Claude

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -29,11 +29,13 @@ Resolves the session ID via the PID mapping written by `session-pid-map.sh`.
 
 Detects when sessions become idle (waiting for user input) or start processing. Writes signal files to `~/.open-cockpit/idle-signals/<PID>`.
 
+**No false positives.** Idle signals must only appear when a session is truly waiting for user input. The app may trigger notifications (e.g. a bell) on idle, so a premature signal is worse than a delayed one. The `stop` trigger defers writing for a few seconds and verifies the transcript hasn't changed (which would indicate a re-prompt from another hook).
+
 ### Signal lifecycle
 
 | Hook Event | Matcher | Action | Meaning |
 |------------|---------|--------|---------|
-| `Stop` | — | write (stop) | Claude finished responding |
+| `Stop` | — | deferred write (stop) | Claude finished responding (verified after 3s) |
 | `PreToolUse` | `AskUserQuestion\|ExitPlanMode` | write (tool) | Claude is asking for input |
 | `PermissionRequest` | — | write (permission) | Waiting for permission approval |
 | `PostToolUse` | — | clear | Processing resumed after tool use |
@@ -48,6 +50,7 @@ Detects when sessions become idle (waiting for user input) or start processing. 
 
 ### How the app uses signals
 
+- **Has signal + transcript mtime > signal mtime** → processing (Stop hook re-prompted Claude)
 - **Has signal + has human turns in JSONL** → idle (ready for input)
 - **Has signal + no human turns** → fresh (never used)
 - **No signal + alive** → processing

--- a/hooks/idle-signal.sh
+++ b/hooks/idle-signal.sh
@@ -3,12 +3,18 @@
 # Called by Claude Code hooks (Stop, PreToolUse, PermissionRequest,
 # PostToolUse, UserPromptSubmit, SessionStart).
 #
+# IMPORTANT: Idle signals must have NO FALSE POSITIVES. A session must only
+# be marked idle when it is truly waiting for user input. The "stop" trigger
+# defers writing for IDLE_VERIFY_DELAY seconds and verifies the transcript
+# hasn't changed (which would indicate a re-prompt from another Stop hook).
+#
 # Usage: idle-signal.sh write [stop|tool|permission]
 #        idle-signal.sh clear
 
 set -euo pipefail
 
 SIGNAL_DIR="$HOME/.open-cockpit/idle-signals"
+IDLE_VERIFY_DELAY=3
 mkdir -p "$SIGNAL_DIR"
 
 # $PPID is the Claude process that spawned this hook
@@ -32,6 +38,11 @@ json_get() {
     echo "$1" | sed -n 's/.*"'"$2"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
 }
 
+# Cross-platform file mtime in epoch seconds (macOS uses -f, Linux uses -c)
+file_mtime() {
+    stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0
+}
+
 case "${1:-}" in
     write)
         trigger="${2:-unknown}"
@@ -46,11 +57,50 @@ case "${1:-}" in
         # Escape JSON string values (handle \, ", and control chars)
         json_esc() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g; s/	/\\t/g'; }
 
-        # Write signal file as JSON
-        printf '{"cwd":"%s","session_id":"%s","transcript":"%s","ts":%d,"trigger":"%s"}\n' \
-            "$(json_esc "$(pwd)")" "$(json_esc "$session_id")" "$(json_esc "$transcript")" "$(date +%s)" "$(json_esc "$trigger")" > "$signal_file"
+        # Build the signal JSON (capture now, write later for deferred triggers)
+        signal_json=$(printf '{"cwd":"%s","session_id":"%s","transcript":"%s","ts":%d,"trigger":"%s"}\n' \
+            "$(json_esc "$(pwd)")" "$(json_esc "$session_id")" "$(json_esc "$transcript")" "$(date +%s)" "$(json_esc "$trigger")")
+
+        if [ "$trigger" = "stop" ]; then
+            # Defer: verify session is truly idle before writing.
+            # Another Stop hook may re-prompt Claude, making it not actually idle.
+            pending="$signal_file.pending"
+            echo "$$" > "$pending"
+
+            (
+                trap 'rm -f "$pending"' EXIT
+
+                before=""
+                if [ -n "$transcript" ] && [ -f "$transcript" ]; then
+                    before=$(file_mtime "$transcript")
+                fi
+
+                i=0
+                while [ "$i" -lt "$IDLE_VERIFY_DELAY" ]; do
+                    sleep 1
+                    i=$((i + 1))
+
+                    # Abort if our pending claim was invalidated (clear or new stop)
+                    [ ! -f "$pending" ] && exit 0
+                    [ "$(cat "$pending" 2>/dev/null)" != "$$" ] && exit 0
+
+                    # Abort if transcript changed (re-prompt or user input)
+                    if [ -n "$before" ] && [ -f "$transcript" ]; then
+                        after=$(file_mtime "$transcript")
+                        [ "$before" != "$after" ] && exit 0
+                    fi
+                done
+
+                # Session is truly idle — write signal
+                printf '%s\n' "$signal_json" > "$signal_file"
+            ) &
+            disown
+        else
+            # tool/permission triggers write immediately (user is already waiting)
+            printf '%s\n' "$signal_json" > "$signal_file"
+        fi
         ;;
     clear)
-        rm -f "$signal_file"
+        rm -f "$signal_file" "$signal_file.pending"
         ;;
 esac

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,7 @@ const {
 const { promisify } = require("util");
 const execFileAsync = promisify(execFile);
 const { sortSessions } = require("./sort-sessions");
+const { isTranscriptNewerThanSignal } = require("./session-status");
 const { createApiServer } = require("./api-server");
 const {
   readPool: readPoolFile,
@@ -246,12 +247,14 @@ function getIntentionHeading(filePath) {
   }
 }
 
-// Read idle signal for a PID. Returns {cwd, ts, trigger, session_id} or null.
+// Read idle signal for a PID. Returns {cwd, ts, trigger, session_id, signalMtimeMs} or null.
 function getIdleSignal(pid) {
   try {
     const signalFile = path.join(IDLE_SIGNALS_DIR, String(pid));
-    if (!fs.existsSync(signalFile)) return null;
-    return JSON.parse(fs.readFileSync(signalFile, "utf-8"));
+    const stat = fs.statSync(signalFile);
+    const parsed = JSON.parse(fs.readFileSync(signalFile, "utf-8"));
+    parsed.signalMtimeMs = stat.mtimeMs;
+    return parsed;
   } catch {
     return null;
   }
@@ -415,7 +418,16 @@ async function getSessionsUncached() {
       status = "dead";
     } else if (idleSignal) {
       idleTs = idleSignal.ts || 0;
-      if (!hasUserInput(idleSignal.transcript)) {
+      if (
+        isTranscriptNewerThanSignal(
+          idleSignal.signalMtimeMs,
+          idleSignal.transcript,
+        )
+      ) {
+        // Transcript was written after the idle signal — a Stop hook re-prompted
+        // Claude and it's still processing (no new idle signal yet)
+        status = "processing";
+      } else if (!hasUserInput(idleSignal.transcript)) {
         status = "fresh";
       } else {
         status = "idle";

--- a/src/session-status.js
+++ b/src/session-status.js
@@ -1,0 +1,17 @@
+const fs = require("fs");
+
+// Check if the JSONL transcript was modified after the idle signal was written.
+// This detects re-prompts from blocking Stop hooks: the idle signal exists but
+// Claude is still processing because another hook re-prompted it.
+// Uses pre-fetched signal mtime (from getIdleSignal) to avoid redundant stat calls.
+function isTranscriptNewerThanSignal(signalMtimeMs, transcriptPath) {
+  if (!transcriptPath || !signalMtimeMs) return false;
+  try {
+    const transcriptMtime = fs.statSync(transcriptPath).mtimeMs;
+    return transcriptMtime > signalMtimeMs;
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { isTranscriptNewerThanSignal };

--- a/test/session-status.test.js
+++ b/test/session-status.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { isTranscriptNewerThanSignal } from "../src/session-status";
+
+const TMP = path.join(os.tmpdir(), "session-status-test");
+
+function sleep(ms) {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {}
+}
+
+function mtimeMs(filePath) {
+  return fs.statSync(filePath).mtimeMs;
+}
+
+describe("isTranscriptNewerThanSignal", () => {
+  beforeEach(() => {
+    fs.mkdirSync(TMP, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(TMP, { recursive: true, force: true });
+  });
+
+  it("returns false when transcript was written before signal (normal idle)", () => {
+    const transcript = path.join(TMP, "transcript.jsonl");
+    const signal = path.join(TMP, "signal.json");
+    fs.writeFileSync(transcript, '{"type":"assistant"}');
+    sleep(10);
+    fs.writeFileSync(signal, '{"ts":1234}');
+    expect(isTranscriptNewerThanSignal(mtimeMs(signal), transcript)).toBe(
+      false,
+    );
+  });
+
+  it("returns true when transcript was written after signal (re-prompt)", () => {
+    const transcript = path.join(TMP, "transcript.jsonl");
+    const signal = path.join(TMP, "signal.json");
+    fs.writeFileSync(signal, '{"ts":1234}');
+    sleep(10);
+    fs.writeFileSync(transcript, '{"type":"assistant"}');
+    expect(isTranscriptNewerThanSignal(mtimeMs(signal), transcript)).toBe(true);
+  });
+
+  it("returns true when transcript is appended after signal (mid-session re-prompt)", () => {
+    const transcript = path.join(TMP, "transcript.jsonl");
+    const signal = path.join(TMP, "signal.json");
+    fs.writeFileSync(transcript, '{"type":"assistant","msg":"first"}\n');
+    sleep(10);
+    fs.writeFileSync(signal, '{"ts":1234}');
+    const signalMtime = mtimeMs(signal);
+    sleep(10);
+    fs.appendFileSync(transcript, '{"type":"assistant","msg":"reprompt"}\n');
+    expect(isTranscriptNewerThanSignal(signalMtime, transcript)).toBe(true);
+  });
+
+  it("returns false for empty transcript path", () => {
+    expect(isTranscriptNewerThanSignal(Date.now(), "")).toBe(false);
+  });
+
+  it("returns false for null/undefined transcript path", () => {
+    expect(isTranscriptNewerThanSignal(Date.now(), null)).toBe(false);
+    expect(isTranscriptNewerThanSignal(Date.now(), undefined)).toBe(false);
+  });
+
+  it("returns false for null/undefined/zero signalMtimeMs", () => {
+    const transcript = path.join(TMP, "transcript.jsonl");
+    fs.writeFileSync(transcript, "data");
+    expect(isTranscriptNewerThanSignal(null, transcript)).toBe(false);
+    expect(isTranscriptNewerThanSignal(undefined, transcript)).toBe(false);
+    expect(isTranscriptNewerThanSignal(0, transcript)).toBe(false);
+  });
+
+  it("returns false when transcript file does not exist", () => {
+    expect(
+      isTranscriptNewerThanSignal(
+        Date.now(),
+        path.join(TMP, "nonexistent.jsonl"),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when signal is rewritten after re-prompt response completes", () => {
+    const transcript = path.join(TMP, "transcript.jsonl");
+    const signal = path.join(TMP, "signal.json");
+    fs.writeFileSync(
+      transcript,
+      '{"type":"assistant","msg":"reprompt response"}',
+    );
+    sleep(10);
+    fs.writeFileSync(signal, '{"ts":9999}');
+    expect(isTranscriptNewerThanSignal(mtimeMs(signal), transcript)).toBe(
+      false,
+    );
+  });
+
+  it("detects near-simultaneous writes correctly on APFS", () => {
+    const transcript = path.join(TMP, "transcript.jsonl");
+    const signal = path.join(TMP, "signal.json");
+    fs.writeFileSync(signal, "x");
+    const signalMtime = mtimeMs(signal);
+    fs.writeFileSync(transcript, "y");
+    expect(isTranscriptNewerThanSignal(signalMtime, transcript)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- When a blocking Stop hook (e.g. `check-improvements.sh`) re-prompts Claude, the session was immediately marked idle despite still processing
- This would cause false positives for features like idle notifications (e.g. a bell)
- Two-layer fix: **deferred write** in the hook (3s verification delay) + **mtime check** in the app as defense-in-depth

## How it works

**Hook side** (`idle-signal.sh`):
- `stop` trigger now defers the idle signal write by 3 seconds
- Background process polls every second: checks if the JSONL transcript mtime changed (indicating a re-prompt) or if a `.pending` marker was invalidated (clear event or new stop)
- Only writes the signal if the session is truly idle after the delay
- `tool`/`permission` triggers still write immediately (user is already waiting)

**App side** (`session-status.js` + `main.js`):
- Defense-in-depth: compares transcript file mtime against signal file mtime
- If transcript is newer than the signal → treats session as "processing"
- Uses APFS sub-millisecond precision (no tolerance needed)

## Test plan

- [ ] 9 new unit tests for `isTranscriptNewerThanSignal` covering normal idle, re-prompt, edge cases, APFS precision
- [ ] All 97 existing tests pass
- [ ] Verify pool sessions show correct status after hook re-prompts
- [ ] Verify idle detection still works (with ~3s delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)