### PR TITLE
Fix /clear leaving session without idle signal (stale idle)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/idle-signal.sh clear"
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/idle-signal.sh write session-clear"
           }
         ]
       }

--- a/src/main.js
+++ b/src/main.js
@@ -88,7 +88,7 @@ const jsonlPathCache = new Map();
 // If a "processing" session's transcript hasn't been written to in this long, treat as idle
 const STALE_PROCESSING_MS = 5 * 60 * 1000; // 5 minutes
 
-// Deduplicate stale processing log messages (only log once per session)
+// Track stale sessions to detect transitions (stale → not-stale)
 const staleLoggedSessions = new Set();
 
 // Cache hasUserInput results (transcript -> true, once true stays true)
@@ -473,17 +473,20 @@ async function getSessionsUncached() {
       // Fallback: if transcript hasn't been written to in a while, treat as idle
       const mtime = await getJsonlMtime(sessionId);
       if (mtime && Date.now() - mtime > STALE_PROCESSING_MS) {
-        if (!staleLoggedSessions.has(sessionId)) {
-          staleLoggedSessions.add(sessionId);
-          console.warn(
-            `[main] Stale processing detected for session ${sessionId} (no activity for ${Math.round((Date.now() - mtime) / 1000)}s) — treating as idle. Idle signal hook may have failed.`,
-          );
-        }
+        // Always log — stale sessions indicate a hook failure and should never happen
+        console.error(
+          `[main] Stale processing detected for session ${sessionId} (no activity for ${Math.round((Date.now() - mtime) / 1000)}s) — treating as idle. Idle signal hook may have failed.`,
+        );
+        staleLoggedSessions.add(sessionId);
         status = "idle";
         staleIdle = true;
         idleTs = mtime;
       } else {
-        staleLoggedSessions.delete(sessionId);
+        if (staleLoggedSessions.delete(sessionId)) {
+          console.log(
+            `[main] Session ${sessionId} is no longer stale (resumed processing).`,
+          );
+        }
         const jsonlPath = jsonlPathCache.get(sessionId);
         status = hasUserInput(jsonlPath) ? "processing" : "fresh";
       }

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -232,6 +232,41 @@ describe("idle-signal.sh", () => {
     const content = JSON.parse(fs.readFileSync(signalFile, "utf-8"));
     expect(content.trigger).toBe("permission");
   });
+
+  it("writes signal file on 'write session-clear' (replaces old signal)", () => {
+    // Simulate existing idle signal from before /clear
+    const signalFile = path.join(
+      tmpHome,
+      ".open-cockpit/idle-signals",
+      hookPid(),
+    );
+    fs.writeFileSync(signalFile, '{"trigger":"stop","ts":1000}');
+
+    runHook("idle-signal.sh", {
+      args: ["write", "session-clear"],
+      stdin: JSON.stringify({ session_id: FAKE_SESSION_ID }),
+    });
+    expect(fs.existsSync(signalFile)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(signalFile, "utf-8"));
+    expect(content.trigger).toBe("session-clear");
+    expect(content.session_id).toBe(FAKE_SESSION_ID);
+    expect(content.ts).toBeGreaterThan(1000);
+  });
+});
+
+describe("hooks.json - regression guards", () => {
+  it("SessionStart/clear writes idle signal (not just clears)", () => {
+    const hooksJson = JSON.parse(
+      fs.readFileSync(path.join(HOOKS_DIR, "hooks.json"), "utf-8"),
+    );
+    const clearEntry = hooksJson.hooks.SessionStart.find(
+      (e) => e.matcher === "clear",
+    );
+    expect(clearEntry).toBeDefined();
+    const cmd = clearEntry.hooks[0].command;
+    expect(cmd).toContain("idle-signal.sh write");
+    expect(cmd).not.toMatch(/idle-signal\.sh clear/);
+  });
 });
 
 describe("all hooks - robustness", () => {


### PR DESCRIPTION
## Summary

- After `/clear`, the `SessionStart` hook only cleared the idle signal without writing a new one. Since no `Stop` hook fires after `/clear`, the session had no signal and fell through to the 5-minute stale processing fallback — showing as "stale idle" in the UI.
- **Fix**: SessionStart/clear now calls `idle-signal.sh write session-clear` (immediate write, no delay) instead of `idle-signal.sh clear`
- Stale detection logging upgraded: `console.warn` → `console.error`, logs every occurrence (not just first), and logs recovery transitions

## Test plan

- [x] `write session-clear` test: verifies signal file is written with correct trigger and session ID
- [x] `hooks.json` regression guard: verifies SessionStart/clear calls `write` not `clear`
- [x] All 146 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)