### PR TITLE
Auto-recover error pool slots via periodic reconciliation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Electron app + Claude Code plugin for session intention tracking.
 The app can manage a pool of pre-started Claude sessions. Pool state lives in `~/.open-cockpit/pool.json`.
 
 - **Init**: via UI or API (`pool-init` with size). Spawns Claude sessions via the PTY daemon using `resolveClaudePath()` (finds `claude` binary via `which` + fallback paths). Trust prompt is accepted via buffer polling (not hardcoded delay).
-- **Dead slots**: `reconcilePool()` auto-restarts dead slots on app startup. Orphaned processes are killed by PID as fallback when daemon termIds are stale.
+- **Dead/error slots**: `reconcilePool()` auto-restarts dead and error slots. Runs on startup and every 30s. Orphaned processes are killed via `killSlotProcess()` (daemon + PID fallback) before respawn.
 - **Offloading**: Idle sessions get offloaded (snapshot + `/clear`). External `/clear` is also detected and saved as offloaded.
 - **Archiving**: All dead sessions are auto-archived (`archived: true` in meta.json). Any session can be manually archived via right-click. Pool sessions auto-offload before archiving.
 - **Destroy**: `pool-destroy` kills all slots and removes `pool.json`. Uses `killSlotProcess()` (daemon + PID fallback) to prevent orphans.

--- a/src/main.js
+++ b/src/main.js
@@ -1640,35 +1640,37 @@ async function reconcilePool() {
 
     for (const slot of pool.slots) {
       const pty = daemonPtys.get(slot.termId);
-      if (!pty || pty.exited) {
-        if (slot.status !== "dead") {
-          slot.status = "dead";
-          changed = true;
+      const needsRestart = !pty || pty.exited || slot.status === "error";
+
+      if (needsRestart) {
+        if (!pty || pty.exited) {
+          if (slot.status !== "dead") {
+            slot.status = "dead";
+            changed = true;
+          }
         }
         // Clean up terminal input cache for old termId
         terminalHasInputCache.delete(slot.termId);
-        // Kill orphaned process by PID before restarting
-        if (slot.pid) {
-          try {
-            process.kill(slot.pid, "SIGTERM");
-          } catch {
-            /* ESRCH expected — process may already be dead */
-          }
-        }
-        // Auto-restart dead slot
+        // Kill old process/PTY before restarting
+        await killSlotProcess(slot);
+        // Auto-restart slot
         try {
+          const reason = slot.status === "error" ? "error" : "dead";
+          debugLog(
+            "main",
+            `Auto-recovering ${reason} slot ${slot.index} (termId=${slot.termId} pid=${slot.pid})`,
+          );
           const newSlot = await spawnPoolSlot(slot.index);
           slot.termId = newSlot.termId;
           slot.pid = newSlot.pid;
           slot.status = "starting";
           slot.sessionId = null;
           changed = true;
-          // Track slot in background (trust prompt + session ID polling)
           trackNewSlot(slot);
         } catch (err) {
-          console.error(
-            `[main] Failed to restart slot ${slot.index}:`,
-            err.message,
+          debugLog(
+            "main",
+            `Failed to restart slot ${slot.index}: ${err.message}`,
           );
         }
         continue;
@@ -2273,12 +2275,19 @@ app.whenReady().then(async () => {
     console.error("[main] Idle signal cleanup failed:", err.message);
   }
 
-  // Reconcile pool state with surviving daemon terminals
+  // Reconcile pool state with surviving daemon terminals (startup + periodic)
   try {
     await reconcilePool();
   } catch (err) {
     console.error("[main] Pool reconciliation failed:", err.message);
   }
+  setInterval(async () => {
+    try {
+      await reconcilePool();
+    } catch {
+      /* logged inside reconcilePool */
+    }
+  }, 30000);
 
   // Watch session-pids and idle-signals dirs for changes → push updates to renderer.
   // Debounced: fs.watch fires multiple events per operation.


### PR DESCRIPTION
## Summary

- Extend `reconcilePool()` to auto-restart error slots (not just dead ones). Error slots have alive-but-stuck processes (e.g., trust prompt never accepted).
- Run `reconcilePool()` every 30s instead of startup-only. Slots self-heal without manual intervention.
- Use `killSlotProcess()` for consistent cleanup (daemon kill + PID fallback).

## Test plan

- [x] All 202 tests pass
- [ ] Manually verify: init pool, kill a Claude process → slot should auto-recover within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)