### PR TITLE
Add configurable keyboard shortcuts with settings UI

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -4,26 +4,38 @@
 
 Shortcuts flow through three layers:
 
-1. **Menu accelerators** (`src/main.js`) — Electron menu items with `accelerator` keys (e.g., `CmdOrCtrl+N`). These call `send(channel)` which forwards to the renderer via `webContents.send()`.
+1. **Menu accelerators** (`src/main.js`) — Electron menu items with dynamic `accelerator` keys from the shortcuts config. These call `send(channel)` which forwards to the renderer via `webContents.send()`.
 
-2. **`before-input-event` handler** (`src/main.js`) — For shortcuts that can't be menu accelerators (e.g., `Ctrl+Tab`, `Escape`). Intercepts raw keyboard input and dispatches IPC messages.
+2. **`before-input-event` handler** (`src/main.js`) — For shortcuts that can't be menu accelerators (e.g., `Ctrl+Tab`, `Cmd+Shift+Tab`, arrow-key combos). Intercepts raw keyboard input and dispatches IPC messages. Uses `matchesInput()` from `src/shortcuts.js` to check against the current config.
 
 3. **Renderer listeners** (`src/renderer.js`) — Registered via `window.api.on<Action>()` callbacks exposed through the preload bridge. Execute the actual UI logic.
 
 ### Adding a new shortcut
 
-1. **`src/preload.js`**: Add the channel name to the `channels` array (for stale listener cleanup) and expose an `on<Action>` listener in the `contextBridge`.
-2. **`src/main.js`**: Add a menu entry with `accelerator` and `click: () => send("channel-name")` in the appropriate menu section.
-3. **`src/renderer.js`**:
+1. **`src/shortcuts.js`**: Add the action ID and default accelerator to `DEFAULT_SHORTCUTS`. If the shortcut needs `before-input-event` handling (arrow keys, Tab, etc.), add its ID to `INPUT_EVENT_ACTIONS`.
+2. **`src/preload.js`**: Add the channel name to the `channels` array (for stale listener cleanup) and expose an `on<Action>` listener in the `contextBridge`.
+3. **`src/main.js`**: Add a menu entry with `accelerator: accel("action-id")` and `click: () => send("channel-name")`. If it's an input-event action, add a mapping in `inputEventChannels`.
+4. **`src/renderer.js`**:
    - Implement the action function
-   - Add a `COMMANDS` entry (for command palette visibility)
+   - Add a `COMMANDS` entry with `shortcutAction` (for dynamic display) and `action`
+   - Add the `SHORTCUT_LABELS` entry (for settings UI)
    - Wire up `window.api.on<Action>(handler)` at the bottom with other listeners
+
+### Shortcut configuration
+
+Users can customize all shortcuts via the **Keyboard Shortcuts** settings dialog (accessible from the command palette).
+
+- **Click** a shortcut key to rebind it (press new key combo, Escape to cancel)
+- **Right-click** a shortcut key to unbind it
+- **↺** button resets to default
+
+Overrides are stored in `~/.open-cockpit/shortcuts.json`. Only overridden values are saved; missing keys use defaults.
 
 ### Command palette
 
-All shortcuts should also appear in the command palette (`Cmd+/`). The `COMMANDS` array in `renderer.js` defines entries with `id`, `label`, `shortcut` (display string), and `action` (function).
+All shortcuts appear in the command palette (`Cmd+/`). The `COMMANDS` array in `renderer.js` defines entries with `id`, `label`, `shortcutAction` (action ID for dynamic shortcut lookup), and `action` (function). Display strings are generated dynamically from the shortcut config.
 
-## Current shortcuts
+## Default shortcuts
 
 | Shortcut | Action |
 |----------|--------|
@@ -34,12 +46,13 @@ All shortcuts should also appear in the command palette (`Cmd+/`). The `COMMANDS
 | `Cmd+1`–`9` | Switch to Tab N |
 | `Ctrl+Tab` / `Ctrl+Shift+Tab` | Next / Previous Tab (alt) |
 | `Alt+Down` / `Alt+Up` | Next / Previous Session |
+| `Cmd+Shift+Tab` | Cycle Pane Focus (editor → terminals → editor) |
 | `Cmd+J` | Jump to Recent Idle Session |
 | `Cmd+D` | Archive Current Session |
 | `Cmd+\` | Toggle Sidebar |
-| `Alt+Left` / `Alt+Right` | Toggle Pane Focus |
 | `Cmd+E` | Focus Editor |
 | `` Cmd+` `` | Focus Terminal |
 | `Cmd+O` | Focus External Terminal |
 | `Escape` | Focus Terminal |
 | `Cmd+/` | Command Palette |
+| *(unbound)* | Toggle Pane Focus (editor ↔ terminal) |

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,16 @@ const { sortSessions } = require("./sort-sessions");
 const { isTranscriptNewerThanSignal } = require("./session-status");
 const { createApiServer } = require("./api-server");
 const {
+  loadShortcuts,
+  getShortcut,
+  getAllShortcuts,
+  getDefaultShortcut,
+  setShortcut,
+  resetShortcut,
+  findMatchingInputAction,
+  INPUT_EVENT_ACTIONS,
+} = require("./shortcuts");
+const {
   readPool: readPoolFile,
   writePool: writePoolFile,
   computePoolHealth,
@@ -210,31 +220,28 @@ function createWindow() {
   mainWindow.loadFile(path.join(__dirname, "index.html"));
 
   // Shortcuts not supported as menu accelerators — handle via input events
+  // Maps input-event action IDs to IPC channels
+  const inputEventChannels = {
+    "next-terminal-tab-alt": "next-terminal-tab",
+    "prev-terminal-tab-alt": "prev-terminal-tab",
+    "next-session": "next-session",
+    "prev-session": "prev-session",
+    "cycle-pane": "cycle-pane",
+  };
+
   mainWindow.webContents.on("before-input-event", (event, input) => {
-    if (input.control && input.key === "Tab") {
-      event.preventDefault();
-      mainWindow.webContents.send(
-        input.shift ? "prev-terminal-tab" : "next-terminal-tab",
-      );
-    }
-    // Alt+Up / Alt+Down — switch sessions
-    if (input.alt && (input.key === "ArrowUp" || input.key === "ArrowDown")) {
-      event.preventDefault();
-      mainWindow.webContents.send(
-        input.key === "ArrowUp" ? "prev-session" : "next-session",
-      );
-    }
-    // Alt+Left / Alt+Right — toggle focus between terminal and editor
-    if (
-      input.alt &&
-      (input.key === "ArrowLeft" || input.key === "ArrowRight")
-    ) {
-      event.preventDefault();
-      mainWindow.webContents.send("toggle-pane-focus");
-    }
     // Escape — focus terminal (only when not in command palette)
     if (input.key === "Escape" && !input.meta && !input.control && !input.alt) {
       mainWindow.webContents.send("focus-terminal");
+      return;
+    }
+
+    // Check all input-event-based shortcuts (uses pre-parsed cache)
+    const matchedAction = findMatchingInputAction(input);
+    if (matchedAction) {
+      event.preventDefault();
+      const channel = inputEventChannels[matchedAction] || matchedAction;
+      mainWindow.webContents.send(channel);
     }
   });
 
@@ -2631,153 +2638,185 @@ app.whenReady().then(async () => {
     }
   };
 
-  // Build menu with keyboard shortcuts
-  const menuTemplate = [
-    {
-      label: app.name,
-      submenu: [
-        { role: "about" },
-        { type: "separator" },
-        { role: "hide" },
-        { role: "hideOthers" },
-        { role: "unhide" },
-        { type: "separator" },
-        { role: "quit" },
-      ],
-    },
-    {
-      label: "File",
-      submenu: [
-        {
-          label: "New Claude Session",
-          accelerator: "CmdOrCtrl+N",
-          click: () => send("new-session"),
-        },
-        {
-          label: "New Terminal Tab",
-          accelerator: "CmdOrCtrl+T",
-          click: () => send("new-terminal-tab"),
-        },
-        {
-          label: "Close Terminal Tab",
-          accelerator: "CmdOrCtrl+W",
-          click: () => send("close-terminal-tab"),
-        },
-        { type: "separator" },
-        {
-          label: "Next Tab",
-          accelerator: "CmdOrCtrl+Shift+]",
-          click: () => send("next-terminal-tab"),
-        },
-        {
-          label: "Previous Tab",
-          accelerator: "CmdOrCtrl+Shift+[",
-          click: () => send("prev-terminal-tab"),
-        },
-        { type: "separator" },
-        ...Array.from({ length: 9 }, (_, i) => ({
-          label: `Tab ${i + 1}`,
-          accelerator: `CmdOrCtrl+${i + 1}`,
-          click: () => send("switch-terminal-tab", i),
-        })),
-        { type: "separator" },
-        { role: "close" },
-      ],
-    },
-    {
-      label: "Navigate",
-      submenu: [
-        {
-          label: "Next Session",
-          accelerator: "Alt+Down",
-          click: () => send("next-session"),
-        },
-        {
-          label: "Previous Session",
-          accelerator: "Alt+Up",
-          click: () => send("prev-session"),
-        },
-        { type: "separator" },
-        {
-          label: "Toggle Sidebar",
-          accelerator: "CmdOrCtrl+\\",
-          click: () => send("toggle-sidebar"),
-        },
-        {
-          label: "Toggle Pane Focus",
-          accelerator: "Alt+Left",
-          click: () => send("toggle-pane-focus"),
-        },
-        {
-          label: "Focus Editor",
-          accelerator: "CmdOrCtrl+E",
-          click: () => send("focus-editor"),
-        },
-        {
-          label: "Focus Terminal",
-          accelerator: "CmdOrCtrl+`",
-          click: () => send("focus-terminal"),
-        },
-        {
-          label: "Focus External Terminal",
-          accelerator: "CmdOrCtrl+O",
-          click: () => send("focus-external"),
-        },
-        { type: "separator" },
-        {
-          label: "Jump to Recent Idle",
-          accelerator: "CmdOrCtrl+J",
-          click: () => send("jump-recent-idle"),
-        },
-        {
-          label: "Archive Current Session",
-          accelerator: "CmdOrCtrl+D",
-          click: () => send("archive-current-session"),
-        },
-        { type: "separator" },
-        {
-          label: "Command Palette",
-          accelerator: "CmdOrCtrl+/",
-          click: () => send("toggle-command-palette"),
-        },
-      ],
-    },
-    {
-      label: "Edit",
-      submenu: [
-        { role: "undo" },
-        { role: "redo" },
-        { type: "separator" },
-        { role: "cut" },
-        { role: "copy" },
-        { role: "paste" },
-        { role: "selectAll" },
-      ],
-    },
-    {
-      label: "View",
-      submenu: [
-        { role: "reload" },
-        { role: "forceReload" },
-        { role: "toggleDevTools" },
-        { type: "separator" },
-        { role: "resetZoom" },
-        { role: "zoomIn" },
-        { role: "zoomOut" },
-        { role: "togglefullscreen" },
-      ],
-    },
-    {
-      label: "Window",
-      submenu: [
-        { role: "minimize" },
-        { role: "zoom" },
-        { type: "separator" },
-        { role: "front" },
-      ],
-    },
-  ];
-  Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
+  // Build menu with keyboard shortcuts (dynamic from config)
+  function buildMenu() {
+    // Helper: only set accelerator if action has a binding and isn't input-event-only
+    function accel(actionId) {
+      if (INPUT_EVENT_ACTIONS.has(actionId)) return undefined;
+      const shortcut = getShortcut(actionId);
+      return shortcut || undefined;
+    }
+
+    const menuTemplate = [
+      {
+        label: app.name,
+        submenu: [
+          { role: "about" },
+          { type: "separator" },
+          { role: "hide" },
+          { role: "hideOthers" },
+          { role: "unhide" },
+          { type: "separator" },
+          { role: "quit" },
+        ],
+      },
+      {
+        label: "File",
+        submenu: [
+          {
+            label: "New Claude Session",
+            accelerator: accel("new-session"),
+            click: () => send("new-session"),
+          },
+          {
+            label: "New Terminal Tab",
+            accelerator: accel("new-terminal-tab"),
+            click: () => send("new-terminal-tab"),
+          },
+          {
+            label: "Close Terminal Tab",
+            accelerator: accel("close-terminal-tab"),
+            click: () => send("close-terminal-tab"),
+          },
+          { type: "separator" },
+          {
+            label: "Next Tab",
+            accelerator: accel("next-tab"),
+            click: () => send("next-terminal-tab"),
+          },
+          {
+            label: "Previous Tab",
+            accelerator: accel("prev-tab"),
+            click: () => send("prev-terminal-tab"),
+          },
+          { type: "separator" },
+          ...Array.from({ length: 9 }, (_, i) => ({
+            label: `Tab ${i + 1}`,
+            accelerator: `CmdOrCtrl+${i + 1}`,
+            click: () => send("switch-terminal-tab", i),
+          })),
+          { type: "separator" },
+          { role: "close" },
+        ],
+      },
+      {
+        label: "Navigate",
+        submenu: [
+          {
+            label: "Next Session",
+            accelerator: accel("next-session"),
+            click: () => send("next-session"),
+          },
+          {
+            label: "Previous Session",
+            accelerator: accel("prev-session"),
+            click: () => send("prev-session"),
+          },
+          { type: "separator" },
+          {
+            label: "Toggle Sidebar",
+            accelerator: accel("toggle-sidebar"),
+            click: () => send("toggle-sidebar"),
+          },
+          {
+            label: "Cycle Pane Focus",
+            accelerator: accel("cycle-pane"),
+            click: () => send("cycle-pane"),
+          },
+          {
+            label: "Toggle Pane Focus",
+            accelerator: accel("toggle-pane-focus"),
+            click: () => send("toggle-pane-focus"),
+          },
+          {
+            label: "Focus Editor",
+            accelerator: accel("focus-editor"),
+            click: () => send("focus-editor"),
+          },
+          {
+            label: "Focus Terminal",
+            accelerator: accel("focus-terminal"),
+            click: () => send("focus-terminal"),
+          },
+          {
+            label: "Focus External Terminal",
+            accelerator: accel("focus-external"),
+            click: () => send("focus-external"),
+          },
+          { type: "separator" },
+          {
+            label: "Jump to Recent Idle",
+            accelerator: accel("jump-recent-idle"),
+            click: () => send("jump-recent-idle"),
+          },
+          {
+            label: "Archive Current Session",
+            accelerator: accel("archive-current-session"),
+            click: () => send("archive-current-session"),
+          },
+          { type: "separator" },
+          {
+            label: "Command Palette",
+            accelerator: accel("toggle-command-palette"),
+            click: () => send("toggle-command-palette"),
+          },
+        ],
+      },
+      {
+        label: "Edit",
+        submenu: [
+          { role: "undo" },
+          { role: "redo" },
+          { type: "separator" },
+          { role: "cut" },
+          { role: "copy" },
+          { role: "paste" },
+          { role: "selectAll" },
+        ],
+      },
+      {
+        label: "View",
+        submenu: [
+          { role: "reload" },
+          { role: "forceReload" },
+          { role: "toggleDevTools" },
+          { type: "separator" },
+          { role: "resetZoom" },
+          { role: "zoomIn" },
+          { role: "zoomOut" },
+          { role: "togglefullscreen" },
+        ],
+      },
+      {
+        label: "Window",
+        submenu: [
+          { role: "minimize" },
+          { role: "zoom" },
+          { type: "separator" },
+          { role: "front" },
+        ],
+      },
+    ];
+    Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
+  }
+
+  // Load shortcuts config and build initial menu
+  loadShortcuts();
+  buildMenu();
+
+  // IPC handlers for shortcut settings
+  ipcMain.handle("get-shortcuts", () => getAllShortcuts());
+  ipcMain.handle("get-default-shortcut", (_e, actionId) =>
+    getDefaultShortcut(actionId),
+  );
+  ipcMain.handle("set-shortcut", (_e, actionId, accelerator) => {
+    setShortcut(actionId, accelerator);
+    buildMenu(); // Rebuild menu with updated accelerators
+  });
+  ipcMain.handle("reset-shortcut", (_e, actionId) => {
+    resetShortcut(actionId);
+    buildMenu();
+  });
 
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/src/preload.js
+++ b/src/preload.js
@@ -20,6 +20,7 @@ const channels = [
   "focus-terminal",
   "toggle-command-palette",
   "toggle-pane-focus",
+  "cycle-pane",
   "focus-external",
   "jump-recent-idle",
   "archive-current-session",
@@ -96,6 +97,14 @@ contextBridge.exposeInMainWorld("api", {
   listSetupScripts: () => ipcRenderer.invoke("list-setup-scripts"),
   readSetupScript: (name) => ipcRenderer.invoke("read-setup-script", name),
 
+  // Shortcut settings
+  getShortcuts: () => ipcRenderer.invoke("get-shortcuts"),
+  getDefaultShortcut: (actionId) =>
+    ipcRenderer.invoke("get-default-shortcut", actionId),
+  setShortcut: (actionId, accelerator) =>
+    ipcRenderer.invoke("set-shortcut", actionId, accelerator),
+  resetShortcut: (actionId) => ipcRenderer.invoke("reset-shortcut", actionId),
+
   // Menu actions
   onNewTerminalTab: (callback) =>
     ipcRenderer.on("new-terminal-tab", () => callback()),
@@ -121,6 +130,7 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.on("toggle-command-palette", () => callback()),
   onTogglePaneFocus: (callback) =>
     ipcRenderer.on("toggle-pane-focus", () => callback()),
+  onCyclePane: (callback) => ipcRenderer.on("cycle-pane", () => callback()),
   onFocusExternalTerminal: (callback) =>
     ipcRenderer.on("focus-external", () => callback()),
   onJumpRecentIdle: (callback) =>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1588,29 +1588,69 @@ function focusEditor() {
 }
 
 // --- Command palette ---
+// --- Shortcut display helpers ---
+// Convert Electron accelerator to display string (e.g. "CmdOrCtrl+N" → "⌘N")
+function formatShortcutDisplay(accel) {
+  if (!accel) return "";
+  return accel
+    .replace(/CmdOrCtrl\+/gi, "⌘")
+    .replace(/Cmd\+/gi, "⌘")
+    .replace(/Ctrl\+/gi, "⌃")
+    .replace(/Shift\+/gi, "⇧")
+    .replace(/Alt\+/gi, "⌥")
+    .replace(/\+/g, "")
+    .replace(/Tab/gi, "⇥")
+    .replace(/Up/gi, "↑")
+    .replace(/Down/gi, "↓")
+    .replace(/Left/gi, "←")
+    .replace(/Right/gi, "→");
+}
+
+// Loaded shortcut config (populated on init)
+let shortcutConfig = {};
+
+// Cycle pane focus: editor → terminal tabs (round-robin) → back to editor
+function cyclePane() {
+  if (editorMount.contains(document.activeElement)) {
+    // Editor focused → go to first terminal
+    focusTerminal();
+  } else if (activeTermIndex >= 0 && terminals.length > 1) {
+    // On a terminal tab — cycle to next, or wrap to editor
+    const nextIdx = activeTermIndex + 1;
+    if (nextIdx < terminals.length) {
+      switchToTerminal(nextIdx);
+    } else {
+      focusEditor();
+    }
+  } else {
+    // On terminal (single) or somewhere else → go to editor
+    focusEditor();
+  }
+}
+
 const COMMANDS = [
   {
     id: "next-session",
     label: "Next Session",
-    shortcut: "Alt+↓",
+    shortcutAction: "next-session",
     action: () => switchSession(1),
   },
   {
     id: "prev-session",
     label: "Previous Session",
-    shortcut: "Alt+↑",
+    shortcutAction: "prev-session",
     action: () => switchSession(-1),
   },
   {
     id: "new-session",
     label: "New Claude Session",
-    shortcut: "⌘N",
+    shortcutAction: "new-session",
     action: () => newSessionBtn.click(),
   },
   {
     id: "new-terminal",
     label: "New Terminal Tab",
-    shortcut: "⌘T",
+    shortcutAction: "new-terminal-tab",
     action: () => {
       if (currentSessionId) spawnTerminal(currentSessionCwd);
     },
@@ -1618,7 +1658,7 @@ const COMMANDS = [
   {
     id: "close-terminal",
     label: "Close Terminal Tab",
-    shortcut: "⌘W",
+    shortcutAction: "close-terminal-tab",
     action: () => {
       if (activeTermIndex >= 0) closeTerminal(activeTermIndex);
     },
@@ -1626,7 +1666,7 @@ const COMMANDS = [
   {
     id: "next-tab",
     label: "Next Terminal Tab",
-    shortcut: "⌘⇧]",
+    shortcutAction: "next-tab",
     action: () => {
       if (terminals.length > 1)
         switchToTerminal((activeTermIndex + 1) % terminals.length);
@@ -1635,7 +1675,7 @@ const COMMANDS = [
   {
     id: "prev-tab",
     label: "Previous Terminal Tab",
-    shortcut: "⌘⇧[",
+    shortcutAction: "prev-tab",
     action: () => {
       if (terminals.length > 1)
         switchToTerminal(
@@ -1646,43 +1686,31 @@ const COMMANDS = [
   {
     id: "jump-recent-idle",
     label: "Jump to Recent Idle",
-    shortcut: "⌘J",
+    shortcutAction: "jump-recent-idle",
     action: jumpToRecentIdle,
   },
   {
     id: "archive-current-session",
     label: "Archive Current Session",
-    shortcut: "⌘D",
+    shortcutAction: "archive-current-session",
     action: archiveCurrentSession,
   },
   {
     id: "toggle-sidebar",
     label: "Toggle Sidebar",
-    shortcut: "⌘\\",
+    shortcutAction: "toggle-sidebar",
     action: toggleSidebar,
   },
   {
-    id: "focus-editor",
-    label: "Focus Editor",
-    shortcut: "⌘E",
-    action: focusEditor,
-  },
-  {
-    id: "focus-terminal",
-    label: "Focus Terminal",
-    shortcut: "⌘`",
-    action: focusTerminal,
-  },
-  {
-    id: "focus-external-terminal",
-    label: "Focus External Terminal",
-    shortcut: "⌘O",
-    action: focusCurrentExternalTerminal,
+    id: "cycle-pane",
+    label: "Cycle Pane Focus",
+    shortcutAction: "cycle-pane",
+    action: cyclePane,
   },
   {
     id: "toggle-pane-focus",
     label: "Toggle Pane Focus",
-    shortcut: "Alt+←/→",
+    shortcutAction: "toggle-pane-focus",
     action: () => {
       if (editorMount.contains(document.activeElement)) {
         focusTerminal();
@@ -1692,9 +1720,26 @@ const COMMANDS = [
     },
   },
   {
+    id: "focus-editor",
+    label: "Focus Editor",
+    shortcutAction: "focus-editor",
+    action: focusEditor,
+  },
+  {
+    id: "focus-terminal",
+    label: "Focus Terminal",
+    shortcutAction: "focus-terminal",
+    action: focusTerminal,
+  },
+  {
+    id: "focus-external-terminal",
+    label: "Focus External Terminal",
+    shortcutAction: "focus-external",
+    action: focusCurrentExternalTerminal,
+  },
+  {
     id: "refresh",
     label: "Refresh Sessions",
-    shortcut: "",
     action: () => {
       loadDirColors();
       loadSessions();
@@ -1703,7 +1748,7 @@ const COMMANDS = [
   {
     id: "command-palette",
     label: "Command Palette",
-    shortcut: "⌘/",
+    shortcutAction: "toggle-command-palette",
     action: () => toggleCommandPalette(),
   },
 ];
@@ -1746,13 +1791,19 @@ function closeCommandPalette() {
   focusTerminal();
 }
 
+// Get display shortcut for a command (dynamic from config)
+function getCommandShortcut(cmd) {
+  if (!cmd.shortcutAction) return "";
+  return formatShortcutDisplay(shortcutConfig[cmd.shortcutAction] || "");
+}
+
 function renderPaletteList(query) {
   const q = query.toLowerCase();
   filteredCommands = q
     ? COMMANDS.filter(
         (c) =>
           c.label.toLowerCase().includes(q) ||
-          c.shortcut.toLowerCase().includes(q),
+          getCommandShortcut(c).toLowerCase().includes(q),
       )
     : COMMANDS.filter((c) => !c.id.startsWith("tab-")); // Hide tab-N from unfiltered list
 
@@ -1765,7 +1816,8 @@ function renderPaletteList(query) {
   filteredCommands.forEach((cmd, i) => {
     const item = document.createElement("div");
     item.className = `command-palette-item${i === paletteSelectedIndex ? " selected" : ""}`;
-    item.innerHTML = `<span class="command-palette-label">${cmd.label}</span><span class="command-palette-shortcut">${cmd.shortcut}</span>`;
+    const shortcut = getCommandShortcut(cmd);
+    item.innerHTML = `<span class="command-palette-label">${cmd.label}</span><span class="command-palette-shortcut">${shortcut}</span>`;
     item.addEventListener("click", () => {
       closeCommandPalette();
       cmd.action();
@@ -1869,6 +1921,7 @@ window.api.onTogglePaneFocus(() => {
     focusEditor();
   }
 });
+window.api.onCyclePane(cyclePane);
 window.api.onFocusExternalTerminal(focusCurrentExternalTerminal);
 window.api.onJumpRecentIdle(jumpToRecentIdle);
 window.api.onArchiveCurrentSession(archiveCurrentSession);
@@ -2397,11 +2450,193 @@ async function showPoolSettings() {
 COMMANDS.push({
   id: "pool-settings",
   label: "Pool Settings",
-  shortcut: "",
   action: () => showPoolSettings(),
 });
 
+// --- Shortcut Settings UI ---
+// Build labels from COMMANDS entries (avoids duplicating labels)
+const SHORTCUT_LABELS = {};
+for (const cmd of COMMANDS) {
+  if (cmd.shortcutAction) SHORTCUT_LABELS[cmd.shortcutAction] = cmd.label;
+}
+// Actions only reachable via input events (no COMMANDS entry)
+SHORTCUT_LABELS["next-terminal-tab-alt"] = "Next Tab (Alt)";
+SHORTCUT_LABELS["prev-terminal-tab-alt"] = "Previous Tab (Alt)";
+
+async function showShortcutSettings() {
+  const existing = document.getElementById("shortcut-settings");
+  if (existing) existing.remove();
+
+  const shortcuts = await window.api.getShortcuts();
+  shortcutConfig = shortcuts;
+
+  // Track active keydown listener for cleanup
+  let activeKeyHandler = null;
+
+  function cleanupRecording() {
+    if (activeKeyHandler) {
+      document.removeEventListener("keydown", activeKeyHandler, true);
+      activeKeyHandler = null;
+    }
+  }
+
+  const overlay = document.createElement("div");
+  overlay.id = "shortcut-settings";
+  overlay.className = "offload-menu-overlay";
+
+  const actionIds = Object.keys(SHORTCUT_LABELS);
+  const rows = actionIds
+    .map((id) => {
+      const label = SHORTCUT_LABELS[id];
+      const current = shortcuts[id] || "";
+      const display = formatShortcutDisplay(current) || "—";
+      return `<div class="shortcut-row" data-action="${id}">
+        <span class="shortcut-label">${label}</span>
+        <button class="shortcut-key-btn" title="Click to rebind">${display}</button>
+        <button class="shortcut-reset-btn" title="Reset to default">↺</button>
+      </div>`;
+    })
+    .join("");
+
+  overlay.innerHTML = `
+    <div class="shortcut-settings-dialog">
+      <div class="pool-settings-header">
+        <span>Keyboard Shortcuts</span>
+        <button class="close-dialog-btn">✕</button>
+      </div>
+      <div class="shortcut-settings-body">
+        ${rows}
+      </div>
+    </div>
+  `;
+
+  document.body.appendChild(overlay);
+
+  function closeDialog() {
+    cleanupRecording();
+    overlay.remove();
+  }
+
+  // Close on overlay click or close button
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay) closeDialog();
+  });
+  overlay
+    .querySelector(".close-dialog-btn")
+    .addEventListener("click", closeDialog);
+
+  // Rebind: click key button → enter recording mode
+  overlay.querySelectorAll(".shortcut-key-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      // Cancel any existing recording
+      cleanupRecording();
+      const existingBtn = overlay.querySelector(".shortcut-key-btn.recording");
+      if (existingBtn && existingBtn !== btn) {
+        existingBtn.classList.remove("recording");
+        const oldAction = existingBtn.closest(".shortcut-row").dataset.action;
+        existingBtn.textContent =
+          formatShortcutDisplay(shortcuts[oldAction]) || "\u2014";
+      }
+
+      btn.classList.add("recording");
+      btn.textContent = "Press keys...";
+
+      function onKeyDown(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        // Ignore lone modifier keys
+        if (["Meta", "Control", "Shift", "Alt"].includes(e.key)) return;
+
+        // Escape cancels recording
+        if (e.key === "Escape") {
+          btn.classList.remove("recording");
+          const actionId = btn.closest(".shortcut-row").dataset.action;
+          btn.textContent =
+            formatShortcutDisplay(shortcuts[actionId]) || "\u2014";
+          cleanupRecording();
+          return;
+        }
+
+        // Build Electron accelerator from the event
+        const parts = [];
+        if (e.metaKey) parts.push("CmdOrCtrl");
+        if (e.ctrlKey && !e.metaKey) parts.push("Ctrl");
+        if (e.shiftKey) parts.push("Shift");
+        if (e.altKey) parts.push("Alt");
+
+        const keyMap = {
+          ArrowUp: "Up",
+          ArrowDown: "Down",
+          ArrowLeft: "Left",
+          ArrowRight: "Right",
+          " ": "Space",
+          Backspace: "Backspace",
+          Delete: "Delete",
+          Enter: "Return",
+          Tab: "Tab",
+        };
+        const key = keyMap[e.key] || e.key.toUpperCase();
+        parts.push(key);
+
+        const accelerator = parts.join("+");
+        const actionId = btn.closest(".shortcut-row").dataset.action;
+
+        btn.classList.remove("recording");
+        btn.textContent = formatShortcutDisplay(accelerator);
+        shortcuts[actionId] = accelerator;
+        shortcutConfig = { ...shortcuts };
+
+        window.api.setShortcut(actionId, accelerator);
+        cleanupRecording();
+      }
+
+      activeKeyHandler = onKeyDown;
+      document.addEventListener("keydown", onKeyDown, true);
+    });
+  });
+
+  // Reset buttons
+  overlay.querySelectorAll(".shortcut-reset-btn").forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      const row = btn.closest(".shortcut-row");
+      const actionId = row.dataset.action;
+      await window.api.resetShortcut(actionId);
+      const defaultVal = await window.api.getDefaultShortcut(actionId);
+      shortcuts[actionId] = defaultVal;
+      shortcutConfig = { ...shortcuts };
+      const keyBtn = row.querySelector(".shortcut-key-btn");
+      keyBtn.textContent = formatShortcutDisplay(defaultVal) || "—";
+    });
+  });
+
+  // Unbind: button to clear a shortcut
+  overlay.querySelectorAll(".shortcut-key-btn").forEach((btn) => {
+    btn.addEventListener("contextmenu", async (e) => {
+      e.preventDefault();
+      const row = btn.closest(".shortcut-row");
+      const actionId = row.dataset.action;
+      await window.api.setShortcut(actionId, "");
+      shortcuts[actionId] = "";
+      shortcutConfig = { ...shortcuts };
+      btn.textContent = "—";
+    });
+  });
+}
+
+// Add shortcut settings to command palette
+COMMANDS.push({
+  id: "shortcut-settings",
+  label: "Keyboard Shortcuts",
+  action: () => showShortcutSettings(),
+});
+
 loadDirColors().then(async () => {
+  // Load shortcut config for command palette display
+  try {
+    shortcutConfig = await window.api.getShortcuts();
+  } catch {}
+
   await reconnectAllPtys();
   const POLL_INTERVAL = 30000; // Safety net — events handle normal refresh
   let sessionPollInterval = setInterval(loadSessions, POLL_INTERVAL);

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -1,0 +1,180 @@
+// Shortcut configuration system
+// Stores user overrides in ~/.open-cockpit/shortcuts.json
+// Missing keys use defaults from DEFAULT_SHORTCUTS
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const SHORTCUTS_FILE = path.join(
+  os.homedir(),
+  ".open-cockpit",
+  "shortcuts.json",
+);
+
+// Default shortcut mappings: action ID -> Electron accelerator string
+// Empty string = unbound by default
+const DEFAULT_SHORTCUTS = {
+  "new-session": "CmdOrCtrl+N",
+  "new-terminal-tab": "CmdOrCtrl+T",
+  "close-terminal-tab": "CmdOrCtrl+W",
+  "next-tab": "CmdOrCtrl+Shift+]",
+  "prev-tab": "CmdOrCtrl+Shift+[",
+  "next-session": "Alt+Down",
+  "prev-session": "Alt+Up",
+  "toggle-sidebar": "CmdOrCtrl+\\",
+  "toggle-pane-focus": "",
+  "cycle-pane": "CmdOrCtrl+Shift+Tab",
+  "focus-editor": "CmdOrCtrl+E",
+  "focus-terminal": "CmdOrCtrl+`",
+  "focus-external": "CmdOrCtrl+O",
+  "jump-recent-idle": "CmdOrCtrl+J",
+  "archive-current-session": "CmdOrCtrl+D",
+  "toggle-command-palette": "CmdOrCtrl+/",
+  // These are handled via before-input-event, not menu accelerators
+  "next-terminal-tab-alt": "Ctrl+Tab",
+  "prev-terminal-tab-alt": "Ctrl+Shift+Tab",
+};
+
+// Actions that use before-input-event instead of menu accelerators
+const INPUT_EVENT_ACTIONS = new Set([
+  "next-terminal-tab-alt",
+  "prev-terminal-tab-alt",
+  "next-session",
+  "prev-session",
+  "cycle-pane",
+]);
+
+let userOverrides = {};
+
+// Pre-parsed accelerators for input-event actions (avoids re-parsing on every keypress)
+const parsedInputAccels = new Map(); // actionId -> { parsed, channel }
+
+function rebuildParsedCache() {
+  parsedInputAccels.clear();
+  for (const actionId of INPUT_EVENT_ACTIONS) {
+    const accel = getShortcut(actionId);
+    if (accel) {
+      const parsed = parseAccelerator(accel);
+      if (parsed) parsedInputAccels.set(actionId, parsed);
+    }
+  }
+}
+
+function loadShortcuts() {
+  try {
+    const data = fs.readFileSync(SHORTCUTS_FILE, "utf-8");
+    userOverrides = JSON.parse(data);
+  } catch {
+    userOverrides = {};
+  }
+  rebuildParsedCache();
+}
+
+function saveShortcuts() {
+  try {
+    fs.writeFileSync(SHORTCUTS_FILE, JSON.stringify(userOverrides, null, 2));
+  } catch (err) {
+    console.error("[shortcuts] Failed to save:", err.message);
+  }
+}
+
+function getShortcut(actionId) {
+  if (actionId in userOverrides) return userOverrides[actionId];
+  return DEFAULT_SHORTCUTS[actionId] || "";
+}
+
+function getAllShortcuts() {
+  const result = {};
+  for (const id of Object.keys(DEFAULT_SHORTCUTS)) {
+    result[id] = getShortcut(id);
+  }
+  return result;
+}
+
+function getDefaultShortcut(actionId) {
+  return DEFAULT_SHORTCUTS[actionId] || "";
+}
+
+function setShortcut(actionId, accelerator) {
+  if (accelerator === DEFAULT_SHORTCUTS[actionId]) {
+    delete userOverrides[actionId];
+  } else {
+    userOverrides[actionId] = accelerator;
+  }
+  saveShortcuts();
+  rebuildParsedCache();
+}
+
+function resetShortcut(actionId) {
+  delete userOverrides[actionId];
+  saveShortcuts();
+  rebuildParsedCache();
+}
+
+// Parse an Electron accelerator into a before-input-event matcher
+// Returns null if the accelerator can't be matched via input events
+function parseAccelerator(accel) {
+  if (!accel) return null;
+  const parts = accel.toLowerCase().split("+");
+  const key = parts[parts.length - 1];
+  const mods = new Set(parts.slice(0, -1));
+  return {
+    meta: mods.has("cmd") || mods.has("cmdorctrl") || mods.has("command"),
+    control: mods.has("ctrl") || mods.has("cmdorctrl") || mods.has("control"),
+    shift: mods.has("shift"),
+    alt: mods.has("alt") || mods.has("option"),
+    key,
+  };
+}
+
+// Key normalization map (shared between matchesInput and matchesParsed)
+const INPUT_KEY_MAP = {
+  arrowup: "up",
+  arrowdown: "down",
+  arrowleft: "left",
+  arrowright: "right",
+};
+
+function matchesParsed(input, parsed) {
+  const inputKey =
+    INPUT_KEY_MAP[input.key.toLowerCase()] || input.key.toLowerCase();
+  if (inputKey !== parsed.key) return false;
+
+  const wantsMeta = parsed.meta;
+  const wantsCtrl = parsed.control && !parsed.meta;
+  if (wantsMeta && !input.meta) return false;
+  if (wantsCtrl && !input.control) return false;
+  if (parsed.shift !== input.shift) return false;
+  if (parsed.alt !== input.alt) return false;
+  return true;
+}
+
+// Check if a before-input-event input matches an accelerator string
+function matchesInput(input, accel) {
+  const parsed = parseAccelerator(accel);
+  if (!parsed) return false;
+  return matchesParsed(input, parsed);
+}
+
+// Find matching input-event action using pre-parsed cache (hot path)
+// Returns actionId or null
+function findMatchingInputAction(input) {
+  for (const [actionId, parsed] of parsedInputAccels) {
+    if (matchesParsed(input, parsed)) return actionId;
+  }
+  return null;
+}
+
+module.exports = {
+  DEFAULT_SHORTCUTS,
+  INPUT_EVENT_ACTIONS,
+  loadShortcuts,
+  getShortcut,
+  getAllShortcuts,
+  getDefaultShortcut,
+  setShortcut,
+  resetShortcut,
+  matchesInput,
+  findMatchingInputAction,
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -876,3 +876,101 @@ body {
 .session-context-item:hover {
   background: var(--accent-dim);
 }
+
+/* Shortcut settings */
+.shortcut-settings-dialog {
+  width: 520px;
+  max-height: 80vh;
+  background: #161616;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.shortcut-settings-body {
+  padding: 12px 16px;
+  overflow-y: auto;
+}
+
+.shortcut-row {
+  display: flex;
+  align-items: center;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.shortcut-row:last-child {
+  border-bottom: none;
+}
+
+.shortcut-label {
+  flex: 1;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.shortcut-key-btn {
+  min-width: 100px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: "SF Mono", Menlo, monospace;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  cursor: pointer;
+  text-align: center;
+  transition: border-color 0.15s;
+}
+
+.shortcut-key-btn:hover {
+  border-color: var(--accent);
+}
+
+.shortcut-key-btn.recording {
+  border-color: var(--accent);
+  color: var(--accent);
+  animation: pulse-border 1s ease-in-out infinite;
+}
+
+@keyframes pulse-border {
+  0%,
+  100% {
+    border-color: var(--accent);
+  }
+  50% {
+    border-color: var(--border);
+  }
+}
+
+.shortcut-reset-btn {
+  margin-left: 6px;
+  padding: 4px 8px;
+  font-size: 14px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.shortcut-reset-btn:hover {
+  color: var(--text);
+  border-color: var(--border);
+}
+
+.close-dialog-btn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 2px 6px;
+}
+
+.close-dialog-btn:hover {
+  color: var(--text);
+}

--- a/test/main-menu.test.js
+++ b/test/main-menu.test.js
@@ -13,26 +13,14 @@ describe("Main process menu", () => {
     expect(mainSource).toContain('label: "Navigate"');
   });
 
-  it("registers session navigation accelerators", () => {
-    expect(mainSource).toContain('accelerator: "Alt+Down"');
-    expect(mainSource).toContain('accelerator: "Alt+Up"');
-  });
-
-  it("registers sidebar toggle accelerator", () => {
-    expect(mainSource).toContain('accelerator: "CmdOrCtrl+\\\\"');
-  });
-
-  it("registers focus accelerators", () => {
-    expect(mainSource).toContain('accelerator: "CmdOrCtrl+E"');
-    expect(mainSource).toContain('accelerator: "CmdOrCtrl+`"');
-  });
-
-  it("registers command palette accelerator", () => {
-    expect(mainSource).toContain('accelerator: "CmdOrCtrl+/"');
-  });
-
-  it("registers new session accelerator", () => {
-    expect(mainSource).toContain('accelerator: "CmdOrCtrl+N"');
+  it("uses dynamic accelerators from shortcuts config", () => {
+    // Menu accelerators are now dynamic via accel() helper
+    expect(mainSource).toContain("accel(");
+    expect(mainSource).toContain('accel("new-session")');
+    expect(mainSource).toContain('accel("toggle-sidebar")');
+    expect(mainSource).toContain('accel("focus-editor")');
+    expect(mainSource).toContain('accel("focus-terminal")');
+    expect(mainSource).toContain('accel("toggle-command-palette")');
   });
 
   it("sends correct IPC messages for navigation", () => {
@@ -44,20 +32,27 @@ describe("Main process menu", () => {
       "focus-terminal",
       "toggle-command-palette",
       "new-session",
+      "cycle-pane",
     ];
     for (const msg of ipcMessages) {
       expect(mainSource, `Missing IPC send for "${msg}"`).toContain(`"${msg}"`);
     }
   });
 
-  it("handles Alt+Up/Down in before-input-event", () => {
-    expect(mainSource).toContain("ArrowUp");
-    expect(mainSource).toContain("ArrowDown");
-    expect(mainSource).toContain("input.alt");
+  it("handles input-event-based shortcuts via cached matching", () => {
+    expect(mainSource).toContain("findMatchingInputAction");
+    expect(mainSource).toContain("INPUT_EVENT_ACTIONS");
+    expect(mainSource).toContain("before-input-event");
   });
 
   it("handles Escape for focus-terminal", () => {
     expect(mainSource).toContain('input.key === "Escape"');
     expect(mainSource).toContain("focus-terminal");
+  });
+
+  it("supports menu rebuild on shortcut change", () => {
+    expect(mainSource).toContain("buildMenu()");
+    expect(mainSource).toContain('ipcMain.handle("set-shortcut"');
+    expect(mainSource).toContain('ipcMain.handle("reset-shortcut"');
   });
 });

--- a/test/shortcut-config.test.js
+++ b/test/shortcut-config.test.js
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const SHORTCUTS_FILE = path.join(
+  os.homedir(),
+  ".open-cockpit",
+  "shortcuts.json",
+);
+
+// Fresh require for each test to reset module state
+let shortcuts;
+function loadModule() {
+  // Clear module cache
+  delete require.cache[require.resolve("../src/shortcuts.js")];
+  return require("../src/shortcuts.js");
+}
+
+describe("Shortcut config system", () => {
+  let originalFile;
+
+  beforeEach(() => {
+    try {
+      originalFile = fs.readFileSync(SHORTCUTS_FILE, "utf-8");
+    } catch {
+      originalFile = null;
+    }
+    // Start clean
+    try {
+      fs.unlinkSync(SHORTCUTS_FILE);
+    } catch {}
+    shortcuts = loadModule();
+    shortcuts.loadShortcuts();
+  });
+
+  afterEach(() => {
+    // Restore original file
+    if (originalFile !== null) {
+      fs.writeFileSync(SHORTCUTS_FILE, originalFile);
+    } else {
+      try {
+        fs.unlinkSync(SHORTCUTS_FILE);
+      } catch {}
+    }
+  });
+
+  it("returns default shortcuts when no config file exists", () => {
+    const all = shortcuts.getAllShortcuts();
+    expect(all["new-session"]).toBe("CmdOrCtrl+N");
+    expect(all["toggle-pane-focus"]).toBe("");
+    expect(all["cycle-pane"]).toBe("CmdOrCtrl+Shift+Tab");
+  });
+
+  it("getShortcut returns default for unknown action", () => {
+    expect(shortcuts.getShortcut("nonexistent")).toBe("");
+  });
+
+  it("setShortcut persists override and getShortcut reflects it", () => {
+    shortcuts.setShortcut("toggle-pane-focus", "Alt+Left");
+    expect(shortcuts.getShortcut("toggle-pane-focus")).toBe("Alt+Left");
+
+    // Reload and verify persistence
+    const fresh = loadModule();
+    fresh.loadShortcuts();
+    expect(fresh.getShortcut("toggle-pane-focus")).toBe("Alt+Left");
+  });
+
+  it("setShortcut to default value removes override", () => {
+    shortcuts.setShortcut("new-session", "CmdOrCtrl+Shift+N");
+    expect(shortcuts.getShortcut("new-session")).toBe("CmdOrCtrl+Shift+N");
+
+    shortcuts.setShortcut("new-session", "CmdOrCtrl+N"); // back to default
+    const data = JSON.parse(fs.readFileSync(SHORTCUTS_FILE, "utf-8"));
+    expect(data["new-session"]).toBeUndefined();
+  });
+
+  it("resetShortcut removes override", () => {
+    shortcuts.setShortcut("focus-editor", "CmdOrCtrl+Shift+E");
+    expect(shortcuts.getShortcut("focus-editor")).toBe("CmdOrCtrl+Shift+E");
+
+    shortcuts.resetShortcut("focus-editor");
+    expect(shortcuts.getShortcut("focus-editor")).toBe("CmdOrCtrl+E");
+  });
+
+  it("getDefaultShortcut always returns the built-in default", () => {
+    shortcuts.setShortcut("new-session", "F12");
+    expect(shortcuts.getDefaultShortcut("new-session")).toBe("CmdOrCtrl+N");
+  });
+
+  it("toggle-pane-focus defaults to unbound", () => {
+    expect(shortcuts.getShortcut("toggle-pane-focus")).toBe("");
+  });
+
+  it("cycle-pane defaults to CmdOrCtrl+Shift+Tab", () => {
+    expect(shortcuts.getShortcut("cycle-pane")).toBe("CmdOrCtrl+Shift+Tab");
+  });
+});
+
+describe("matchesInput", () => {
+  const { matchesInput } = loadModule();
+
+  it("matches Ctrl+Tab", () => {
+    const input = {
+      key: "Tab",
+      meta: false,
+      control: true,
+      shift: false,
+      alt: false,
+    };
+    expect(matchesInput(input, "Ctrl+Tab")).toBe(true);
+    expect(matchesInput(input, "Ctrl+Shift+Tab")).toBe(false);
+  });
+
+  it("matches CmdOrCtrl+Shift+Tab on macOS (meta)", () => {
+    const input = {
+      key: "Tab",
+      meta: true,
+      control: false,
+      shift: true,
+      alt: false,
+    };
+    expect(matchesInput(input, "CmdOrCtrl+Shift+Tab")).toBe(true);
+  });
+
+  it("matches Alt+Down", () => {
+    const input = {
+      key: "ArrowDown",
+      meta: false,
+      control: false,
+      shift: false,
+      alt: true,
+    };
+    expect(matchesInput(input, "Alt+Down")).toBe(true);
+    expect(matchesInput(input, "Alt+Up")).toBe(false);
+  });
+
+  it("returns false for empty accelerator", () => {
+    const input = {
+      key: "Tab",
+      meta: false,
+      control: true,
+      shift: false,
+      alt: false,
+    };
+    expect(matchesInput(input, "")).toBe(false);
+  });
+
+  it("matches CmdOrCtrl+E (meta on macOS)", () => {
+    const input = {
+      key: "e",
+      meta: true,
+      control: false,
+      shift: false,
+      alt: false,
+    };
+    expect(matchesInput(input, "CmdOrCtrl+E")).toBe(true);
+  });
+});
+
+describe("findMatchingInputAction", () => {
+  it("finds matching action from cached accelerators", () => {
+    const mod = loadModule();
+    mod.loadShortcuts();
+
+    const input = {
+      key: "ArrowDown",
+      meta: false,
+      control: false,
+      shift: false,
+      alt: true,
+    };
+    expect(mod.findMatchingInputAction(input)).toBe("next-session");
+  });
+
+  it("returns null when no action matches", () => {
+    const mod = loadModule();
+    mod.loadShortcuts();
+
+    const input = {
+      key: "z",
+      meta: false,
+      control: false,
+      shift: false,
+      alt: false,
+    };
+    expect(mod.findMatchingInputAction(input)).toBeNull();
+  });
+});

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -10,32 +10,105 @@ function computeNextSessionIndex(currentId, sessions, direction) {
   return (currentIndex + direction + sessions.length) % sessions.length;
 }
 
+// formatShortcutDisplay (mirrors renderer.js)
+function formatShortcutDisplay(accel) {
+  if (!accel) return "";
+  return accel
+    .replace(/CmdOrCtrl\+/gi, "\u2318")
+    .replace(/Cmd\+/gi, "\u2318")
+    .replace(/Ctrl\+/gi, "\u2303")
+    .replace(/Shift\+/gi, "\u21E7")
+    .replace(/Alt\+/gi, "\u2325")
+    .replace(/\+/g, "")
+    .replace(/Tab/gi, "\u21E5")
+    .replace(/Up/gi, "\u2191")
+    .replace(/Down/gi, "\u2193")
+    .replace(/Left/gi, "\u2190")
+    .replace(/Right/gi, "\u2192");
+}
+
+// Shortcut config (default values for testing)
+const shortcutConfig = {
+  "next-session": "Alt+Down",
+  "prev-session": "Alt+Up",
+  "new-session": "CmdOrCtrl+N",
+  "new-terminal-tab": "CmdOrCtrl+T",
+  "close-terminal-tab": "CmdOrCtrl+W",
+  "next-tab": "CmdOrCtrl+Shift+]",
+  "prev-tab": "CmdOrCtrl+Shift+[",
+  "toggle-sidebar": "CmdOrCtrl+\\",
+  "focus-editor": "CmdOrCtrl+E",
+  "focus-terminal": "CmdOrCtrl+`",
+  "toggle-command-palette": "CmdOrCtrl+/",
+  "cycle-pane": "CmdOrCtrl+Shift+Tab",
+  "toggle-pane-focus": "",
+};
+
+function getCommandShortcut(cmd) {
+  if (!cmd.shortcutAction) return "";
+  return formatShortcutDisplay(shortcutConfig[cmd.shortcutAction] || "");
+}
+
 // Command filtering logic (mirrors renderPaletteList)
 function filterCommands(commands, query) {
   const q = query.toLowerCase();
   if (!q) return commands.filter((c) => !c.id.startsWith("tab-"));
   return commands.filter(
     (c) =>
-      c.label.toLowerCase().includes(q) || c.shortcut.toLowerCase().includes(q),
+      c.label.toLowerCase().includes(q) ||
+      getCommandShortcut(c).toLowerCase().includes(q),
   );
 }
 
 // Sample command list matching renderer.js structure
 const COMMANDS = [
-  { id: "next-session", label: "Next Session", shortcut: "Alt+↓" },
-  { id: "prev-session", label: "Previous Session", shortcut: "Alt+↑" },
-  { id: "new-session", label: "New Claude Session", shortcut: "⌘N" },
-  { id: "new-terminal", label: "New Terminal Tab", shortcut: "⌘T" },
-  { id: "close-terminal", label: "Close Terminal Tab", shortcut: "⌘W" },
-  { id: "next-tab", label: "Next Terminal Tab", shortcut: "⌘⇧]" },
-  { id: "prev-tab", label: "Previous Terminal Tab", shortcut: "⌘⇧[" },
-  { id: "toggle-sidebar", label: "Toggle Sidebar", shortcut: "⌘\\" },
-  { id: "focus-editor", label: "Focus Editor", shortcut: "⌘E" },
-  { id: "focus-terminal", label: "Focus Terminal", shortcut: "⌘`" },
-  { id: "refresh", label: "Refresh Sessions", shortcut: "" },
-  { id: "command-palette", label: "Command Palette", shortcut: "⌘/" },
-  { id: "tab-1", label: "Switch to Tab 1", shortcut: "⌘1" },
-  { id: "tab-2", label: "Switch to Tab 2", shortcut: "⌘2" },
+  { id: "next-session", label: "Next Session", shortcutAction: "next-session" },
+  {
+    id: "prev-session",
+    label: "Previous Session",
+    shortcutAction: "prev-session",
+  },
+  {
+    id: "new-session",
+    label: "New Claude Session",
+    shortcutAction: "new-session",
+  },
+  {
+    id: "new-terminal",
+    label: "New Terminal Tab",
+    shortcutAction: "new-terminal-tab",
+  },
+  {
+    id: "close-terminal",
+    label: "Close Terminal Tab",
+    shortcutAction: "close-terminal-tab",
+  },
+  { id: "next-tab", label: "Next Terminal Tab", shortcutAction: "next-tab" },
+  {
+    id: "prev-tab",
+    label: "Previous Terminal Tab",
+    shortcutAction: "prev-tab",
+  },
+  {
+    id: "toggle-sidebar",
+    label: "Toggle Sidebar",
+    shortcutAction: "toggle-sidebar",
+  },
+  { id: "cycle-pane", label: "Cycle Pane Focus", shortcutAction: "cycle-pane" },
+  { id: "focus-editor", label: "Focus Editor", shortcutAction: "focus-editor" },
+  {
+    id: "focus-terminal",
+    label: "Focus Terminal",
+    shortcutAction: "focus-terminal",
+  },
+  { id: "refresh", label: "Refresh Sessions" },
+  {
+    id: "command-palette",
+    label: "Command Palette",
+    shortcutAction: "toggle-command-palette",
+  },
+  { id: "tab-1", label: "Switch to Tab 1" },
+  { id: "tab-2", label: "Switch to Tab 2" },
 ];
 
 describe("Session switching", () => {
@@ -73,7 +146,7 @@ describe("Command palette filtering", () => {
   it("returns all non-tab commands when query is empty", () => {
     const result = filterCommands(COMMANDS, "");
     expect(result.every((c) => !c.id.startsWith("tab-"))).toBe(true);
-    expect(result.length).toBe(12); // All except tab-1, tab-2
+    expect(result.length).toBe(13); // All except tab-1, tab-2
   });
 
   it("filters by label substring", () => {
@@ -84,8 +157,8 @@ describe("Command palette filtering", () => {
     ).toBe(true);
   });
 
-  it("filters by shortcut", () => {
-    const result = filterCommands(COMMANDS, "alt");
+  it("filters by shortcut display", () => {
+    const result = filterCommands(COMMANDS, "\u2325"); // ⌥ (Alt symbol)
     expect(result.length).toBe(2);
     expect(result[0].id).toBe("next-session");
     expect(result[1].id).toBe("prev-session");
@@ -124,5 +197,25 @@ describe("Command list completeness", () => {
     for (const cmd of COMMANDS) {
       expect(cmd.label).toBeTruthy();
     }
+  });
+});
+
+describe("formatShortcutDisplay", () => {
+  it("converts CmdOrCtrl+N to symbol", () => {
+    expect(formatShortcutDisplay("CmdOrCtrl+N")).toBe("\u2318N");
+  });
+
+  it("converts Alt+Down to symbol", () => {
+    expect(formatShortcutDisplay("Alt+Down")).toBe("\u2325\u2193");
+  });
+
+  it("converts CmdOrCtrl+Shift+Tab", () => {
+    expect(formatShortcutDisplay("CmdOrCtrl+Shift+Tab")).toBe(
+      "\u2318\u21E7\u21E5",
+    );
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(formatShortcutDisplay("")).toBe("");
   });
 });


### PR DESCRIPTION
## Summary

- Free Alt+Left/Right from toggle-pane-focus (needed for word-jumping in editors)
- Add `Cmd+Shift+Tab` cycle-pane action: cycles editor → terminal tabs → back to editor
- New `src/shortcuts.js` config module with `~/.open-cockpit/shortcuts.json` persistence
- Dynamic menu accelerators that rebuild on shortcut change
- **Keyboard Shortcuts** settings dialog (command palette → "Keyboard Shortcuts"):
  - Click shortcut key → recording mode → press new combo
  - Right-click → unbind
  - ↺ button → reset to default
- Pre-parsed accelerator cache for efficient `before-input-event` matching
- `SHORTCUT_LABELS` derived from COMMANDS to avoid label duplication

## Test plan

- [x] All 162 tests pass (11 test files)
- [x] Build succeeds
- [ ] Manual: open command palette → "Keyboard Shortcuts" → verify all actions listed
- [ ] Manual: click a shortcut → press new key combo → verify it updates
- [ ] Manual: right-click a shortcut → verify it unbinds
- [ ] Manual: press ↺ → verify reset to default
- [ ] Manual: verify Cmd+Shift+Tab cycles editor → terminals → editor
- [ ] Manual: verify Alt+Left/Right no longer intercepts (word-jumping works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)