### PR TITLE
Fix poolClean: deduplicate archive logic and prevent TOCTOU race

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1609,22 +1609,20 @@ async function poolClean() {
   });
   let cleaned = 0;
   for (const slot of idleSlots) {
-    const session = sessionMap.get(slot.sessionId);
+    // Re-check status before offloading (slot may have become busy since we read)
+    const currentSessions = await getSessions();
+    const currentSession = currentSessions.find(
+      (s) => s.sessionId === slot.sessionId,
+    );
+    if (!currentSession || currentSession.status !== "idle") {
+      continue;
+    }
     await offloadSession(slot.sessionId, slot.termId, null, {
-      cwd: session?.cwd,
-      gitRoot: session?.gitRoot,
+      cwd: currentSession.cwd,
+      gitRoot: currentSession.gitRoot,
       pid: slot.pid,
     });
-    // Mark as archived so it moves to Archive section instead of staying in Recent
-    const offloadedMeta = readOffloadMeta(slot.sessionId);
-    if (offloadedMeta && !offloadedMeta.archived) {
-      offloadedMeta.archived = true;
-      offloadedMeta.archivedAt = new Date().toISOString();
-      secureWriteFileSync(
-        path.join(OFFLOADED_DIR, slot.sessionId, "meta.json"),
-        JSON.stringify(offloadedMeta, null, 2),
-      );
-    }
+    await archiveSession(slot.sessionId);
     cleaned++;
   }
   return cleaned;


### PR DESCRIPTION
## Summary

- **#132**: Replace manual archive-marking block in `poolClean()` with `archiveSession()` call, eliminating duplicated `readOffloadMeta` + `secureWriteFileSync` logic. Since `offloadSession()` runs first, `archiveSession()` takes the fast path (meta already exists).
- **#137**: Re-check slot status via `getSessions()` before offloading each slot in the loop, preventing a TOCTOU race where a slot becomes busy between the initial idle check and the `/clear` send.

Closes #132
Closes #137

## Test plan

- [x] All 146 tests pass (`npm test`)
- [ ] Manual: run `pool-clean` while a session is transitioning from idle to processing — verify it skips the busy session

🤖 Generated with [Claude Code](https://claude.com/claude-code)