### PR TITLE
Fix resumed sessions disappearing from sidebar

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1342,6 +1342,7 @@ function trackNewSlot(
     excludeId = null,
     expectedStatus = "starting",
     skipTrustPrompt = false,
+    skipFreshSignal = false,
     onResolved = null,
   } = {},
 ) {
@@ -1354,9 +1355,14 @@ function trackNewSlot(
         const s = p.slots.find((x) => x.termId === slot.termId);
         if (s && s.status === expectedStatus) {
           s.sessionId = sessionId;
-          s.status = sessionId ? "fresh" : "error";
+          if (skipFreshSignal) {
+            // Resume case: keep slot as busy, let real idle hook handle status
+            if (!sessionId) s.status = "error";
+          } else {
+            s.status = sessionId ? "fresh" : "error";
+            if (sessionId) createFreshIdleSignal(s.pid, sessionId);
+          }
           writePool(p);
-          if (sessionId) createFreshIdleSignal(s.pid, sessionId);
         }
       });
       if (onResolved) await onResolved(sessionId);
@@ -1758,6 +1764,7 @@ async function poolResume(sessionId) {
         excludeId: oldSlotSessionId,
         expectedStatus: "busy",
         skipTrustPrompt: true,
+        skipFreshSignal: true,
         onResolved: async (newSessionId) => {
           if (newSessionId) removeOffloadData(sessionId);
           invalidateSessionsCache();


### PR DESCRIPTION
## Summary

- Resumed sessions vanished from the sidebar because `trackNewSlot()` unconditionally created a fresh idle signal and set slot status to "fresh" — making `getSessions()` classify them as hidden pool slots
- Added `skipFreshSignal` option so the resume path keeps the slot as "busy" and lets the real idle hook handle transitions

## Test plan

- [ ] Resume an archived session → verify it stays visible in the sidebar throughout (shows as "processing", then transitions to "idle")
- [ ] Verify fresh pool slots still work normally (init pool, check slots appear as fresh)
- [ ] Verify offload+re-track still creates fresh idle signal (`/clear` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)