### PR TITLE
Skip archiving empty sessions that were never used

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ fresh → typing → processing → idle → offloaded (graceful /clear, snapsho
 
 ### Archiving
 
-- **Auto-archive**: All dead sessions (including external) are auto-archived. Previously only dead sessions with intentions were archived.
+- **Auto-archive**: Dead sessions with an intention heading are auto-archived. Sessions that were never used (no intention, no snapshot) are silently discarded to avoid archive spam.
 - **Manual archive**: Right-click any session → "Archive". Pool sessions are auto-offloaded (snapshot + `/clear`) before archiving.
 - **Sidebar**: Archive section appears below Processing. Archived sessions are dimmed.
 - **Resume**: Click an archived session → "Restart Session" dialog → acquires a fresh pool slot, runs `/resume <uuid>`, moves back to Recent.

--- a/src/main.js
+++ b/src/main.js
@@ -489,6 +489,30 @@ async function getOffloadedSessions() {
       if (!meta) continue;
       const snapshotFile = path.join(OFFLOADED_DIR, dir, "snapshot.log");
       const hasSnapshot = fs.existsSync(snapshotFile);
+
+      // Delete empty sessions (no snapshot + no intention) — they were never used
+      if (!hasSnapshot && !meta.intentionHeading) {
+        try {
+          fs.rmSync(path.join(OFFLOADED_DIR, dir), { recursive: true });
+          // Clean up empty intention file if it exists
+          const intentionPath = path.join(INTENTIONS_DIR, `${dir}.md`);
+          try {
+            const stat = fs.statSync(intentionPath);
+            if (stat.size === 0) fs.unlinkSync(intentionPath);
+          } catch {
+            /* no file or non-empty */
+          }
+        } catch (err) {
+          debugLog(
+            "main",
+            "failed to clean up empty session",
+            dir,
+            err.message,
+          );
+        }
+        continue;
+      }
+
       // Sessions without a snapshot can't be meaningfully resumed — treat as archived
       const isArchived = meta.archived || !hasSnapshot;
       if (!meta.archived && !hasSnapshot) {
@@ -774,6 +798,30 @@ async function getSessionsUncached() {
 
     const offloadDir = path.join(OFFLOADED_DIR, s.sessionId);
     if (!fs.existsSync(offloadDir)) {
+      // Skip archiving sessions that were never used (no intention = no user prompt)
+      if (!s.intentionHeading) {
+        try {
+          fs.unlinkSync(path.join(SESSION_PIDS_DIR, String(s.pid)));
+        } catch (err) {
+          debugLog(
+            "main",
+            "failed to remove dead PID file",
+            s.pid,
+            err.message,
+          );
+        }
+        // Clean up empty intention file if it exists
+        try {
+          const intentionPath = path.join(INTENTIONS_DIR, `${s.sessionId}.md`);
+          const stat = fs.statSync(intentionPath);
+          if (stat.size === 0) fs.unlinkSync(intentionPath);
+        } catch {
+          /* no intention file or non-empty — fine */
+        }
+        sessions.splice(i, 1);
+        continue;
+      }
+
       // Recover cwd from JSONL since lsof doesn't work on dead processes
       let cwd = s.cwd || (await getCwdFromJsonl(s.sessionId));
       let gitRoot = s.gitRoot || (await findGitRoot(cwd));


### PR DESCRIPTION
## Summary

- Dead sessions without an intention heading (never prompted by user) are silently discarded instead of archived
- Existing empty archived sessions (no snapshot + no intention) are deleted on startup
- Empty 0-byte intention files are cleaned up in both paths

Fixes 50+ junk entries spamming the archive from pool sessions that were spawned but never used.

## Test plan

- [x] All 202 tests pass
- [ ] Restart production app → verify empty archived sessions are cleaned up
- [ ] Kill a fresh pool session → verify it doesn't appear in archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)