### PR TITLE
Fix terminal scrambling on reload by matching PTY dimensions

### DIFF
--- a/src/pty-daemon.js
+++ b/src/pty-daemon.js
@@ -125,6 +125,8 @@ function handleSpawn(socket, msg) {
       cwd,
       pid: proc.pid,
       exited: false,
+      cols: msg.cols || 80,
+      rows: msg.rows || 24,
     },
     chunks: [],
     chunksLen: 0,
@@ -177,6 +179,8 @@ function handleResize(msg) {
   const entry = terminals.get(msg.termId);
   if (entry && !entry.meta.exited) {
     entry.proc.resize(msg.cols, msg.rows);
+    entry.meta.cols = msg.cols;
+    entry.meta.rows = msg.rows;
   }
 }
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1816,6 +1816,9 @@ async function reconnectTerminal(ptyInfo) {
     fontFamily: "'SF Mono', Menlo, monospace",
     fontSize: 13,
     cursorBlink: true,
+    // Match the PTY's current dimensions so replay buffer renders correctly
+    ...(ptyInfo.cols && { cols: ptyInfo.cols }),
+    ...(ptyInfo.rows && { rows: ptyInfo.rows }),
   });
 
   const fitAddon = new FitAddon();


### PR DESCRIPTION
## Summary

- **Daemon**: tracks `cols`/`rows` in terminal meta (set on spawn, updated on resize), already exposed via list response
- **Renderer**: initializes xterm at PTY's actual dimensions during `reconnectTerminal()` so the replay buffer renders correctly

Complements b8f0020 which added `ptyResize` to `switchToTerminal` — that fixed the final state after SIGWINCH but not the initial replay rendering (buffer was written into 80×24 xterm when PTY was at e.g. 142×38).

## Test plan

- [ ] Open a session, interact with Claude so there's substantial terminal output
- [ ] Cmd+R to reload — terminal content should not be scrambled
- [ ] Cursor should be at the correct position after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)