### PR TITLE
Fix Cmd+D archive: instant switch + correct fresh status

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -909,6 +909,8 @@ async function offloadSession(
             s.sessionId = newSessionId;
             s.status = newSessionId ? "fresh" : "error";
             writePool(p);
+            // Write idle signal so getSessions detects slot as "fresh" (no user input)
+            if (newSessionId) createFreshIdleSignal(s.pid, newSessionId);
           }
         });
       })

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1523,17 +1523,25 @@ async function archiveCurrentSession() {
   // Can't archive already-archived sessions
   if (session.status === "archived") return;
 
+  const archivingSessionId = currentSessionId;
+
+  // Jump away immediately — don't wait for the slow offload+/clear
+  const idle = cachedSessions.find(
+    (s) =>
+      s.sessionId !== archivingSessionId &&
+      (s.status === "idle" || s.status === "fresh"),
+  );
+  if (idle) {
+    selectSession(idle);
+  }
+
+  // Archive in background
   try {
-    await window.api.archiveSession(currentSessionId);
+    await window.api.archiveSession(archivingSessionId);
   } catch (err) {
     console.error("Failed to archive session:", err);
   }
   await loadSessions();
-  // Jump to the most recent idle session
-  const idle = cachedSessions.find((s) => s.status === "idle");
-  if (idle) {
-    selectSession(idle);
-  }
 }
 
 // --- Sidebar toggle ---


### PR DESCRIPTION
## Summary
- **Instant session switch**: Cmd+D now jumps to the next idle/fresh session immediately instead of waiting for the slow offload+`/clear` to complete. Archive runs in the background.
- **Correct fresh status**: Added missing `createFreshIdleSignal()` call in `offloadSession` post-poll callback (already present in pool-init and reconcilePool), fixing sessions showing as "processing" instead of "fresh" after `/clear`.

## Test plan
- [ ] Press Cmd+D on an active session — should instantly jump to next idle/fresh session
- [ ] Verify the archived session disappears from processing and appears in archive
- [ ] After archiving, verify the freed slot shows as "fresh" (not "processing") in pool settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)