### PR TITLE
Show toast notification when pool slots auto-recover

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1630,6 +1630,7 @@ async function reconcilePool() {
     if (!pool) return;
 
     let changed = false;
+    const recovered = [];
     let daemonPtys;
     try {
       const resp = await daemonRequest({ type: "list" });
@@ -1643,6 +1644,7 @@ async function reconcilePool() {
       const needsRestart = !pty || pty.exited || slot.status === "error";
 
       if (needsRestart) {
+        const reason = !pty || pty.exited ? "dead" : "error";
         if (!pty || pty.exited) {
           if (slot.status !== "dead") {
             slot.status = "dead";
@@ -1655,7 +1657,6 @@ async function reconcilePool() {
         await killSlotProcess(slot);
         // Auto-restart slot
         try {
-          const reason = slot.status === "error" ? "error" : "dead";
           debugLog(
             "main",
             `Auto-recovering ${reason} slot ${slot.index} (termId=${slot.termId} pid=${slot.pid})`,
@@ -1666,6 +1667,7 @@ async function reconcilePool() {
           slot.status = "starting";
           slot.sessionId = null;
           changed = true;
+          recovered.push({ index: slot.index, reason });
           trackNewSlot(slot);
         } catch (err) {
           debugLog(
@@ -1698,6 +1700,11 @@ async function reconcilePool() {
     }
 
     if (changed) writePool(pool);
+
+    // Notify renderer about recovered slots
+    if (recovered.length > 0 && mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send("pool-slots-recovered", recovered);
+    }
   });
 }
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -24,6 +24,7 @@ const channels = [
   "focus-external",
   "jump-recent-idle",
   "archive-current-session",
+  "pool-slots-recovered",
 ];
 for (const ch of channels) ipcRenderer.removeAllListeners(ch);
 
@@ -137,4 +138,6 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.on("jump-recent-idle", () => callback()),
   onArchiveCurrentSession: (callback) =>
     ipcRenderer.on("archive-current-session", () => callback()),
+  onPoolSlotsRecovered: (callback) =>
+    ipcRenderer.on("pool-slots-recovered", (_e, slots) => callback(slots)),
 });

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1226,6 +1226,30 @@ function showNotification(msg) {
   }, 3000);
 }
 
+// Corner toast for important system events (auto-recovery, errors)
+function showToast(msg, level = "info") {
+  let container = document.getElementById("toast-container");
+  if (!container) {
+    container = document.createElement("div");
+    container.id = "toast-container";
+    document.body.appendChild(container);
+  }
+  const toast = document.createElement("div");
+  toast.className = `toast toast-${level}`;
+  toast.textContent = msg;
+  container.appendChild(toast);
+  // Auto-dismiss after 8s
+  setTimeout(() => {
+    toast.classList.add("toast-exit");
+    toast.addEventListener("animationend", () => toast.remove());
+  }, 8000);
+  // Click to dismiss
+  toast.addEventListener("click", () => {
+    toast.classList.add("toast-exit");
+    toast.addEventListener("animationend", () => toast.remove());
+  });
+}
+
 async function selectSession(session) {
   // If already viewing this session, nothing to do
   if (session.sessionId === currentSessionId) return;
@@ -1951,6 +1975,14 @@ window.api.onCyclePane(cyclePane);
 window.api.onFocusExternalTerminal(focusCurrentExternalTerminal);
 window.api.onJumpRecentIdle(jumpToRecentIdle);
 window.api.onArchiveCurrentSession(archiveCurrentSession);
+
+// Pool slot recovery toast
+window.api.onPoolSlotsRecovered((slots) => {
+  const reasons = slots.map((s) => `slot ${s.index} (${s.reason})`).join(", ");
+  const msg = `Auto-recovered ${slots.length} pool slot${slots.length > 1 ? "s" : ""}: ${reasons}`;
+  debugLog("pool", msg);
+  showToast(msg, "warning");
+});
 
 // Reconnect a single PTY from daemon (after app restart or reload)
 async function reconnectTerminal(ptyInfo) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -994,3 +994,59 @@ body {
 .close-dialog-btn:hover {
   color: var(--text);
 }
+
+/* Toast notifications */
+#toast-container {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  z-index: 10000;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.toast {
+  pointer-events: auto;
+  padding: 10px 16px;
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--text);
+  background: var(--bg-sidebar);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  max-width: 400px;
+  animation: toast-in 0.2s ease-out;
+}
+
+.toast-warning {
+  border-color: var(--accent);
+  background: rgba(255, 40, 40, 0.1);
+}
+
+.toast-exit {
+  animation: toast-out 0.2s ease-in forwards;
+}
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes toast-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+}


### PR DESCRIPTION
## Summary

- When `reconcilePool` auto-restarts dead/error slots, a toast notification appears in the bottom-right corner
- Shows which slots were recovered and why (dead vs error)
- Toast auto-dismisses after 8s, click to dismiss early
- Also logged to `debug.log` via the renderer's `debugLog`
- Adds reusable `showToast(msg, level)` for future system notifications

## Test plan

- [x] All 202 tests pass
- [ ] Manually verify: kill a Claude process from a pool slot → toast should appear within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)