### PR TITLE
Add persistent debug logging for main and renderer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ New sessions will have the latest hooks.
 - `~/.open-cockpit/pool.json` — Pool state (slots, sizes, session mappings)
 - `~/.open-cockpit/offloaded/<sessionId>/` — Offloaded/archived session data (meta.json, snapshot.log)
 - `~/.open-cockpit/setup-scripts/` — Setup script files for Cmd+N picker
+- `~/.open-cockpit/debug.log` — Debug log (both main + renderer, rotates at 2 MB)
 - `~/.open-cockpit/api.sock` — Programmatic API Unix socket
 - `~/.open-cockpit/pty-daemon.sock` — PTY daemon Unix socket
 - `~/.open-cockpit/pty-daemon.pid` — PTY daemon PID file
@@ -136,6 +137,7 @@ DAEMON_PID=$(cat ~/.open-cockpit/pty-daemon.pid 2>/dev/null || echo NONE); lsof 
 - [docs/hooks.md](docs/hooks.md) — Plugin hooks
 - [docs/api.md](docs/api.md) — Programmatic API (Unix socket, CLI helper)
 - [docs/shortcuts.md](docs/shortcuts.md) — Keyboard shortcuts reference + how to add new ones
+- [docs/debug-logging.md](docs/debug-logging.md) — Persistent debug logging (`~/.open-cockpit/debug.log`)
 
 ## Session origin tags
 

--- a/docs/debug-logging.md
+++ b/docs/debug-logging.md
@@ -1,0 +1,72 @@
+# Debug Logging
+
+Persistent file-based logging for both main and renderer processes. Logs write to `~/.open-cockpit/debug.log`.
+
+## Usage
+
+### Main process
+
+```js
+debugLog("main", "message", optionalData);
+```
+
+### Renderer process
+
+```js
+debugLog("tag", "message", optionalData);
+// Automatically prefixed as "renderer:tag" in the log file
+```
+
+The renderer helper sends logs to main via IPC (`debug-log` channel). It's safe to call before the API is ready (uses optional chaining).
+
+## Log format
+
+```
+2026-03-05T14:23:01.123Z [renderer:session] select abc123 gen=5 origin=pool
+2026-03-05T14:23:01.456Z [main] starting (dev) pid=12345
+```
+
+Each line: ISO timestamp, tag in brackets, message. Non-string arguments are JSON-serialized.
+
+## Rotation
+
+Log rotates at 2 MB. Previous log is kept as `debug.log.1`. Only one generation of backup is retained.
+
+## Current instrumentation
+
+### Renderer (`renderer:*`)
+
+| Tag | What's logged |
+|-----|--------------|
+| `renderer:session` | Session selection, race-condition aborts (with generation counter) |
+| `renderer:pool` | Offload attempts, fresh-slot polling, poll timeouts, resume failures |
+| `renderer:term` | Terminal attach failures |
+| `renderer:editor` | Intention save failures |
+| `renderer:startup` | PTY reconnection count, orphaned PTY detach |
+
+### Main (`main`)
+
+| What's logged |
+|--------------|
+| App startup (dev/prod mode, PID) |
+
+## Reading logs
+
+```bash
+# Tail live
+tail -f ~/.open-cockpit/debug.log
+
+# Search for session race aborts
+grep "race abort" ~/.open-cockpit/debug.log
+
+# Search for pool issues
+grep "renderer:pool" ~/.open-cockpit/debug.log
+```
+
+## Adding new log points
+
+1. **Renderer**: Call `debugLog("tag", "message", ...args)` — the helper is available globally in `renderer.js`
+2. **Main**: Call `debugLog("tag", "message", ...args)` — the function is defined at the top of `main.js`
+3. Use descriptive tags: `session`, `pool`, `term`, `editor`, `startup`, `api`, etc.
+4. Include identifiers (session IDs, term IDs, generation counters) for traceability
+5. Log at decision points, not on every event — keep volume reasonable

--- a/src/main.js
+++ b/src/main.js
@@ -49,7 +49,44 @@ const OFFLOADED_DIR = path.join(OPEN_COCKPIT_DIR, "offloaded");
 const POOL_FILE = path.join(OPEN_COCKPIT_DIR, "pool.json");
 const SETUP_SCRIPTS_DIR = path.join(OPEN_COCKPIT_DIR, "setup-scripts");
 const API_SOCKET = path.join(OPEN_COCKPIT_DIR, "api.sock");
+const DEBUG_LOG_FILE = path.join(OPEN_COCKPIT_DIR, "debug.log");
+const DEBUG_LOG_MAX_SIZE = 2 * 1024 * 1024; // 2 MB
 const DEFAULT_POOL_SIZE = 5;
+
+// --- Debug logging ---
+// Append timestamped lines to ~/.open-cockpit/debug.log.
+// Used by both main and renderer (via IPC). Rotates at 2 MB.
+let debugLogFd = null;
+let debugLogSize = 0;
+function debugLog(tag, ...args) {
+  const line = `${new Date().toISOString()} [${tag}] ${args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ")}\n`;
+  try {
+    if (!debugLogFd) {
+      debugLogFd = fs.openSync(DEBUG_LOG_FILE, "a", 0o600);
+      debugLogSize = fs.fstatSync(debugLogFd).size;
+    }
+    if (debugLogSize > DEBUG_LOG_MAX_SIZE) {
+      fs.closeSync(debugLogFd);
+      try {
+        fs.renameSync(DEBUG_LOG_FILE, DEBUG_LOG_FILE + ".1");
+      } catch {}
+      debugLogFd = fs.openSync(DEBUG_LOG_FILE, "a", 0o600);
+      debugLogSize = 0;
+    }
+    fs.writeSync(debugLogFd, line);
+    debugLogSize += Buffer.byteLength(line);
+  } catch {
+    // Last resort — don't crash the app over logging
+  }
+}
+function closeDebugLog() {
+  if (debugLogFd !== null) {
+    try {
+      fs.closeSync(debugLogFd);
+    } catch {}
+    debugLogFd = null;
+  }
+}
 
 // Poll a condition until it returns a truthy value, with timeout.
 // Returns the truthy value, or throws on timeout.
@@ -1993,6 +2030,7 @@ function handleDaemonMessage(msg) {
 }
 
 app.whenReady().then(async () => {
+  debugLog("main", `starting${IS_DEV ? " (dev)" : ""} pid=${process.pid}`);
   // Ensure setup-scripts directory exists
   secureMkdirSync(SETUP_SCRIPTS_DIR, { recursive: true });
 
@@ -2073,6 +2111,9 @@ app.whenReady().then(async () => {
     if (anyDied) onDirChange();
   }, LIVENESS_CHECK_INTERVAL);
 
+  ipcMain.on("debug-log", (_e, tag, args) => {
+    debugLog(tag, ...args);
+  });
   ipcMain.handle("get-dir-colors", () => {
     try {
       return JSON.parse(fs.readFileSync(COLORS_FILE, "utf-8"));
@@ -2675,6 +2716,7 @@ app.whenReady().then(async () => {
 });
 
 app.on("before-quit", () => {
+  closeDebugLog();
   // Disconnect from daemon (daemon keeps PTYs alive)
   if (daemonSocket && !daemonSocket.destroyed) {
     daemonSocket.destroy();

--- a/src/preload.js
+++ b/src/preload.js
@@ -26,6 +26,7 @@ const channels = [
 for (const ch of channels) ipcRenderer.removeAllListeners(ch);
 
 contextBridge.exposeInMainWorld("api", {
+  debugLog: (tag, ...args) => ipcRenderer.send("debug-log", tag, args),
   getDirColors: () => ipcRenderer.invoke("get-dir-colors"),
   getSessions: () => ipcRenderer.invoke("get-sessions"),
   readIntention: (sessionId) => ipcRenderer.invoke("read-intention", sessionId),

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -12,6 +12,11 @@ import { syntaxTree } from "@codemirror/language";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 
+// --- Debug logging (writes to ~/.open-cockpit/debug.log via main process) ---
+function debugLog(tag, ...args) {
+  window.api?.debugLog?.(`renderer:${tag}`, ...args);
+}
+
 // --- Bullet widget: replaces "- " / "* " / "1. " with rendered bullet ---
 class BulletWidget extends WidgetType {
   constructor(ordered, index) {
@@ -477,6 +482,7 @@ async function spawnTerminal(cwd, cmd, args) {
   try {
     await window.api.ptyAttach(termId);
   } catch (err) {
+    debugLog("term", `attach failed termId=${termId}`, err.message);
     const idx = terminals.indexOf(entry);
     if (idx !== -1) terminals.splice(idx, 1);
     term.dispose();
@@ -537,6 +543,7 @@ async function attachPoolTerminal(poolTermId) {
   try {
     await window.api.ptyAttach(poolTermId);
   } catch (err) {
+    debugLog("pool", `attach failed poolTermId=${poolTermId}`, err.message);
     const idx = terminals.indexOf(entry);
     if (idx !== -1) terminals.splice(idx, 1);
     term.dispose();
@@ -1127,11 +1134,15 @@ async function acquireFreshSlot() {
       { cwd: victim.cwd, gitRoot: victim.gitRoot, pid: victim.pid },
     );
   } catch (err) {
-    console.error("Failed to offload session:", err);
+    debugLog("pool", `offload failed session=${victim.sessionId}`, err.message);
     return null;
   }
 
   // Poll until the slot becomes fresh (idle signal changes after /clear)
+  debugLog(
+    "pool",
+    `polling for fresh slot after offload of ${victim.sessionId}`,
+  );
   const fresh = await pollForFreshSlot(30000);
   if (fresh) {
     destroySessionTerminals(victim.sessionId);
@@ -1154,8 +1165,12 @@ async function pollForFreshSlot(timeoutMs) {
     const fresh = sessions.find(
       (s) => s.status === "fresh" || poolFreshIds.has(s.sessionId),
     );
-    if (fresh) return fresh;
+    if (fresh) {
+      debugLog("pool", `fresh slot found: ${fresh.sessionId}`);
+      return fresh;
+    }
   }
+  debugLog("pool", `poll timed out after ${timeoutMs}ms — no fresh slot`);
   return null;
 }
 
@@ -1165,6 +1180,7 @@ async function resumeOffloadedSession(session) {
     const result = await window.api.poolResume(session.sessionId);
     showNotification(`Resuming session in slot ${result.slotIndex}…`);
   } catch (err) {
+    debugLog("pool", `resume failed session=${session.sessionId}`, err.message);
     showNotification(`Resume failed: ${err.message}`);
     return;
   }
@@ -1199,6 +1215,10 @@ async function selectSession(session) {
   currentSessionId = session.sessionId;
   currentSessionCwd = session.cwd;
   const gen = ++sessionGeneration;
+  debugLog(
+    "session",
+    `select ${session.sessionId} gen=${gen} origin=${session.origin}`,
+  );
 
   document.querySelectorAll(".session-item").forEach((el) => {
     el.classList.toggle("active", el.dataset.sessionId === session.sessionId);
@@ -1227,7 +1247,10 @@ async function selectSession(session) {
   // External sessions: try to focus their terminal app (iTerm/Cursor)
   if (session.origin !== "pool" && session.alive) {
     const result = await window.api.focusExternalTerminal(session.pid);
-    if (gen !== sessionGeneration) return;
+    if (gen !== sessionGeneration) {
+      debugLog("session", `race abort gen=${gen} at focusExternal`);
+      return;
+    }
     if (result.focused) {
       saveStatus.textContent = `Focused ${result.app}`;
       setTimeout(() => {
@@ -1242,21 +1265,27 @@ async function selectSession(session) {
     if (session.origin === "pool") {
       // Pool session: attach to the pool slot's existing Claude TUI
       const pool = await window.api.poolRead();
-      if (gen !== sessionGeneration) return;
+      if (gen !== sessionGeneration) {
+        debugLog("session", `race abort gen=${gen} at poolRead`);
+        return;
+      }
       const slot = pool?.slots.find((s) => s.sessionId === session.sessionId);
       if (slot) {
         try {
           const entry = await attachPoolTerminal(slot.termId);
           if (gen !== sessionGeneration) {
-            // Session changed while attaching — detach and clean up
-            // Also purge from sessionTerminals (hideCurrentTerminals may have cached it)
+            debugLog("session", `race abort gen=${gen} at poolAttach`);
             destroySessionTerminals(session.sessionId);
             return;
           }
         } catch {
-          // Attach failed (slot dead?) — fall back to fresh shell
+          debugLog(
+            "session",
+            `pool attach failed for slot ${slot.termId}, falling back to shell`,
+          );
           const entry = await spawnTerminal(session.cwd);
           if (gen !== sessionGeneration) {
+            debugLog("session", `race abort gen=${gen} at spawnFallback`);
             destroySessionTerminals(session.sessionId);
             return;
           }
@@ -1265,6 +1294,7 @@ async function selectSession(session) {
         // No pool slot found — fall back to fresh shell
         const entry = await spawnTerminal(session.cwd);
         if (gen !== sessionGeneration) {
+          debugLog("session", `race abort gen=${gen} at noSlotSpawn`);
           destroySessionTerminals(session.sessionId);
           return;
         }
@@ -1273,7 +1303,7 @@ async function selectSession(session) {
       // External session: spawn a fresh shell
       const entry = await spawnTerminal(session.cwd);
       if (gen !== sessionGeneration) {
-        // Session changed while spawning — orphan cleanup
+        debugLog("session", `race abort gen=${gen} at extSpawn`);
         destroySessionTerminals(session.sessionId);
         return;
       }
@@ -1451,7 +1481,11 @@ function scheduleSave() {
         if (saveStatus.textContent === "Saved") saveStatus.textContent = "";
       }, 2000);
     } catch (err) {
-      console.error("Failed to save intention:", err);
+      debugLog(
+        "editor",
+        `intention save failed session=${currentSessionId}`,
+        err.message,
+      );
       saveStatus.textContent = "";
     }
   }, 500);
@@ -1887,6 +1921,7 @@ async function reconnectTerminal(ptyInfo) {
 // On app start: reconnect to any PTYs that survived from previous instance
 async function reconnectAllPtys() {
   const ptys = await window.api.ptyList();
+  debugLog("startup", `reconnecting ${ptys.length} PTYs`);
   if (ptys.length === 0) return;
 
   // Identify pool slot termIds so we can tag reconnected terminals
@@ -1910,7 +1945,7 @@ async function reconnectAllPtys() {
   // Reconnect each session's terminals (skip orphaned terminals with no session)
   for (const [sid, sessionPtys] of bySession) {
     if (sid === "__none__") {
-      // Detach orphaned terminals — they have no session to display under
+      debugLog("startup", `detaching ${sessionPtys.length} orphaned PTYs`);
       for (const p of sessionPtys) {
         window.api.ptyDetach(p.termId).catch(() => {});
       }


### PR DESCRIPTION
## Summary

- Adds `debugLog(tag, ...args)` utility writing timestamped lines to `~/.open-cockpit/debug.log`
- 2 MB rotation with one backup generation (`.log.1`)
- Renderer logs via fire-and-forget IPC (`send`/`on`, no round-trip)
- Instrumented critical renderer paths: session switches, race-condition aborts, pool operations, terminal attach failures, PTY reconnection, intention save errors
- Main logs app startup (dev/prod, PID)
- fd properly cleaned up on app quit
- New doc: `docs/debug-logging.md`

## Test plan

- [x] Dev instance creates `~/.open-cockpit/debug.log` on startup
- [x] Log contains startup, PTY reconnection, and orphan detach entries
- [ ] Session switch logs `select` + `origin`
- [ ] Race-condition aborts logged with generation counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)