### PR TITLE
Fix cockpit-cli socket detection and PATH availability

### DIFF
--- a/bin/cockpit-cli
+++ b/bin/cockpit-cli
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SOCKET="${COCKPIT_SOCKET:-$HOME/.open-cockpit/api.sock}"
+OC_DIR="$HOME/.open-cockpit"
+PROD_SOCKET="$OC_DIR/api.sock"
+DEV_SOCKET="$OC_DIR/api-dev.sock"
+if [ -n "${COCKPIT_SOCKET:-}" ]; then
+  SOCKET="$COCKPIT_SOCKET"
+elif [ -S "$PROD_SOCKET" ]; then
+  SOCKET="$PROD_SOCKET"
+elif [ -S "$DEV_SOCKET" ]; then
+  SOCKET="$DEV_SOCKET"
+else
+  SOCKET="$PROD_SOCKET"
+fi
 CLAUDE_PROJECTS_DIR="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
 SESSION_PIDS_DIR="${SESSION_PIDS_DIR:-$HOME/.open-cockpit/session-pids}"
 

--- a/hooks/session-pid-map.sh
+++ b/hooks/session-pid-map.sh
@@ -10,6 +10,17 @@ source "$(dirname "$0")/common.sh"
 
 mkdir -p "$SESSION_PIDS_DIR"
 
+# Ensure cockpit-cli is accessible at a stable path
+OC_BIN_DIR="$OC_DIR/bin"
+PLUGIN_CLI="$(dirname "$0")/../bin/cockpit-cli"
+if [ -f "$PLUGIN_CLI" ]; then
+    target="$(cd "$(dirname "$PLUGIN_CLI")" && pwd)/cockpit-cli"
+    if [ "$(readlink "$OC_BIN_DIR/cockpit-cli" 2>/dev/null)" != "$target" ]; then
+        mkdir -p "$OC_BIN_DIR"
+        ln -sf "$target" "$OC_BIN_DIR/cockpit-cli"
+    fi
+fi
+
 # Read session_id from JSON stdin (avoid python3 startup overhead)
 input=""
 read -t 1 -r input 2>/dev/null || true

--- a/skills/cockpit-terminals/SKILL.md
+++ b/skills/cockpit-terminals/SKILL.md
@@ -7,7 +7,12 @@ description: Use when needing to run shell commands, check server output, or do 
 
 Your session has **terminal tabs** visible in the Open Cockpit sidebar. Tab 0 is the Claude TUI (you). Additional tabs are persistent shells — the user can see, type into, and read them in real-time, and so can you.
 
-All `cockpit-cli term` commands auto-detect your session ID — no target argument needed.
+The CLI lives at `~/.open-cockpit/bin/cockpit-cli`. All `term` commands auto-detect your session ID — no target argument needed.
+
+**First, set up an alias** (run once per session):
+```bash
+alias cockpit-cli=~/.open-cockpit/bin/cockpit-cli
+```
 
 ## Quick Start
 

--- a/test/cockpit-cli.test.js
+++ b/test/cockpit-cli.test.js
@@ -700,6 +700,78 @@ describe("cockpit-cli", () => {
     });
   });
 
+  describe("socket auto-detection", () => {
+    it("falls back to api-dev.sock when api.sock missing", async () => {
+      // Move api.sock to api-dev.sock
+      const ocDir = path.join(TMP_DIR, ".open-cockpit");
+      const prodSock = path.join(ocDir, "api.sock");
+      const devSock = path.join(ocDir, "api-dev.sock");
+      fs.renameSync(prodSock, devSock);
+
+      try {
+        const r = await runCli(["ping"]);
+        expect(r.code).toBe(0);
+        expect(r.stdout).toContain("pong");
+      } finally {
+        // Restore
+        fs.renameSync(devSock, prodSock);
+      }
+    });
+
+    it("prefers api.sock when both exist", async () => {
+      // Create a dev socket that returns a different response
+      const ocDir = path.join(TMP_DIR, ".open-cockpit");
+      const devSock = path.join(ocDir, "api-dev.sock");
+      const devServer = net.createServer((socket) => {
+        socket.on("data", () => {
+          socket.write(
+            JSON.stringify({ type: "error", error: "wrong socket" }) + "\n",
+          );
+        });
+      });
+
+      await new Promise((resolve) => devServer.listen(devSock, resolve));
+
+      try {
+        // api.sock exists and works, so it should be preferred
+        const r = await runCli(["ping"]);
+        expect(r.code).toBe(0);
+        expect(r.stdout).toContain("pong");
+      } finally {
+        devServer.close();
+      }
+    });
+
+    it("respects COCKPIT_SOCKET env override", async () => {
+      const ocDir = path.join(TMP_DIR, ".open-cockpit");
+      const customSock = path.join(ocDir, "custom.sock");
+      const customServer = net.createServer((socket) => {
+        let buf = "";
+        socket.on("data", (chunk) => {
+          buf += chunk.toString();
+          let idx;
+          while ((idx = buf.indexOf("\n")) !== -1) {
+            const line = buf.slice(0, idx);
+            buf = buf.slice(idx + 1);
+            if (!line.trim()) continue;
+            const msg = JSON.parse(line);
+            socket.write(JSON.stringify({ type: "pong", id: msg.id }) + "\n");
+          }
+        });
+      });
+
+      await new Promise((resolve) => customServer.listen(customSock, resolve));
+
+      try {
+        const r = await runCli(["ping"], { COCKPIT_SOCKET: customSock });
+        expect(r.code).toBe(0);
+        expect(r.stdout).toContain("pong");
+      } finally {
+        customServer.close();
+      }
+    });
+  });
+
   describe("help", () => {
     it("shows help text", async () => {
       const r = await runCli(["help"]);


### PR DESCRIPTION
## Summary

- `cockpit-cli` now auto-detects the API socket: `COCKPIT_SOCKET` env → `api.sock` → `api-dev.sock` fallback
- SessionStart hook creates a stable symlink at `~/.open-cockpit/bin/cockpit-cli`
- Skill docs updated to reference the stable path with alias setup

Fixes sessions spawned by the dev instance failing with `ENOENT` on `api.sock`.

## Test plan

- [x] 3 new tests: socket fallback, preference order, env override
- [x] Full suite passes (220/220)

🤖 Generated with [Claude Code](https://claude.com/claude-code)