### PR TITLE
Fix trust prompt reliability during pool init

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -984,32 +984,64 @@ function writePool(pool) {
 }
 
 // Poll a terminal's buffer for the trust prompt and send Enter to accept it.
-// Returns true if prompt was found and accepted, false if timed out.
-async function waitForTrustPromptAndAccept(termId, timeoutMs = 10000) {
-  const POLL_INTERVAL = 300;
+// Uses read-buffer (single terminal) instead of list (all terminals) to avoid
+// socket contention when many slots poll simultaneously.
+// Verifies the prompt was actually dismissed after sending Enter.
+async function waitForTrustPromptAndAccept(termId, timeoutMs = 15000) {
+  const POLL_INTERVAL = 200;
+  const VERIFY_INTERVAL = 150;
+  const VERIFY_TIMEOUT = 3000;
+  const MAX_RETRIES = 3;
   const TRUST_PATTERNS = ["Do you trust", "trust the files"];
+
+  const bufferHasTrustPrompt = (buffer) =>
+    TRUST_PATTERNS.some((pat) => buffer.includes(pat));
+
+  const readBuffer = async () => {
+    const resp = await daemonRequest({ type: "read-buffer", termId });
+    return resp.buffer || "";
+  };
+
   let elapsed = 0;
   while (elapsed < timeoutMs) {
+    let buffer;
     try {
-      const resp = await daemonRequest({ type: "list" });
-      const pty = resp.ptys.find((p) => p.termId === termId);
-      if (pty && pty.buffer) {
-        const hasTrustPrompt = TRUST_PATTERNS.some((pat) =>
-          pty.buffer.includes(pat),
-        );
-        if (hasTrustPrompt) {
-          daemonSend({ type: "write", termId, data: "\r" });
-          return true;
-        }
-      }
+      buffer = await readBuffer();
     } catch {
-      // Daemon disconnected or terminal gone — stop polling
+      return false; // Daemon gone
+    }
+
+    if (bufferHasTrustPrompt(buffer)) {
+      // Trust prompt detected — send Enter and verify it was accepted
+      for (let _attempt = 0; _attempt < MAX_RETRIES; _attempt++) {
+        daemonSend({ type: "write", termId, data: "\r" });
+        // Verify the prompt disappeared
+        const verifyStart = Date.now();
+        while (Date.now() - verifyStart < VERIFY_TIMEOUT) {
+          await new Promise((r) => setTimeout(r, VERIFY_INTERVAL));
+          try {
+            const newBuffer = await readBuffer();
+            if (!bufferHasTrustPrompt(newBuffer)) return true; // Confirmed
+          } catch {
+            return false;
+          }
+        }
+        // Prompt still there — retry
+        console.warn(
+          `[pool] Trust prompt still present after Enter (termId=${termId}), retrying...`,
+        );
+      }
+      // All retries exhausted but prompt still present
+      console.error(
+        `[pool] Failed to dismiss trust prompt after ${MAX_RETRIES} retries (termId=${termId})`,
+      );
       return false;
     }
+
     await new Promise((r) => setTimeout(r, POLL_INTERVAL));
     elapsed += POLL_INTERVAL;
   }
-  // Fallback: send Enter anyway in case we missed the prompt (e.g. buffer wrapped)
+  // Fallback: send Enter in case prompt appeared but wasn't pattern-matched
   daemonSend({ type: "write", termId, data: "\r" });
   return false;
 }


### PR DESCRIPTION
## Summary

- **Use `read-buffer` instead of `list` RPC** for trust prompt polling — avoids serializing all terminal buffers (N² contention when N slots poll simultaneously)
- **Verify prompt dismissal after sending Enter** — polls buffer to confirm trust prompt text disappeared, retries up to 3 times if not
- **Use `Date.now()` for verify timeout** — accurate wall-clock timing regardless of async delays
- Increased detection window from 10s→15s and poll interval from 300ms→200ms for faster detection

### Root cause

When initializing a pool with many slots, all slots simultaneously called the `list` RPC (which serializes ALL terminal buffers) every 300ms. This created socket backpressure, causing the fire-and-forget Enter keystroke (`daemonSend`) to be delayed or lost. The old code returned immediately after sending Enter without verifying the prompt was actually dismissed.

## Test plan

- [ ] `pool-destroy` then `pool-init` with 8+ slots — all should reach `fresh` status
- [ ] Repeat 3-5 times to verify reliability
- [ ] Check console for any retry warnings (indicates marginal timing, not failure)
- [ ] Single slot init still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)