### PR TITLE
Add Cmd+O to focus external terminal

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -40,5 +40,6 @@ All shortcuts should also appear in the command palette (`Cmd+/`). The `COMMANDS
 | `Alt+Left` / `Alt+Right` | Toggle Pane Focus |
 | `Cmd+E` | Focus Editor |
 | `` Cmd+` `` | Focus Terminal |
+| `Cmd+O` | Focus External Terminal |
 | `Escape` | Focus Terminal |
 | `Cmd+/` | Command Palette |

--- a/src/main.js
+++ b/src/main.js
@@ -2654,6 +2654,11 @@ app.whenReady().then(async () => {
           accelerator: "CmdOrCtrl+`",
           click: () => send("focus-terminal"),
         },
+        {
+          label: "Focus External Terminal",
+          accelerator: "CmdOrCtrl+O",
+          click: () => send("focus-external"),
+        },
         { type: "separator" },
         {
           label: "Jump to Recent Idle",

--- a/src/preload.js
+++ b/src/preload.js
@@ -20,6 +20,7 @@ const channels = [
   "focus-terminal",
   "toggle-command-palette",
   "toggle-pane-focus",
+  "focus-external",
   "jump-recent-idle",
   "archive-current-session",
 ];
@@ -120,6 +121,8 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.on("toggle-command-palette", () => callback()),
   onTogglePaneFocus: (callback) =>
     ipcRenderer.on("toggle-pane-focus", () => callback()),
+  onFocusExternalTerminal: (callback) =>
+    ipcRenderer.on("focus-external", () => callback()),
   onJumpRecentIdle: (callback) =>
     ipcRenderer.on("jump-recent-idle", () => callback()),
   onArchiveCurrentSession: (callback) =>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1195,20 +1195,8 @@ function showNotification(msg) {
 }
 
 async function selectSession(session) {
-  // If already viewing this session, re-focus its external terminal (if any)
-  if (session.sessionId === currentSessionId) {
-    if (session.alive) {
-      const result = await window.api.focusExternalTerminal(session.pid);
-      if (result.focused) {
-        saveStatus.textContent = `Focused ${result.app}`;
-        setTimeout(() => {
-          if (saveStatus.textContent === `Focused ${result.app}`)
-            saveStatus.textContent = "";
-        }, 2000);
-      }
-    }
-    return;
-  }
+  // If already viewing this session, nothing to do
+  if (session.sessionId === currentSessionId) return;
 
   hideCurrentTerminals();
 
@@ -1242,22 +1230,6 @@ async function selectSession(session) {
     colorBar.style.background = dirColor;
     colorBar.style.boxShadow = `0 0 8px ${dirColor}`;
     header.appendChild(colorBar);
-  }
-
-  // External sessions: try to focus their terminal app (iTerm/Cursor)
-  if (session.origin !== "pool" && session.alive) {
-    const result = await window.api.focusExternalTerminal(session.pid);
-    if (gen !== sessionGeneration) {
-      debugLog("session", `race abort gen=${gen} at focusExternal`);
-      return;
-    }
-    if (result.focused) {
-      saveStatus.textContent = `Focused ${result.app}`;
-      setTimeout(() => {
-        if (saveStatus.textContent === `Focused ${result.app}`)
-          saveStatus.textContent = "";
-      }, 2000);
-    }
   }
 
   // Restore cached terminals immediately (sync, no race risk)
@@ -1535,6 +1507,14 @@ function jumpToRecentIdle() {
   if (idle) selectSession(idle);
 }
 
+// --- Focus external terminal for current session ---
+async function focusCurrentExternalTerminal() {
+  const session = cachedSessions.find((s) => s.sessionId === currentSessionId);
+  if (!session || !session.alive || session.origin === "pool") return;
+  const result = await window.api.focusExternalTerminal(session.pid);
+  if (result.focused) showNotification(`Focused ${result.app}`);
+}
+
 // --- Archive current session (then jump to recent idle) ---
 async function archiveCurrentSession() {
   if (!currentSessionId) return;
@@ -1657,6 +1637,12 @@ const COMMANDS = [
     label: "Focus Terminal",
     shortcut: "⌘`",
     action: focusTerminal,
+  },
+  {
+    id: "focus-external-terminal",
+    label: "Focus External Terminal",
+    shortcut: "⌘O",
+    action: focusCurrentExternalTerminal,
   },
   {
     id: "toggle-pane-focus",
@@ -1848,6 +1834,7 @@ window.api.onTogglePaneFocus(() => {
     focusEditor();
   }
 });
+window.api.onFocusExternalTerminal(focusCurrentExternalTerminal);
 window.api.onJumpRecentIdle(jumpToRecentIdle);
 window.api.onArchiveCurrentSession(archiveCurrentSession);
 


### PR DESCRIPTION
## Summary

- Clicking/navigating to an external session no longer auto-focuses its terminal app (iTerm/Cursor)
- New `Cmd+O` shortcut explicitly brings the current session's external terminal to front
- Available in command palette as "Focus External Terminal"

## Changes

- Removed auto-focus from `selectSession()` (both initial select and re-click paths)
- Added `focusCurrentExternalTerminal()` — uses existing `showNotification()`, skips pool sessions
- Wired through all three layers: menu accelerator → preload bridge → renderer action

## Test plan

- [ ] Navigate to an external session — should NOT auto-focus its terminal
- [ ] Press `Cmd+O` on an external session — should focus its terminal + show notification
- [ ] Press `Cmd+O` on a pool session — should do nothing (no external terminal)
- [ ] `Alt+Down/Up` and `Cmd+J` still navigate instantly without focusing external terminals
- [ ] Command palette shows "Focus External Terminal" with ⌘O

🤖 Generated with [Claude Code](https://claude.com/claude-code)