### PR TITLE
Fix terminal focus on spawn, close, and DOM rebuild

### DIFF
--- a/src/dock-helpers.js
+++ b/src/dock-helpers.js
@@ -109,7 +109,6 @@ export function focusLeafContent(dock, leafId, terminals) {
   if (activeTabId === TAB_EDITOR) return; // caller handles editor focus
   const entry = terminals.find((t) => t.dockTabId === activeTabId);
   if (entry) {
-    dock.activateTab(activeTabId);
-    entry.term.focus();
+    dock.activateTab(activeTabId); // fires onTabActivate which focuses the terminal
   }
 }

--- a/src/dock-layout.js
+++ b/src/dock-layout.js
@@ -297,6 +297,13 @@ export class DockLayout {
   // --- Rendering ---
 
   _render() {
+    // Save focused element before DOM rebuild — detaching content drops focus
+    const activeEl = document.activeElement;
+    const hadFocus =
+      activeEl &&
+      activeEl !== document.body &&
+      this.container.contains(activeEl);
+
     this._detachAllContent();
     this.container.innerHTML = "";
     if (!this.root) return;
@@ -305,6 +312,12 @@ export class DockLayout {
     // Dispatch synchronously — handlers use their own rAF to read layout after
     // the browser has recalculated flex sizes in the next frame.
     window.dispatchEvent(new Event("dock-resize"));
+
+    // Restore focus — content elements are reattached, so the previously
+    // focused element (e.g. xterm textarea) is back in the DOM
+    if (hadFocus && this.container.contains(activeEl)) {
+      activeEl.focus();
+    }
   }
 
   _renderNode(node) {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -476,7 +476,7 @@ function ensureDock() {
       // Focus the activated tab's content — resize is handled by dock-resize event
       const entry = terminals.find((t) => t.dockTabId === tabId);
       if (entry) {
-        requestAnimationFrame(() => entry.term.focus());
+        entry.term.focus();
       }
       if (tabId === TAB_EDITOR && editorView) {
         editorView.focus();
@@ -622,6 +622,9 @@ async function spawnTerminal(cwd, cmd, args, targetLeafId) {
     dock.addTab(entry.dockTabId, leaf);
   }
 
+  // Focus the new terminal so user can type immediately
+  entry.term.focus();
+
   syncSessionCache();
   return entry;
 }
@@ -674,6 +677,9 @@ async function attachPoolTerminal(poolTermId) {
     dock.addTab(entry.dockTabId, leaf);
   }
 
+  // Focus the new terminal so user can type immediately
+  entry.term.focus();
+
   syncSessionCache();
   return entry;
 }
@@ -699,6 +705,9 @@ async function closeTerminal(index) {
   if (terminals.length === 0) {
     sessionView.classList.add("hidden");
     emptyState.classList.remove("hidden");
+  } else {
+    // Focus the remaining active terminal (or first terminal)
+    focusTerminal();
   }
 
   syncSessionCache();


### PR DESCRIPTION
## Summary
- `_render()` saves/restores `document.activeElement` across DOM rebuild — fixes focus loss on tab drag-drop, splits, and tab removal
- `spawnTerminal`/`attachPoolTerminal` auto-focus the new terminal after `dock.addTab()`
- `closeTerminal` focuses remaining terminal instead of leaving focus orphaned
- `onTabActivate` focuses synchronously (removed rAF delay that allowed focus stealing)
- `focusLeafContent` removes redundant `term.focus()` (`activateTab` fires `onTabActivate`)

## Test plan
- [ ] Cmd+T: cursor in new terminal immediately
- [ ] Close terminal tab: cursor jumps to remaining terminal
- [ ] Switch tabs (Ctrl+Tab / Ctrl+Shift+Tab): cursor always active
- [ ] Switch sessions in sidebar: cursor in Claude terminal
- [ ] Drag tab to split: cursor stays in dragged tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)