### PR TITLE
CLI: add input validation and response error checks

### DIFF
--- a/bin/cockpit-cli
+++ b/bin/cockpit-cli
@@ -3,10 +3,11 @@ set -euo pipefail
 
 SOCKET="$HOME/.open-cockpit/api.sock"
 
-# Validate that a slot index is a non-negative integer
-validate_slot() {
+# Validate that a value is a non-negative integer. Args: <value> [label]
+validate_int() {
+  local label="${2:-value}"
   if ! [[ "$1" =~ ^[0-9]+$ ]]; then
-    echo "Error: slot index must be a non-negative integer, got '$1'" >&2
+    echo "Error: $label must be a non-negative integer, got '$1'" >&2
     exit 1
   fi
 }
@@ -170,7 +171,7 @@ case "$CMD" in
     SESSION_ID="${1:?sessionId or --slot required}"
     if [[ "$SESSION_ID" == "--slot" ]]; then
       SLOT="${2:?slot index required}"
-      validate_slot "$SLOT"
+      validate_int "$SLOT" "slot index"
       json="{\"type\":\"pool-capture\",\"id\":1,\"slotIndex\":$SLOT}"
     else
       json="{\"type\":\"pool-capture\",\"id\":1,\"sessionId\":\"$SESSION_ID\"}"
@@ -184,7 +185,7 @@ case "$CMD" in
     SESSION_ID="${1:?sessionId or --slot required}"
     if [[ "$SESSION_ID" == "--slot" ]]; then
       SLOT="${2:?slot index required}"
-      validate_slot "$SLOT"
+      validate_int "$SLOT" "slot index"
       json="{\"type\":\"pool-result\",\"id\":1,\"slotIndex\":$SLOT}"
     else
       json="{\"type\":\"pool-result\",\"id\":1,\"sessionId\":\"$SESSION_ID\"}"
@@ -198,7 +199,7 @@ case "$CMD" in
     SESSION_ID="${1:?sessionId or --slot required}"
     if [[ "$SESSION_ID" == "--slot" ]]; then
       SLOT="${2:?slot index required}"
-      validate_slot "$SLOT"
+      validate_int "$SLOT" "slot index"
       TEXT=$(printf '%b' "${3:?text required}")
       DATA_JSON=$(printf '%s' "$TEXT" | jq -Rs .)
       json="{\"type\":\"pool-input\",\"id\":1,\"slotIndex\":$SLOT,\"data\":$DATA_JSON}"
@@ -227,8 +228,11 @@ case "$CMD" in
     case "$SUBCMD" in
       init)
         SIZE="${1:-5}"
+        validate_int "$SIZE" "pool size"
         json="{\"type\":\"pool-init\",\"id\":1,\"size\":$SIZE}"
-        send_api "$json" 120
+        RESULT=$(send_api "$json" 120)
+        check_error "$RESULT"
+        echo "$RESULT"
         ;;
       status)
         json="{\"type\":\"pool-health\",\"id\":1}"
@@ -236,12 +240,17 @@ case "$CMD" in
         ;;
       resize)
         SIZE="${1:?size required}"
+        validate_int "$SIZE" "pool size"
         json="{\"type\":\"pool-resize\",\"id\":1,\"size\":$SIZE}"
-        send_api "$json" 120
+        RESULT=$(send_api "$json" 120)
+        check_error "$RESULT"
+        echo "$RESULT"
         ;;
       destroy)
         json="{\"type\":\"pool-destroy\",\"id\":1}"
-        send_api "$json" 30
+        RESULT=$(send_api "$json" 30)
+        check_error "$RESULT"
+        echo "$RESULT"
         ;;
       *)
         echo "Unknown pool subcommand: $SUBCMD" >&2
@@ -259,7 +268,7 @@ case "$CMD" in
     case "$SUBCMD" in
       read)
         SLOT="${1:?slot index required}"
-        validate_slot "$SLOT"
+        validate_int "$SLOT" "slot index"
         json="{\"type\":\"slot-read\",\"id\":1,\"slotIndex\":$SLOT}"
         RESULT=$(send_api "$json")
         check_error "$RESULT"
@@ -267,7 +276,7 @@ case "$CMD" in
         ;;
       write)
         SLOT="${1:?slot index required}"
-        validate_slot "$SLOT"
+        validate_int "$SLOT" "slot index"
         TEXT="${2:?data required}"
         # Interpret escape sequences (\x1b, \r, \n, \t, etc.)
         TEXT=$(printf '%b' "$TEXT")
@@ -278,7 +287,7 @@ case "$CMD" in
         ;;
       status)
         SLOT="${1:?slot index required}"
-        validate_slot "$SLOT"
+        validate_int "$SLOT" "slot index"
         json="{\"type\":\"slot-status\",\"id\":1,\"slotIndex\":$SLOT}"
         send_api "$json"
         ;;
@@ -292,11 +301,11 @@ case "$CMD" in
 
   # --- Legacy flat commands (backward compatible) ---
 
-  pool-init)    json="{\"type\":\"pool-init\",\"id\":1,\"size\":${1:-5}}"; send_api "$json" 120 ;;
-  pool-resize)  json="{\"type\":\"pool-resize\",\"id\":1,\"size\":${1:?size required}}"; send_api "$json" 120 ;;
+  pool-init)    SIZE="${1:-5}"; validate_int "$SIZE" "pool size"; json="{\"type\":\"pool-init\",\"id\":1,\"size\":$SIZE}"; RESULT=$(send_api "$json" 120); check_error "$RESULT"; echo "$RESULT" ;;
+  pool-resize)  SIZE="${1:?size required}"; validate_int "$SIZE" "pool size"; json="{\"type\":\"pool-resize\",\"id\":1,\"size\":$SIZE}"; RESULT=$(send_api "$json" 120); check_error "$RESULT"; echo "$RESULT" ;;
   pool-health)  json="{\"type\":\"pool-health\",\"id\":1}"; send_api "$json" ;;
   pool-read)    json="{\"type\":\"pool-read\",\"id\":1}"; send_api "$json" ;;
-  pool-destroy) json="{\"type\":\"pool-destroy\",\"id\":1}"; send_api "$json" 30 ;;
+  pool-destroy) json="{\"type\":\"pool-destroy\",\"id\":1}"; RESULT=$(send_api "$json" 30); check_error "$RESULT"; echo "$RESULT" ;;
   get-sessions) json="{\"type\":\"get-sessions\",\"id\":1}"; send_api "$json" ;;
   read-intention)  json="{\"type\":\"read-intention\",\"id\":1,\"sessionId\":\"${1:?sessionId required}\"}"; send_api "$json" ;;
   write-intention) json="{\"type\":\"write-intention\",\"id\":1,\"sessionId\":\"${1:?sessionId required}\",\"content\":$(printf '%s' "${2:?content required}" | jq -Rs .)}"; send_api "$json" ;;


### PR DESCRIPTION
## Summary

- Generalize `validate_slot()` into `validate_int()` with a configurable label parameter
- Validate numeric arguments before `pool-init`, `pool-resize`, and all slot index commands — prints clear error and exits 1 on invalid input
- `pool-init`, `pool-resize`, `pool-destroy` now read the API response and check for error fields (both `pool` subcommand and legacy flat command variants)

Fixes #139

## Test plan

- [ ] `cockpit-cli pool init abc` → prints "pool size must be a non-negative integer" and exits 1
- [ ] `cockpit-cli pool resize -3` → same validation error
- [ ] `cockpit-cli slot read foo` → prints "slot index must be a non-negative integer"
- [ ] `cockpit-cli pool init 3` with app running → succeeds, prints response JSON
- [ ] `cockpit-cli pool destroy` with app running → succeeds, prints response JSON
- [ ] `npm test` passes (146 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)