### PR TITLE
Add session shortcuts (Cmd+J, Cmd+D)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ DAEMON_PID=$(cat ~/.open-cockpit/pty-daemon.pid 2>/dev/null || echo NONE); lsof 
 - [docs/theme.md](docs/theme.md) — Color scheme, directory color coding, user overrides
 - [docs/hooks.md](docs/hooks.md) — Plugin hooks
 - [docs/api.md](docs/api.md) — Programmatic API (Unix socket, CLI helper)
+- [docs/shortcuts.md](docs/shortcuts.md) — Keyboard shortcuts reference + how to add new ones
 
 ## Session origin tags
 
@@ -183,6 +184,7 @@ fresh → processing → idle → offloaded (graceful /clear, snapshot saved)
 
 ## Conventions
 
+- **Every user-facing action must have a keyboard shortcut.** See [docs/shortcuts.md](docs/shortcuts.md) for the full list and how to add new ones.
 - Electron: contextIsolation, sandbox off (preload needs npm packages)
 - CodeMirror 6 bundled with esbuild
 - Auto-save 500ms debounce, file watching via `fs.watchFile` (polling)

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -1,0 +1,44 @@
+# Keyboard Shortcuts
+
+## How shortcuts are implemented
+
+Shortcuts flow through three layers:
+
+1. **Menu accelerators** (`src/main.js`) — Electron menu items with `accelerator` keys (e.g., `CmdOrCtrl+N`). These call `send(channel)` which forwards to the renderer via `webContents.send()`.
+
+2. **`before-input-event` handler** (`src/main.js`) — For shortcuts that can't be menu accelerators (e.g., `Ctrl+Tab`, `Escape`). Intercepts raw keyboard input and dispatches IPC messages.
+
+3. **Renderer listeners** (`src/renderer.js`) — Registered via `window.api.on<Action>()` callbacks exposed through the preload bridge. Execute the actual UI logic.
+
+### Adding a new shortcut
+
+1. **`src/preload.js`**: Add the channel name to the `channels` array (for stale listener cleanup) and expose an `on<Action>` listener in the `contextBridge`.
+2. **`src/main.js`**: Add a menu entry with `accelerator` and `click: () => send("channel-name")` in the appropriate menu section.
+3. **`src/renderer.js`**:
+   - Implement the action function
+   - Add a `COMMANDS` entry (for command palette visibility)
+   - Wire up `window.api.on<Action>(handler)` at the bottom with other listeners
+
+### Command palette
+
+All shortcuts should also appear in the command palette (`Cmd+/`). The `COMMANDS` array in `renderer.js` defines entries with `id`, `label`, `shortcut` (display string), and `action` (function).
+
+## Current shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd+N` | New Claude Session |
+| `Cmd+T` | New Terminal Tab |
+| `Cmd+W` | Close Terminal Tab |
+| `Cmd+Shift+]` / `[` | Next / Previous Tab |
+| `Cmd+1`–`9` | Switch to Tab N |
+| `Ctrl+Tab` / `Ctrl+Shift+Tab` | Next / Previous Tab (alt) |
+| `Alt+Down` / `Alt+Up` | Next / Previous Session |
+| `Cmd+J` | Jump to Recent Idle Session |
+| `Cmd+D` | Archive Current Session |
+| `Cmd+\` | Toggle Sidebar |
+| `Alt+Left` / `Alt+Right` | Toggle Pane Focus |
+| `Cmd+E` | Focus Editor |
+| `` Cmd+` `` | Focus Terminal |
+| `Escape` | Focus Terminal |
+| `Cmd+/` | Command Palette |

--- a/src/main.js
+++ b/src/main.js
@@ -2156,6 +2156,17 @@ app.whenReady().then(async () => {
         },
         { type: "separator" },
         {
+          label: "Jump to Recent Idle",
+          accelerator: "CmdOrCtrl+J",
+          click: () => send("jump-recent-idle"),
+        },
+        {
+          label: "Archive Current Session",
+          accelerator: "CmdOrCtrl+D",
+          click: () => send("archive-current-session"),
+        },
+        { type: "separator" },
+        {
           label: "Command Palette",
           accelerator: "CmdOrCtrl+/",
           click: () => send("toggle-command-palette"),

--- a/src/preload.js
+++ b/src/preload.js
@@ -20,6 +20,8 @@ const channels = [
   "focus-terminal",
   "toggle-command-palette",
   "toggle-pane-focus",
+  "jump-recent-idle",
+  "archive-current-session",
 ];
 for (const ch of channels) ipcRenderer.removeAllListeners(ch);
 
@@ -116,4 +118,8 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.on("toggle-command-palette", () => callback()),
   onTogglePaneFocus: (callback) =>
     ipcRenderer.on("toggle-pane-focus", () => callback()),
+  onJumpRecentIdle: (callback) =>
+    ipcRenderer.on("jump-recent-idle", () => callback()),
+  onArchiveCurrentSession: (callback) =>
+    ipcRenderer.on("archive-current-session", () => callback()),
 });

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1478,6 +1478,31 @@ function switchSession(direction) {
   selectSession(navigable[nextIndex]);
 }
 
+// --- Jump to most recent idle session ---
+function jumpToRecentIdle() {
+  const idle = cachedSessions.find(
+    (s) => s.status === "idle" && s.sessionId !== currentSessionId,
+  );
+  if (idle) selectSession(idle);
+}
+
+// --- Archive current session (then jump to recent idle) ---
+async function archiveCurrentSession() {
+  if (!currentSessionId) return;
+  const session = cachedSessions.find((s) => s.sessionId === currentSessionId);
+  if (!session) return;
+  // Can't archive already-archived sessions
+  if (session.status === "archived") return;
+
+  await window.api.archiveSession(currentSessionId);
+  await loadSessions();
+  // Jump to the most recent idle session
+  const idle = cachedSessions.find((s) => s.status === "idle");
+  if (idle) {
+    selectSession(idle);
+  }
+}
+
 // --- Sidebar toggle ---
 function toggleSidebar() {
   sidebar.classList.toggle("collapsed");
@@ -1549,6 +1574,18 @@ const COMMANDS = [
           (activeTermIndex - 1 + terminals.length) % terminals.length,
         );
     },
+  },
+  {
+    id: "jump-recent-idle",
+    label: "Jump to Recent Idle",
+    shortcut: "⌘J",
+    action: jumpToRecentIdle,
+  },
+  {
+    id: "archive-current-session",
+    label: "Archive Current Session",
+    shortcut: "⌘D",
+    action: archiveCurrentSession,
   },
   {
     id: "toggle-sidebar",
@@ -1758,6 +1795,8 @@ window.api.onTogglePaneFocus(() => {
     focusEditor();
   }
 });
+window.api.onJumpRecentIdle(jumpToRecentIdle);
+window.api.onArchiveCurrentSession(archiveCurrentSession);
 
 // Reconnect a single PTY from daemon (after app restart or reload)
 async function reconnectTerminal(ptyInfo) {


### PR DESCRIPTION
## Summary

- **Cmd+J**: Jump to the most recent idle session
- **Cmd+D**: Archive the current session, then auto-jump to the most recent idle session
- New `docs/shortcuts.md` with full shortcut reference and guide for adding new shortcuts
- CLAUDE.md convention: every user-facing action must have a keyboard shortcut

## Test plan

- [ ] Cmd+J switches to the most recent idle session
- [ ] Cmd+D archives the current session and lands on the next idle one
- [ ] Both appear in the Navigate menu and command palette (Cmd+/)
- [ ] All 88 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)