### PR TITLE
Detect dead external sessions within 3s instead of 30s

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2036,6 +2036,40 @@ app.whenReady().then(async () => {
     }
   }
 
+  // Lightweight periodic liveness check: detect dead processes between fingerprint refreshes.
+  // process.kill(pid, 0) is a single syscall per PID — no subprocess overhead.
+  // Note: PID reuse could cause a false "alive" — extremely unlikely on macOS and harmless
+  // (the stale PID file gets cleaned up on the next full refresh anyway).
+  const LIVENESS_CHECK_INTERVAL = 3000;
+  const knownAlivePids = new Set();
+  setInterval(() => {
+    if (!fs.existsSync(SESSION_PIDS_DIR)) return;
+    let files;
+    try {
+      files = fs.readdirSync(SESSION_PIDS_DIR);
+    } catch {
+      return;
+    }
+    const currentFiles = new Set(files);
+    for (const pid of knownAlivePids) {
+      if (!currentFiles.has(pid)) knownAlivePids.delete(pid);
+    }
+    let anyDied = false;
+    for (const pid of files) {
+      if (!/^\d+$/.test(pid)) continue;
+      try {
+        process.kill(Number(pid), 0);
+        knownAlivePids.add(pid);
+      } catch {
+        if (knownAlivePids.has(pid)) {
+          knownAlivePids.delete(pid);
+          anyDied = true;
+        }
+      }
+    }
+    if (anyDied) onDirChange();
+  }, LIVENESS_CHECK_INTERVAL);
+
   ipcMain.handle("get-dir-colors", () => {
     try {
       return JSON.parse(fs.readFileSync(COLORS_FILE, "utf-8"));


### PR DESCRIPTION
## Summary

- Adds a lightweight periodic liveness check (every 3s) that does `process.kill(pid, 0)` for tracked PIDs
- When a death is detected, triggers `onDirChange()` → cache invalidation → renderer notification
- Handles edge cases: `.DS_Store` filtering, unbounded set pruning, batches multiple deaths per tick

**Before:** External session death took up to ~35s to show (30s `MAX_FINGERPRINT_AGE` + 5s renderer poll)
**After:** Detection within ~3s (liveness interval) + 200ms (debounce) + next renderer poll

## Test plan

- [ ] Kill an external Claude session terminal — sidebar should update within ~3-5s
- [ ] Verify pool sessions still detect death correctly
- [ ] Verify no excessive CPU usage (liveness check is just syscalls, no subprocesses)
- [ ] All 144 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)