### PR TITLE
Add Open in Cursor shortcut

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -53,6 +53,7 @@ All shortcuts appear in the command palette (`Cmd+/`). The `COMMANDS` array in `
 | `Cmd+E` | Focus Editor |
 | `` Cmd+` `` | Focus Terminal |
 | `Cmd+O` | Focus External Terminal |
+| `Ctrl+Alt+Cmd+C` | Open in Cursor |
 | `Escape` | Focus Terminal |
 | `Cmd+/` | Command Palette |
 | *(unbound)* | Toggle Pane Focus (editor ↔ terminal) |

--- a/src/main.js
+++ b/src/main.js
@@ -2217,6 +2217,45 @@ function watchIntention(sessionId) {
 
 const pendingPolls = new Set();
 
+// Open the session's project directory in Cursor.
+// Checks for .code-workspace files (matching project name or inside folder).
+async function openInCursor(cwd) {
+  if (!cwd) return;
+
+  const projectName = path.basename(cwd);
+  const workspaceDir = path.join(
+    os.homedir(),
+    "Documents",
+    "Projects",
+    "VS code workspaces",
+  );
+
+  // Check named workspace file
+  const namedWorkspace = path.join(
+    workspaceDir,
+    `${projectName}.code-workspace`,
+  );
+  if (fs.existsSync(namedWorkspace)) {
+    await execFileAsync("open", ["-a", "Cursor", namedWorkspace]);
+    return;
+  }
+
+  // Check in-folder workspace file
+  try {
+    const entries = fs.readdirSync(cwd);
+    const localWs = entries.find((e) => e.endsWith(".code-workspace"));
+    if (localWs) {
+      await execFileAsync("open", ["-a", "Cursor", path.join(cwd, localWs)]);
+      return;
+    }
+  } catch {
+    /* ignore read errors */
+  }
+
+  // Fall back to opening the folder
+  await execFileAsync("open", ["-a", "Cursor", cwd]);
+}
+
 // Try to focus the external terminal (iTerm or Cursor) where a Claude session is running.
 // Returns { focused: true, app: "iTerm"/"Cursor" } or { focused: false }.
 function focusExternalTerminal(pid) {
@@ -2682,6 +2721,8 @@ app.whenReady().then(async () => {
   ipcMain.handle("focus-external-terminal", (_e, pid) =>
     focusExternalTerminal(pid),
   );
+
+  ipcMain.handle("open-in-cursor", (_e, cwd) => openInCursor(cwd));
 
   // Pool / offload IPC handlers
   ipcMain.handle(
@@ -3458,6 +3499,11 @@ app.whenReady().then(async () => {
             label: "Focus External Terminal",
             accelerator: accel("focus-external"),
             click: () => send("focus-external"),
+          },
+          {
+            label: "Open in Cursor",
+            accelerator: accel("open-in-cursor"),
+            click: () => send("open-in-cursor"),
           },
           { type: "separator" },
           {

--- a/src/preload.js
+++ b/src/preload.js
@@ -26,6 +26,7 @@ const channels = [
   "focus-external",
   "jump-recent-idle",
   "archive-current-session",
+  "open-in-cursor",
   "pool-slots-recovered",
 ];
 for (const ch of channels) ipcRenderer.removeAllListeners(ch);
@@ -148,6 +149,12 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.on("jump-recent-idle", () => callback()),
   onArchiveCurrentSession: (callback) =>
     ipcRenderer.on("archive-current-session", () => callback()),
+  onOpenInCursor: (callback) =>
+    ipcRenderer.on("open-in-cursor", () => callback()),
+
+  // Open in Cursor
+  openInCursor: (cwd) => ipcRenderer.invoke("open-in-cursor", cwd),
+
   onPoolSlotsRecovered: (callback) =>
     ipcRenderer.on("pool-slots-recovered", (_e, slots) => callback(slots)),
 });

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1888,6 +1888,14 @@ const COMMANDS = [
     action: focusCurrentExternalTerminal,
   },
   {
+    id: "open-in-cursor",
+    label: "Open in Cursor",
+    shortcutAction: "open-in-cursor",
+    action: () => {
+      if (currentSessionCwd) window.api.openInCursor(currentSessionCwd);
+    },
+  },
+  {
     id: "refresh",
     label: "Refresh Sessions",
     action: () => {
@@ -2156,6 +2164,9 @@ window.api.onCyclePane(cyclePane);
 window.api.onFocusExternalTerminal(focusCurrentExternalTerminal);
 window.api.onJumpRecentIdle(jumpToRecentIdle);
 window.api.onArchiveCurrentSession(archiveCurrentSession);
+window.api.onOpenInCursor(() => {
+  if (currentSessionCwd) window.api.openInCursor(currentSessionCwd);
+});
 
 // Pool slot recovery toast
 window.api.onPoolSlotsRecovered((slots) => {

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -30,6 +30,7 @@ const DEFAULT_SHORTCUTS = {
   "focus-external": "CmdOrCtrl+O",
   "jump-recent-idle": "CmdOrCtrl+J",
   "archive-current-session": "CmdOrCtrl+D",
+  "open-in-cursor": "Ctrl+Alt+Cmd+C",
   "toggle-command-palette": "CmdOrCtrl+/",
   // These are handled via before-input-event, not menu accelerators
   "next-terminal-tab-alt": "Ctrl+Tab",


### PR DESCRIPTION
## Summary
- Adds "Open in Cursor" action (`Ctrl+Alt+Cmd+C`) — opens the current session's project in Cursor
- Detects workspace files (named workspace in `~/Documents/Projects/VS code workspaces/`, in-folder `.code-workspace`, or plain folder)
- Available via keyboard shortcut and command palette

## Test plan
- [x] Build passes
- [x] All 220 tests pass
- [ ] Press `Ctrl+Alt+Cmd+C` on a session → Cursor opens at project dir
- [ ] Verify workspace file detection works
- [ ] Verify command palette shows "Open in Cursor"

🤖 Generated with [Claude Code](https://claude.com/claude-code)