### PR TITLE
Fix pool session CWD showing root directory

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -395,8 +395,8 @@ async function getSessionsUncached() {
   for (const { pid, sessionId, alive } of pidEntries) {
     let cwd = alive ? cwdMap.get(String(pid)) || null : null;
 
-    // Refine CWD via JSONL when spawned from $HOME
-    if (cwd === os.homedir()) {
+    // Refine CWD via JSONL when lsof reports a generic directory
+    if (!cwd || cwd === os.homedir() || cwd === "/") {
       const refined = await getCwdFromJsonl(sessionId);
       if (refined && fs.existsSync(refined) && refined !== os.homedir()) {
         cwd = refined;


### PR DESCRIPTION
## Summary

- Pool sessions' CWD was showing `/` in the sidebar instead of the actual project directory
- `lsof` returns `/` for pool sessions because Claude internally `chdir`s away from `$HOME`
- The JSONL refinement (which has the correct project dir) only triggered when `cwd === os.homedir()`, so `/` was never refined
- Broadened the condition to also refine when cwd is `null` or `/`

## Test plan

- [x] All existing tests pass (88/88)
- [ ] Open a pool session, verify sidebar shows the correct project directory
- [ ] Open a terminal tab ("+"), verify it opens in the project directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)