### PR TITLE
Keep currentSessionCwd in sync on refresh

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -863,6 +863,13 @@ async function loadSessions() {
     cachedSessions.map((s) => [s.sessionId, s.status]),
   );
   cachedSessions = sessions;
+
+  // Keep CWD in sync (may change as JSONL records cd commands)
+  if (currentSessionId) {
+    const current = sessions.find((s) => s.sessionId === currentSessionId);
+    if (current?.cwd) currentSessionCwd = current.cwd;
+  }
+
   cleanupStaleTerminals(sessions);
   updatePoolHealthBadge();
 


### PR DESCRIPTION
## Summary
- Updates `currentSessionCwd` on every session refresh so it stays current when a session `cd`s
- Without this, "New Terminal Tab" and "Open in Cursor" could use a stale CWD (e.g. `~` for pool sessions that later `cd` into a project)

## Test plan
- [x] All 220 tests pass
- [ ] Start a pool session at `~`, `cd` into a project, open a new terminal tab → should spawn in the project dir, not `~`

🤖 Generated with [Claude Code](https://claude.com/claude-code)