### PR TITLE
Fix fresh external sessions showing as processing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -484,7 +484,8 @@ async function getSessionsUncached() {
         idleTs = mtime;
       } else {
         staleLoggedSessions.delete(sessionId);
-        status = "processing";
+        const jsonlPath = jsonlPathCache.get(sessionId);
+        status = hasUserInput(jsonlPath) ? "processing" : "fresh";
       }
     }
 


### PR DESCRIPTION
## Summary

- Fresh external sessions (never had user input) were misclassified as "processing" and incorrectly shown in the sidebar
- **Root cause:** External sessions don't get `createFreshIdleSignal()` like pool sessions do, so they hit the no-idle-signal fallback branch which unconditionally returned "processing"
- **Fix:** Check `hasUserInput()` in the fallback branch — sessions without user input are now correctly marked "fresh" (and hidden from sidebar)

## Test plan

- [x] All 144 existing tests pass
- [ ] Start a fresh `claude` session externally → should NOT appear in sidebar as "processing"
- [ ] Start an external session and type something → should appear as "processing" then "idle"
- [ ] Pool sessions unaffected (they have idle signals, never hit this code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)