### PR TITLE
Detect stale processing sessions and treat as idle

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -78,6 +78,9 @@ const jsonlPathCache = new Map();
 // If a "processing" session's transcript hasn't been written to in this long, treat as idle
 const STALE_PROCESSING_MS = 5 * 60 * 1000; // 5 minutes
 
+// Deduplicate stale processing log messages (only log once per session)
+const staleLoggedSessions = new Set();
+
 // Cache hasUserInput results (transcript -> true, once true stays true)
 const userInputCache = new Map();
 
@@ -406,6 +409,7 @@ async function getSessionsUncached() {
     const idleSignal = alive ? getIdleSignal(pid) : null;
     let status;
     let idleTs = 0;
+    let staleIdle = false;
 
     if (!alive) {
       status = "dead";
@@ -420,12 +424,17 @@ async function getSessionsUncached() {
       // Fallback: if transcript hasn't been written to in a while, treat as idle
       const mtime = await getJsonlMtime(sessionId);
       if (mtime && Date.now() - mtime > STALE_PROCESSING_MS) {
-        console.log(
-          `[main] Stale processing detected for session ${sessionId} (no activity for ${Math.round((Date.now() - mtime) / 1000)}s) — treating as idle`,
-        );
+        if (!staleLoggedSessions.has(sessionId)) {
+          staleLoggedSessions.add(sessionId);
+          console.warn(
+            `[main] Stale processing detected for session ${sessionId} (no activity for ${Math.round((Date.now() - mtime) / 1000)}s) — treating as idle. Idle signal hook may have failed.`,
+          );
+        }
         status = "idle";
+        staleIdle = true;
         idleTs = mtime;
       } else {
+        staleLoggedSessions.delete(sessionId);
         status = "processing";
       }
     }
@@ -442,6 +451,7 @@ async function getSessionsUncached() {
       intentionHeading,
       status,
       idleTs,
+      staleIdle,
     });
   }
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -769,7 +769,7 @@ const STATUS_CLASSES = {
 
 // Build a fingerprint for a session to detect changes
 function sessionFingerprint(s) {
-  return `${s.sessionId}|${s.status}|${s.intentionHeading || ""}|${s.cwd || ""}|${s.origin || ""}`;
+  return `${s.sessionId}|${s.status}|${s.staleIdle ? "stale" : ""}|${s.intentionHeading || ""}|${s.cwd || ""}|${s.origin || ""}`;
 }
 
 // Track previous session fingerprints for diff-based updates
@@ -867,13 +867,16 @@ function createSessionItem(s) {
   const originTag = s.origin
     ? `<span class="session-origin-tag session-origin-${escapeHtml(s.origin)}">${escapeHtml(s.origin)}</span>`
     : "";
+  const staleTag = s.staleIdle
+    ? `<span class="session-origin-tag session-origin-stale">stale</span>`
+    : "";
   li.innerHTML = `
     <div class="session-dir-indicator" style="${indicatorStyle}"></div>
     <div class="session-item-content">
       <div class="session-project">
         <span class="session-status ${STATUS_CLASSES[s.status] || "dead"}"></span>
         ${escapeHtml(heading)}
-        ${originTag}
+        ${originTag}${staleTag}
       </div>
       <div class="session-cwd">${escapeHtml(dp)}</div>
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -255,6 +255,11 @@ body {
   background: var(--border);
 }
 
+.session-origin-stale {
+  color: var(--yellow);
+  background: rgba(255, 255, 0, 0.1);
+}
+
 .session-cwd {
   font-size: 11px;
   color: var(--text-dim);


### PR DESCRIPTION
## Summary

- If a session's JSONL transcript hasn't been written to in 5 minutes while shown as "processing" (no idle signal), automatically treat it as idle
- Catches edge cases where the idle signal hook fails to fire (e.g., Claude hung, hook error)
- Refactors `findJsonlPath` out of `getCwdFromJsonl` to share cached JSONL path lookups
- Invalidates cache on stat failure to handle deleted/moved files
- Logs stale→idle transitions for debugging

## Test plan

- [ ] Start a session, verify normal processing→idle flow still works via hooks
- [ ] Simulate stale processing: manually delete the idle signal file while a session is idle — after 5 min it should re-detect as idle via mtime fallback
- [ ] Verify no performance regression with multiple sessions (cached `find` + async `stat`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)