### PR TITLE
Fix SessionStart hooks sharing stdin

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,11 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-pid-map.sh"
-          },
+          }
+        ]
+      },
+      {
+        "hooks": [
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-intention-intro.sh"


### PR DESCRIPTION
## Summary

- Split `session-pid-map.sh` and `session-intention-intro.sh` into separate hook entries in `hooks.json`
- `session-pid-map.sh` was consuming stdin, leaving `session-intention-intro.sh` with no input — so the intention intro never fired on session start

## Test plan

- [ ] Start a new Claude session with the plugin active
- [ ] Verify intention intro message appears at session start
- [ ] Verify PID mapping still works (`~/.open-cockpit/session-pids/`)
- [ ] Verify intention snapshot is created (`~/.open-cockpit/intentions/.snapshots/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)