### PR TITLE
Lazy intention file creation for faster first response

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ New sessions will have the latest hooks.
 ## Key paths
 
 - `~/.open-cockpit/session-pids/<PID>` — Session ID (written by plugin hook)
-- `~/.open-cockpit/intentions/<session_id>.md` — Intention files (created by app on first open)
+- `~/.open-cockpit/intentions/<session_id>.md` — Intention files (created lazily: by Claude on first prompt, or by app on first user keystroke)
 - `~/.open-cockpit/colors.json` — Directory color overrides ([docs/theme.md](docs/theme.md))
 - `~/.open-cockpit/idle-signals/<PID>` — Idle signal files (written by plugin hooks)
 - `~/.open-cockpit/pool.json` — Pool state (slots, sizes, session mappings)

--- a/hooks/session-intention-intro.sh
+++ b/hooks/session-intention-intro.sh
@@ -59,13 +59,8 @@ if [ -f "$INTENTION_FILE" ]; then
   cp "$INTENTION_FILE" "$SNAPSHOT_DIR/${session_id}.md"
 fi
 
-EMPTY_NOTE=""
-if [ ! -f "$INTENTION_FILE" ] || [ ! -s "$INTENTION_FILE" ]; then
-  EMPTY_NOTE=" (currently empty)"
-fi
-
 cat <<EOF
-Describe this session at: ${INTENTION_FILE}${EMPTY_NOTE}
+Your first action should be to describe this session at: ${INTENTION_FILE}
 
 Write a descriptive heading, then short bullet points about what you're working on together. Add more detail below as needed.
 EOF

--- a/src/main.js
+++ b/src/main.js
@@ -1770,28 +1770,29 @@ function watchIntention(sessionId) {
   lastWrittenContent.delete(sessionId);
 
   const file = path.join(INTENTIONS_DIR, `${sessionId}.md`);
-  if (!fs.existsSync(file)) {
-    secureMkdirSync(INTENTIONS_DIR, { recursive: true });
-    secureWriteFileSync(file, "");
-  }
+  secureMkdirSync(INTENTIONS_DIR, { recursive: true });
 
-  // Use polling (fs.watchFile) — reliable on macOS unlike fs.watch
+  // Use polling (fs.watchFile) — reliable on macOS unlike fs.watch.
+  // Works on non-existent files too (detects when file appears).
   fs.watchFile(file, { interval: 500 }, () => {
+    let content;
     try {
-      const content = fs.readFileSync(file, "utf-8");
-      // Skip if this is content we wrote ourselves
-      if (content === lastWrittenContent.get(sessionId)) return;
-      lastWrittenContent.set(sessionId, content);
-      console.log("[main] External file change detected, sending to renderer");
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send("intention-changed", content);
-      }
+      content = fs.readFileSync(file, "utf-8");
     } catch (err) {
+      if (err.code === "ENOENT") return; // File not yet created
       console.error(
         "[main] Failed to read intention file on change",
         file,
         err.message,
       );
+      return;
+    }
+    // Skip if this is content we wrote ourselves
+    if (content === lastWrittenContent.get(sessionId)) return;
+    lastWrittenContent.set(sessionId, content);
+    console.log("[main] External file change detected, sending to renderer");
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send("intention-changed", content);
     }
   });
 


### PR DESCRIPTION
## Summary

- Stop pre-creating empty intention files in `watchIntention()` — the file watcher now handles non-existent files gracefully
- Hook message updated to tell Claude "Your first action should be" to create the intention file (via `Write` tool, which works without `Read` for new files)
- The app still creates the file on the user's first keystroke (existing `writeIntention()` already handles dir + file creation)

This eliminates the `Read`-before-`Write` round-trip that forced Claude to waste a turn before it could describe the session.

## Test plan

- [ ] Start a new pool session → verify Claude writes the intention file as its first action
- [ ] Click a session in the sidebar → verify the editor shows empty (no errors)
- [ ] Type in the intention editor before Claude writes → verify file is created on save
- [ ] Claude writes intention → verify it appears in the editor via file watcher
- [ ] External edit (e.g. `echo "test" >> file`) → verify change-notify hook still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)