### PR TITLE
Fix restarted sessions showing as typing instead of recent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,7 @@ fresh → typing → processing → idle → offloaded (graceful /clear, snapsho
 - **Why:** Local commands (`/model`, `/help`, etc.) write to the JSONL without triggering hooks, which would cause false "processing" if we compared transcript mtime with signal mtime.
 - **Safety:** `UserPromptSubmit` always clears the signal before processing begins. Stop-hook re-prompts happen within an already-cleared cycle, so no stale signal persists during processing.
 - **No false idle positives.** The app may trigger notifications on idle transitions — a premature "idle" is worse than a delayed one.
+- **Activation tracking:** Sessions with a non-`pool-init` idle signal trigger are marked "activated" in an in-memory Set. Activated sessions always classify as `idle`/`processing`, never `fresh`/`typing` — prevents misclassification when transcript checks fail (e.g. after `/resume` or `/clear`).
 
 ### Debugging session state
 

--- a/src/main.js
+++ b/src/main.js
@@ -253,6 +253,10 @@ function freshOrTyping(hasIntentionContent, hasTermInput) {
 // Cache transcriptContains results (key -> true, once true stays true)
 const userInputCache = new Map();
 
+// Sessions that have been through at least one processing cycle (non-pool-init).
+// Once activated, a session should never fall back to fresh/typing classification.
+const activatedSessions = new Set();
+
 const { parseOrigins } = require("./parse-origins");
 
 // Detect session origin by reading process environment via ps eww (macOS).
@@ -670,6 +674,18 @@ async function getSessionsUncached() {
       poolSlot && terminalHasInputCache.get(poolSlot.termId)
     );
 
+    // Track activation: a non-pool-init idle signal trigger means the session
+    // has been through a real processing cycle and should never revert to
+    // fresh/typing — regardless of what the transcript contains.
+    if (
+      idleSignal &&
+      idleSignal.trigger &&
+      idleSignal.trigger !== "pool-init"
+    ) {
+      activatedSessions.add(sessionId);
+    }
+    const isActivated = activatedSessions.has(sessionId);
+
     if (!alive) {
       status = "dead";
     } else if (idleSignal) {
@@ -680,14 +696,15 @@ async function getSessionsUncached() {
       // local commands (e.g. /model, /help) write to the JSONL without triggering
       // hooks, which would cause permanent false "processing" detection.
       idleTs = idleSignal.ts || 0;
-      // Use "assistant" needle — post-/clear transcripts have "user" entries
-      // from local-command metadata but never assistant responses.
+      // "assistant" needle: post-/clear transcripts have "user" entries from
+      // local-command metadata but never assistant responses.
       if (
-        !(await transcriptContains(idleSignal.transcript, '"type":"assistant"'))
+        isActivated ||
+        (await transcriptContains(idleSignal.transcript, '"type":"assistant"'))
       ) {
-        status = freshOrTyping(hasIntentionContent, hasTermInput);
-      } else {
         status = "idle";
+      } else {
+        status = freshOrTyping(hasIntentionContent, hasTermInput);
       }
     } else {
       // Fallback: if transcript size hasn't changed in a while, treat as idle.
@@ -722,11 +739,15 @@ async function getSessionsUncached() {
           );
         }
         const jsonlPath = jsonlPathCache.get(sessionId);
-        // Use "user" needle — this path only runs when idle signal is absent
-        // (prompt just submitted), so "user" entries are real, not /clear artifacts.
-        status = (await transcriptContains(jsonlPath, '"type":"user"'))
-          ? "processing"
-          : freshOrTyping(hasIntentionContent, hasTermInput);
+        if (isActivated) {
+          status = "processing";
+        } else {
+          // "user" needle: this path only runs when idle signal is absent
+          // (prompt just submitted), so "user" entries are real, not /clear artifacts.
+          status = (await transcriptContains(jsonlPath, '"type":"user"'))
+            ? "processing"
+            : freshOrTyping(hasIntentionContent, hasTermInput);
+        }
       }
     }
 
@@ -920,6 +941,9 @@ async function getSessionsUncached() {
   const liveIds = new Set(sessions.map((s) => s.sessionId));
   for (const id of jsonlSizeTracker.keys()) {
     if (!liveIds.has(id)) jsonlSizeTracker.delete(id);
+  }
+  for (const id of activatedSessions) {
+    if (!liveIds.has(id)) activatedSessions.delete(id);
   }
 
   // Add offloaded/archived sessions, skip if live session exists.


### PR DESCRIPTION
## Summary

- Restarted (resumed) sessions were misclassified as "typing" instead of showing in "Recent" (idle)
- Root cause: `freshOrTyping()` was the fallback for ALL sessions where `hasUserInput(transcript)` returned false, not just truly fresh pool sessions
- After `/resume`, the new JSONL may lack `"type":"user"` entries, triggering this path
- Fix: track "activated" sessions via the idle signal `trigger` field — sessions with a non-`pool-init` trigger always classify as `idle`/`processing`, never `fresh`/`typing`

## Test plan

- [x] All 217 existing tests pass
- [ ] Restart an archived session → verify it appears in Recent (idle), not Typing
- [ ] Fresh pool sessions still show as Fresh/Typing correctly
- [ ] Sessions that go through normal processing cycle → idle transition work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)