### PR TITLE
Fix archive flicker: exclude session-clear from activation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -257,6 +257,10 @@ const transcriptCache = new Map();
 // Once activated, a session should never fall back to fresh/typing classification.
 const activatedSessions = new Set();
 
+// Idle signal triggers that represent fresh/unactivated sessions.
+// Signals with these triggers do NOT mark a session as activated.
+const FRESH_TRIGGERS = new Set(["pool-init", "session-clear"]);
+
 const { parseOrigins } = require("./parse-origins");
 
 // Detect session origin by reading process environment via ps eww (macOS).
@@ -658,11 +662,18 @@ async function getSessionsUncached() {
     const hasIntention = fs.existsSync(intentionFile);
 
     // Run independent I/O in parallel
-    const [intentionHeading, gitRoot, idleSignal] = await Promise.all([
+    const [intentionHeading, gitRoot, rawIdleSignal] = await Promise.all([
       hasIntention ? getIntentionHeading(intentionFile) : null,
       findGitRoot(cwd),
       alive ? getIdleSignal(pid) : null,
     ]);
+    // Discard stale idle signals left by a previous session on the same PID
+    // (e.g. after manual /clear before the session-clear hook overwrites it).
+    // Keep signals with no session_id (backward compat with older hook versions).
+    const idleSignal =
+      !rawIdleSignal?.session_id || rawIdleSignal.session_id === sessionId
+        ? rawIdleSignal
+        : null;
     let status;
     let idleTs = 0;
     let staleIdle = false;
@@ -674,13 +685,12 @@ async function getSessionsUncached() {
       poolSlot && terminalHasInputCache.get(poolSlot.termId)
     );
 
-    // Track activation: a non-pool-init idle signal trigger means the session
-    // has been through a real processing cycle and should never revert to
-    // fresh/typing — regardless of what the transcript contains.
+    // Track activation: triggers NOT in FRESH_TRIGGERS mean the session has
+    // been through a real processing cycle and should never revert to fresh/typing.
     if (
       idleSignal &&
       idleSignal.trigger &&
-      idleSignal.trigger !== "pool-init"
+      !FRESH_TRIGGERS.has(idleSignal.trigger)
     ) {
       activatedSessions.add(sessionId);
     }


### PR DESCRIPTION
## Summary

- After Cmd+D archive, the new post-`/clear` session briefly flickered in "Recent" before being recognized as fresh
- **Root cause**: The `session-clear` SessionStart hook wrote an idle signal whose trigger passed the activation check (`!== "pool-init"`), permanently marking the fresh session as "activated" → "idle"
- **Fix 1**: Refactored activation guard to use a `FRESH_TRIGGERS` Set excluding both `"pool-init"` and `"session-clear"` — both represent fresh sessions not yet through a real processing cycle
- **Fix 2**: Added session_id cross-check — idle signals whose `session_id` doesn't match the PID file's session ID are discarded as stale (prevents misattribution after manual `/clear` before the hook fires)
- The `session-clear` hook itself is kept because it overwrites the stale idle signal from the previous session on the same PID

## Test plan

- [x] All 217 existing tests pass
- [ ] Archive a session with Cmd+D — new session should NOT briefly appear in "Recent"
- [ ] Manual `/clear` in a pool session — session should appear as "fresh", not "idle"
- [ ] Stale idle signal from previous session on same PID should be discarded (session_id mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)