### PR TITLE
Archive offloaded sessions on pool destroy

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2083,24 +2083,7 @@ async function poolDestroy() {
     }
     // Archive non-archived offloaded sessions so they don't linger in Recent
     for (const s of await getOffloadedSessions()) {
-      if (s.status !== "offloaded") continue;
-      const meta = readOffloadMeta(s.sessionId);
-      if (!meta) continue;
-      meta.archived = true;
-      meta.archivedAt = new Date().toISOString();
-      try {
-        secureWriteFileSync(
-          path.join(OFFLOADED_DIR, s.sessionId, "meta.json"),
-          JSON.stringify(meta, null, 2),
-        );
-      } catch (err) {
-        debugLog(
-          "main",
-          "poolDestroy: failed to archive offloaded session",
-          s.sessionId,
-          err.message,
-        );
-      }
+      if (s.status === "offloaded") await archiveSession(s.sessionId);
     }
   });
 }


### PR DESCRIPTION
## Summary

- `poolDestroy()` now archives all non-archived offloaded sessions
- Previously, sessions offloaded via LRU eviction would linger in the "Recent" sidebar section after pool destroy, with no pool slot to resume into
- They now move to Archive where they belong

## Test plan

- [x] All 220 tests pass
- [ ] Destroy pool → verify offloaded sessions move to Archive section (not Recent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)