### PR TITLE
Fix term exec opening ephemeral tab at wrong cwd

### DIFF
--- a/bin/cockpit-cli
+++ b/bin/cockpit-cli
@@ -1098,8 +1098,9 @@ case "$CMD" in
 
         resolve_term_target "$TARGET"
 
-        # Open ephemeral shell tab
-        json="{\"type\":\"session-term-open\",\"id\":1,\"sessionId\":\"$RESOLVED_SESSION_ID\"}"
+        # Open ephemeral shell tab at caller's cwd
+        CWD_JSON=$(printf '%s' "$PWD" | jq -Rs .)
+        json="{\"type\":\"session-term-open\",\"id\":1,\"sessionId\":\"$RESOLVED_SESSION_ID\",\"cwd\":$CWD_JSON}"
         RESULT=$(send_api "$json")
         check_error "$RESULT"
         TAB_INDEX=$(json_field "$RESULT" "tabIndex")


### PR DESCRIPTION
## Summary

- `term exec` was opening the ephemeral shell at the first terminal's cwd (typically `~`), not at the caller's working directory
- Now passes `$PWD` as cwd to `session-term-open`

## Test plan

- [x] 210/210 tests pass
- [x] Manual: `cockpit-cli term exec 'pwd'` from a project dir now returns the project dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)