### PR TITLE
Fix #131, #138: Shared hook helpers + background cleanup

### DIFF
--- a/hooks/common.sh
+++ b/hooks/common.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# shellcheck disable=SC2034  # variables are used by sourcing scripts
+# Shared constants and helpers for all hooks.
+#
+# Usage (source from hook scripts):
+#   source "$(dirname "$0")/common.sh"
+#
+# This sources log-error.sh automatically — no need to source both.
+
+source "$(dirname "${BASH_SOURCE[0]}")/log-error.sh"
+
+# --- Directory constants (used by sourcing scripts) ---
+OC_DIR="$HOME/.open-cockpit"
+SESSION_PIDS_DIR="$OC_DIR/session-pids"
+SIGNAL_DIR="$OC_DIR/idle-signals"
+INTENTIONS_DIR="$OC_DIR/intentions"
+MARKER_DIR="$INTENTIONS_DIR/.intro-sent"
+SNAPSHOT_DIR="$INTENTIONS_DIR/.snapshots"
+
+# --- Shared helpers ---
+
+# Extract a JSON string value using sed (avoids python3 startup overhead).
+# Usage: json_get "$json_string" "key_name"
+json_get() {
+    echo "$1" | sed -n 's/.*"'"$2"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
+}
+
+# Resolve session_id from the PID mapping written by session-pid-map.sh.
+# Sets $session_id or exits 0 if not found.
+# Usage: resolve_session_id
+resolve_session_id() {
+    [ -f "$SESSION_PIDS_DIR/$PPID" ] || exit 0
+    session_id=$(cat "$SESSION_PIDS_DIR/$PPID")
+    [ -n "$session_id" ] || exit 0
+}

--- a/hooks/idle-signal.sh
+++ b/hooks/idle-signal.sh
@@ -15,9 +15,8 @@
 #        idle-signal.sh clear
 
 set -euo pipefail
-source "$(dirname "$0")/log-error.sh"
+source "$(dirname "$0")/common.sh"
 
-SIGNAL_DIR="$HOME/.open-cockpit/idle-signals"
 IDLE_VERIFY_DELAY=3
 mkdir -p "$SIGNAL_DIR"
 
@@ -35,11 +34,6 @@ read_input() {
         echo "$line"
         cat 2>/dev/null
     fi
-}
-
-# Extract a JSON string value using sed (avoids python3 startup overhead)
-json_get() {
-    echo "$1" | sed -n 's/.*"'"$2"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
 }
 
 # Cross-platform file size in bytes (macOS uses -f, Linux uses -c)

--- a/hooks/intention-change-notify.sh
+++ b/hooks/intention-change-notify.sh
@@ -6,23 +6,19 @@
 # Output (stdout): Always a reminder; includes diff if user edited the file
 
 set -euo pipefail
-source "$(dirname "$0")/log-error.sh"
+source "$(dirname "$0")/common.sh"
 
 # Skip if session-intention-intro.sh just fired (avoid redundant output on first prompt)
-JUST_FIRED="$HOME/.open-cockpit/intentions/.intro-sent/.just-fired"
+JUST_FIRED="$MARKER_DIR/.just-fired"
 if [ -f "$JUST_FIRED" ]; then
   rm -f "$JUST_FIRED"
   exit 0
 fi
 
 # Resolve session_id via PID mapping (written by session-pid-map.sh)
-SESSION_PIDS_DIR="$HOME/.open-cockpit/session-pids"
-[ -f "$SESSION_PIDS_DIR/$PPID" ] || exit 0
-session_id=$(cat "$SESSION_PIDS_DIR/$PPID")
-[ -n "$session_id" ] || exit 0
+resolve_session_id
 
-INTENTION_FILE="$HOME/.open-cockpit/intentions/${session_id}.md"
-SNAPSHOT_DIR="$HOME/.open-cockpit/intentions/.snapshots"
+INTENTION_FILE="$INTENTIONS_DIR/${session_id}.md"
 SNAPSHOT_FILE="$SNAPSHOT_DIR/${session_id}.md"
 
 mkdir -p "$SNAPSHOT_DIR"

--- a/hooks/session-intention-intro.sh
+++ b/hooks/session-intention-intro.sh
@@ -6,16 +6,12 @@
 # Output (stdout): Instructions injected into Claude's context (first prompt only)
 
 set -euo pipefail
-source "$(dirname "$0")/log-error.sh"
+source "$(dirname "$0")/common.sh"
 
 # Resolve session_id via PID mapping (written by session-pid-map.sh at SessionStart)
-SESSION_PIDS_DIR="$HOME/.open-cockpit/session-pids"
-[ -f "$SESSION_PIDS_DIR/$PPID" ] || exit 0
-session_id=$(cat "$SESSION_PIDS_DIR/$PPID")
-[ -n "$session_id" ] || exit 0
+resolve_session_id
 
 # Check if we already fired for this session ID (survives /clear → new session_id)
-MARKER_DIR="$HOME/.open-cockpit/intentions/.intro-sent"
 mkdir -p "$MARKER_DIR"
 
 MARKER_FILE="$MARKER_DIR/$session_id"
@@ -29,31 +25,33 @@ touch "$MARKER_FILE"
 # Signal to intention-change-notify.sh to skip this prompt (avoid redundant output)
 echo "$session_id" > "$MARKER_DIR/.just-fired"
 
-# Clean up markers for sessions that no longer have a live PID
-for f in "$MARKER_DIR"/*; do
-  [ -f "$f" ] || continue
-  name=$(basename "$f")
-  # Skip dotfiles (like .just-fired)
-  [[ "$name" == .* ]] && continue
-  # Skip current session
-  [ "$name" = "$session_id" ] && continue
-  # Check if any alive PID maps to this session
-  alive=false
-  for pf in "$SESSION_PIDS_DIR"/*; do
-    [ -f "$pf" ] || continue
-    pid=$(basename "$pf")
-    kill -0 "$pid" 2>/dev/null || continue
-    sid=$(cat "$pf" 2>/dev/null) || continue
-    if [ "$sid" = "$name" ]; then
-      alive=true
-      break
-    fi
+# Clean up markers for sessions that no longer have a live PID (background, #131)
+(
+  for f in "$MARKER_DIR"/*; do
+    [ -f "$f" ] || continue
+    name=$(basename "$f")
+    # Skip dotfiles (like .just-fired)
+    [[ "$name" == .* ]] && continue
+    # Skip current session
+    [ "$name" = "$session_id" ] && continue
+    # Check if any alive PID maps to this session
+    alive=false
+    for pf in "$SESSION_PIDS_DIR"/*; do
+      [ -f "$pf" ] || continue
+      pid=$(basename "$pf")
+      kill -0 "$pid" 2>/dev/null || continue
+      sid=$(cat "$pf" 2>/dev/null) || continue
+      if [ "$sid" = "$name" ]; then
+        alive=true
+        break
+      fi
+    done
+    $alive || rm -f "$f"
   done
-  $alive || rm -f "$f"
-done
+) &
+disown
 
-INTENTION_FILE="$HOME/.open-cockpit/intentions/${session_id}.md"
-SNAPSHOT_DIR="$HOME/.open-cockpit/intentions/.snapshots"
+INTENTION_FILE="$INTENTIONS_DIR/${session_id}.md"
 mkdir -p "$SNAPSHOT_DIR"
 
 # Create initial snapshot for change detection (used by intention-change-notify.sh)

--- a/hooks/session-pid-map.sh
+++ b/hooks/session-pid-map.sh
@@ -6,37 +6,36 @@
 # Output: ~/.open-cockpit/session-pids/<PID> containing the session ID
 
 set -euo pipefail
-source "$(dirname "$0")/log-error.sh"
+source "$(dirname "$0")/common.sh"
 
-SESSION_DIR="$HOME/.open-cockpit/session-pids"
-mkdir -p "$SESSION_DIR"
+mkdir -p "$SESSION_PIDS_DIR"
 
 # Read session_id from JSON stdin (avoid python3 startup overhead)
 input=""
 read -t 1 -r input 2>/dev/null || true
-session_id=$(echo "$input" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p') || true
+session_id=$(json_get "$input" "session_id") || true
 
 [ -z "$session_id" ] && exit 0
 
 # $PPID is the Claude process that spawned this hook
-echo "$session_id" > "$SESSION_DIR/$PPID"
+echo "$session_id" > "$SESSION_PIDS_DIR/$PPID"
 
 # Clean up stale entries (PIDs that no longer exist)
-for f in "$SESSION_DIR"/*; do
+for f in "$SESSION_PIDS_DIR"/*; do
     [ -f "$f" ] || continue
     pid=$(basename "$f")
     kill -0 "$pid" 2>/dev/null || rm -f "$f"
 done
 
 # Deduplicate: if another alive PID maps to same session_id, remove the older file
-for f in "$SESSION_DIR"/*; do
+for f in "$SESSION_PIDS_DIR"/*; do
     [ -f "$f" ] || continue
     pid=$(basename "$f")
     [ "$pid" = "$PPID" ] && continue
     kill -0 "$pid" 2>/dev/null || continue
     other_sid=$(cat "$f" 2>/dev/null) || continue
     if [ "$other_sid" = "$session_id" ]; then
-        if [ "$f" -ot "$SESSION_DIR/$PPID" ]; then
+        if [ "$f" -ot "$SESSION_PIDS_DIR/$PPID" ]; then
             rm -f "$f"
         fi
     fi


### PR DESCRIPTION
## Summary

- **#138 — Hooks shared helpers**: Created `hooks/common.sh` with centralized directory constants (`SESSION_PIDS_DIR`, `SIGNAL_DIR`, `INTENTIONS_DIR`, `MARKER_DIR`, `SNAPSHOT_DIR`), `json_get()`, and `resolve_session_id()`. All hooks now source `common.sh` (which chains `log-error.sh`) instead of duplicating these patterns.
- **#131 — Hook cleanup performance**: Moved the stale marker cleanup loop in `session-intention-intro.sh` to a background subshell with `disown`, so it no longer blocks the first prompt.

Closes #131, closes #138

## Test plan

- [x] All 146 existing tests pass (`npm test`)
- [x] Verified no remaining duplicated `json_get` or session resolution code
- [x] Verified no hooks directly source `log-error.sh` anymore
- [x] shellcheck passes via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)