### PR TITLE
Fix terminal resize when switching sessions

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -735,6 +735,10 @@ function restoreSessionTerminals(sessionId) {
   initDockLayout(terminals, cached.dockLayout);
   for (const entry of terminals) setupTerminalResize(entry);
 
+  // initDockLayout dispatches dock-resize before listeners are registered —
+  // fire again so restored terminals adapt to the current container size
+  window.dispatchEvent(new Event("dock-resize"));
+
   return true;
 }
 


### PR DESCRIPTION
## Summary

- Terminals kept their old dimensions when switching between cached sessions because `initDockLayout` dispatches `dock-resize` before `setupTerminalResize` registers the listeners
- Fix: dispatch `dock-resize` again after listeners are set up

## Test plan

- [ ] Open two sessions at different terminal widths (e.g. resize window between switching)
- [ ] Switch between them — terminals should reflow to current width
- [ ] Cmd+N a new session, switch back — layout should adapt

🤖 Generated with [Claude Code](https://claude.com/claude-code)