### PR TITLE
Fix: separate dev api.sock, stop idle signal, atomic graph writes, graph pruning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,8 @@ New sessions will have the latest hooks.
 - `~/.open-cockpit/shortcuts.json` — User keyboard shortcut overrides (only non-default values)
 - `~/.open-cockpit/setup-scripts/` — Setup script files for Cmd+N picker
 - `~/.open-cockpit/debug.log` — Debug log (both main + renderer, rotates at 2 MB)
-- `~/.open-cockpit/api.sock` — Programmatic API Unix socket
+- `~/.open-cockpit/api.sock` — Programmatic API Unix socket (production)
+- `~/.open-cockpit/api-dev.sock` — API socket for dev instances (isolated from production)
 - `~/.open-cockpit/pty-daemon.sock` — PTY daemon Unix socket
 - `~/.open-cockpit/pty-daemon.pid` — PTY daemon PID file
 

--- a/src/main.js
+++ b/src/main.js
@@ -63,7 +63,10 @@ const POOL_FILE = path.join(
 );
 const SETUP_SCRIPTS_DIR = path.join(OPEN_COCKPIT_DIR, "setup-scripts");
 const SESSION_GRAPH_FILE = path.join(OPEN_COCKPIT_DIR, "session-graph.json");
-const API_SOCKET = path.join(OPEN_COCKPIT_DIR, "api.sock");
+const API_SOCKET = path.join(
+  OPEN_COCKPIT_DIR,
+  IS_DEV ? "api-dev.sock" : "api.sock",
+);
 const DEBUG_LOG_FILE = path.join(OPEN_COCKPIT_DIR, "debug.log");
 const DEBUG_LOG_MAX_SIZE = 2 * 1024 * 1024; // 2 MB
 const DEFAULT_POOL_SIZE = 5;
@@ -1192,7 +1195,11 @@ function readSessionGraph() {
 }
 
 function writeSessionGraph(graph) {
-  secureWriteFileSync(SESSION_GRAPH_FILE, JSON.stringify(graph, null, 2));
+  const data = JSON.stringify(graph, null, 2);
+  const tmp = SESSION_GRAPH_FILE + ".tmp";
+  fs.writeFileSync(tmp, data);
+  fs.chmodSync(tmp, 0o600);
+  fs.renameSync(tmp, SESSION_GRAPH_FILE);
 }
 
 function recordSessionRelation(sessionId, parentSessionId, initiator) {
@@ -1807,7 +1814,38 @@ async function reconcilePool() {
     if (recovered.length > 0 && mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.send("pool-slots-recovered", recovered);
     }
+
+    // Prune session graph — remove entries for sessions that no longer exist
+    pruneSessionGraph(pool);
   });
+}
+
+function pruneSessionGraph(pool) {
+  const graph = readSessionGraph();
+  const graphKeys = Object.keys(graph);
+  if (graphKeys.length === 0) return;
+
+  // Collect all known session IDs: pool slots + offloaded/archived
+  const knownIds = new Set();
+  for (const slot of pool.slots) {
+    if (slot.sessionId) knownIds.add(slot.sessionId);
+  }
+  try {
+    for (const dir of fs.readdirSync(OFFLOADED_DIR)) {
+      knownIds.add(dir);
+    }
+  } catch {
+    /* OFFLOADED_DIR may not exist */
+  }
+
+  let pruned = false;
+  for (const id of graphKeys) {
+    if (!knownIds.has(id)) {
+      delete graph[id];
+      pruned = true;
+    }
+  }
+  if (pruned) writeSessionGraph(graph);
 }
 
 // Sync pool.json slot statuses with live session state.
@@ -2950,6 +2988,29 @@ app.whenReady().then(async () => {
       daemonSendSafe({ type: "write", termId: slot.termId, data: "\x1b" });
       await new Promise((r) => setTimeout(r, 200));
       daemonSendSafe({ type: "write", termId: slot.termId, data: "\x1b" });
+      // Write idle signal after delay — the hook's stop trigger defers 5s
+      // and may not fire on interruption. We write at 6s as a fallback,
+      // only if no signal exists yet (hook wins if it fires first).
+      const stopPid = slot.pid;
+      const stopSessionId = msg.sessionId;
+      if (stopPid) {
+        setTimeout(() => {
+          const sigFile = path.join(IDLE_SIGNALS_DIR, String(stopPid));
+          if (fs.existsSync(sigFile)) return; // hook already wrote it
+          const signal = JSON.stringify({
+            cwd: "",
+            session_id: stopSessionId,
+            transcript: "",
+            ts: Math.floor(Date.now() / 1000),
+            trigger: "api-stop",
+          });
+          try {
+            fs.writeFileSync(sigFile, signal + "\n");
+          } catch {
+            /* ignore — session may be dead */
+          }
+        }, 6000);
+      }
       return { type: "ok", sessionId: msg.sessionId };
     },
 


### PR DESCRIPTION
## Summary

- **Separate dev socket**: Dev instances use `api-dev.sock` instead of stealing production's `api.sock`. Fixes intermittent test failures and dev/production socket conflicts.
- **Stop writes idle signal**: `pool-stop-session` writes idle signal as fallback after 6s if the hook doesn't fire (interrupted sessions were stuck as "processing").
- **Atomic graph writes**: `session-graph.json` uses write-to-tmp + rename to prevent corruption from concurrent writes.
- **Graph pruning**: `reconcilePool()` now prunes orphaned session graph entries (sessions no longer in pool or offloaded).

## Test plan

- [x] All 217 existing tests pass
- [ ] Start dev instance — verify it uses `api-dev.sock` (not `api.sock`)
- [ ] `cockpit-cli stop <id>` — verify session transitions to idle within ~6s
- [ ] Concurrent `cockpit-cli start` calls — verify `session-graph.json` stays valid

Generated with [Claude Code](https://claude.com/claude-code)