### PR TITLE
Fix API socket race condition between Electron instances

### DIFF
--- a/bin/cockpit-cli
+++ b/bin/cockpit-cli
@@ -11,7 +11,9 @@ elif [ -S "$PROD_SOCKET" ]; then
 elif [ -S "$DEV_SOCKET" ]; then
   SOCKET="$DEV_SOCKET"
 else
-  SOCKET="$PROD_SOCKET"
+  echo "Error: Open Cockpit API socket not found (neither api.sock nor api-dev.sock exist)." >&2
+  echo "The app may not be running, or lost its socket after a double-launch. Restart Open Cockpit to fix." >&2
+  exit 1
 fi
 CLAUDE_PROJECTS_DIR="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
 SESSION_PIDS_DIR="${SESSION_PIDS_DIR:-$HOME/.open-cockpit/session-pids}"

--- a/skills/cockpit-terminals/SKILL.md
+++ b/skills/cockpit-terminals/SKILL.md
@@ -7,27 +7,31 @@ description: Use when needing to run shell commands, check server output, or do 
 
 Your session has **terminal tabs** visible in the Open Cockpit sidebar. Tab 0 is the Claude TUI (you). Additional tabs are persistent shells — the user can see, type into, and read them in real-time, and so can you.
 
-The CLI lives at `~/.open-cockpit/bin/cockpit-cli`. All `term` commands auto-detect your session ID — no target argument needed.
+The CLI path is `~/.open-cockpit/bin/cockpit-cli`. Do NOT create a shell alias — aliases don't persist across Bash tool calls. All examples below use the full path.
 
-**First, set up an alias** (run once per session):
-```bash
-alias cockpit-cli=~/.open-cockpit/bin/cockpit-cli
-```
+All `term` commands auto-detect your session ID — no target argument needed.
+
+## Key concepts
+
+- **Tab 0 is your TUI** — you cannot `run` or `exec` on it. Only shell tabs (1+) accept commands.
+- **Fresh sessions may only have tab 0.** Use `term open` or `term exec` (which creates an ephemeral tab automatically).
+- **`term run`** returns clean output (command result only). Prefer it for getting data.
+- **`term exec`** output includes shell prompts and ANSI artifacts — use when you don't need to parse the output.
 
 ## Quick Start
 
 ```bash
 # One-shot: run a command, get output, tab auto-closes
-cockpit-cli term exec 'npm test'
+~/.open-cockpit/bin/cockpit-cli term exec 'npm test'
 
 # Run in an existing shell tab (preserves state, env vars, cwd)
-cockpit-cli term run 1 'git status'
+~/.open-cockpit/bin/cockpit-cli term run 1 'git status'
 
 # Open a new persistent shell tab
-cockpit-cli term open
+~/.open-cockpit/bin/cockpit-cli term open
 
 # See what tabs you have
-cockpit-cli term ls
+~/.open-cockpit/bin/cockpit-cli term ls
 ```
 
 ## Choosing the Right Command
@@ -41,20 +45,21 @@ cockpit-cli term ls
 
 ## Command Reference
 
-```bash
-cockpit-cli term ls                      # List tabs (index, label, TUI flag)
-cockpit-cli term read <tab>              # Read terminal buffer
-cockpit-cli term write <tab> 'text\r'    # Type into terminal (\r = Enter)
-cockpit-cli term key <tab> ctrl-c        # Send named key
-cockpit-cli term watch <tab>             # Follow output live (Ctrl+C to stop)
-cockpit-cli term open                    # New shell at session cwd
-cockpit-cli term open /path/to/dir       # New shell at specific directory
-cockpit-cli term close <tab>             # Close tab (can't close TUI tab)
-cockpit-cli term run <tab> 'cmd'         # Run command, return output when done
-cockpit-cli term run <tab> 'cmd' --timeout 120  # With timeout (default 30s)
-cockpit-cli term exec 'cmd'              # Ephemeral: open → run → output → close
-cockpit-cli term exec 'cmd' --timeout 120
-```
+All commands below follow the pattern `~/.open-cockpit/bin/cockpit-cli term <subcommand> [args]`.
+
+| Subcommand | Description |
+|------------|-------------|
+| `ls` | List tabs (index, label, TUI flag) |
+| `read <tab>` | Read terminal buffer |
+| `write <tab> 'text\r'` | Type into terminal (`\r` = Enter) |
+| `key <tab> ctrl-c` | Send named key |
+| `watch <tab>` | Follow output live (Ctrl+C to stop) |
+| `open [/path]` | New shell tab at session cwd or given path |
+| `close <tab>` | Close tab (can't close TUI tab) |
+| `run <tab> 'cmd'` | Run command, return output when done (default 30s timeout) |
+| `run <tab> 'cmd' --timeout 120` | With custom timeout in seconds |
+| `exec 'cmd'` | Ephemeral: open tab, run, return output, close |
+| `exec 'cmd' --timeout 120` | With custom timeout |
 
 Available keys: `enter`, `escape`, `ctrl-c`, `ctrl-d`, `ctrl-u`, `ctrl-l`, `ctrl-a`, `ctrl-e`, `ctrl-z`, `tab`, `backspace`, `up`, `down`, `left`, `right`.
 
@@ -68,3 +73,7 @@ Available keys: `enter`, `escape`, `ctrl-c`, `ctrl-d`, `ctrl-u`, `ctrl-l`, `ctrl
 **Use the Bash tool when:**
 - You just need command output for your own reasoning
 - The operation is quick and self-contained
+
+## Troubleshooting
+
+If commands fail with `ENOENT` or "API socket not found", the Open Cockpit app lost its API socket or isn't running. Ask the user to restart Open Cockpit — terminals survive restarts (the PTY daemon keeps them alive).

--- a/src/api-server.js
+++ b/src/api-server.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 
 const MAX_BUFFER_SIZE = 1024 * 1024; // 1MB
 
-function createApiServer(socketPath, handlers) {
+function createApiServer(socketPath, handlers, { onListening } = {}) {
   const server = net.createServer((socket) => {
     const chunks = [];
     let chunksLen = 0;
@@ -72,13 +72,49 @@ function createApiServer(socketPath, handlers) {
     if (!socket.destroyed) socket.write(JSON.stringify(msg) + "\n");
   }
 
-  // Clean up stale socket
-  try {
-    fs.unlinkSync(socketPath);
-  } catch {}
+  // Only replace socket if no live instance is listening on it.
+  // Blindly unlinking lets a second instance steal (and then orphan)
+  // the socket of a running instance.
+  function tryListen() {
+    server.listen(socketPath, () => {
+      fs.chmodSync(socketPath, 0o600);
+      if (onListening) onListening();
+    });
+  }
 
-  server.listen(socketPath, () => {
-    fs.chmodSync(socketPath, 0o600);
+  server.on("error", (err) => {
+    if (err.code === "EADDRINUSE") {
+      console.error(`API socket ${socketPath} is in use. Skipping API server.`);
+    } else {
+      console.error("API server error:", err);
+    }
+  });
+
+  // Probe the socket — connect handles both missing (ENOENT) and stale sockets.
+  const probe = new net.Socket();
+  probe.setTimeout(2000);
+  probe.connect(socketPath, () => {
+    // Another instance is alive — don't steal its socket
+    probe.destroy();
+    console.error(
+      `API socket ${socketPath} is in use by another instance. Skipping API server.`,
+    );
+  });
+  probe.on("error", () => {
+    // Socket missing or stale — safe to replace
+    probe.destroy();
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {}
+    tryListen();
+  });
+  probe.on("timeout", () => {
+    // Hung socket — treat as stale
+    probe.destroy();
+    try {
+      fs.unlinkSync(socketPath);
+    } catch {}
+    tryListen();
   });
 
   return server;

--- a/src/main.js
+++ b/src/main.js
@@ -3009,503 +3009,513 @@ app.whenReady().then(async () => {
   }
 
   // --- Programmatic API server (Unix socket) ---
-  const apiServer = createApiServer(API_SOCKET, {
-    ping: async () => ({ type: "pong" }),
-    "get-sessions": async () => {
-      const sessions = await getSessions();
-      enrichSessionsWithGraphData(sessions);
-      return { type: "sessions", sessions };
-    },
-    "pool-init": async (msg) => ({
-      type: "pool",
-      pool: await poolInit(msg.size),
-    }),
-    "pool-resize": async (msg) => ({
-      type: "pool",
-      pool: await poolResize(msg.size),
-    }),
-    "pool-health": async () => ({
-      type: "health",
-      health: await getPoolHealth(),
-    }),
-    "pool-read": async () => ({
-      type: "pool",
-      pool: readPool(),
-    }),
-    "pool-destroy": async () => {
-      await poolDestroy();
-      return { type: "ok" };
-    },
-    "read-intention": async (msg) => {
-      validateSessionId(msg.sessionId);
-      return { type: "intention", content: readIntention(msg.sessionId) };
-    },
-    "write-intention": async (msg) => {
-      validateSessionId(msg.sessionId);
-      writeIntention(msg.sessionId, msg.content);
-      return { type: "ok" };
-    },
-    "pty-list": async () => {
-      const resp = await daemonRequest({ type: "list" });
-      return { type: "ptys", ptys: resp.ptys };
-    },
-    "pty-write": async (msg) => {
-      validateTermId(msg.termId);
-      daemonSendSafe({ type: "write", termId: msg.termId, data: msg.data });
-      triggerPollOnWrite(msg.termId);
-      return { type: "ok" };
-    },
-    "pty-spawn": async (msg) => {
-      const resp = await daemonRequest({
-        type: "spawn",
-        cwd: msg.cwd,
-        cmd: msg.cmd,
-        args: msg.args,
-        sessionId: msg.sessionId,
-      });
-      return { type: "spawned", termId: resp.termId, pid: resp.pid };
-    },
-    "pty-kill": async (msg) => {
-      validateTermId(msg.termId);
-      await daemonRequest({ type: "kill", termId: msg.termId });
-      return { type: "ok" };
-    },
-    "pty-read": async (msg) => {
-      validateTermId(msg.termId);
-      const resp = await daemonRequest({ type: "list" });
-      const p = resp.ptys.find((p) => p.termId === msg.termId);
-      return { type: "buffer", buffer: p ? p.buffer : null };
-    },
-
-    // --- Pool interaction commands (sub-claude compatible) ---
-
-    "pool-start": async (msg) => {
-      if (!msg.prompt) throw new Error("prompt required");
-      const result = await withFreshSlot(async (pool, slot) => {
-        await sendPromptToTerminal(slot.termId, msg.prompt);
-        slot.status = "busy";
-        writePool(pool);
-
-        return {
-          type: "started",
-          sessionId: slot.sessionId,
-          termId: slot.termId,
-          slotIndex: slot.index,
-        };
-      });
-      recordSessionRelation(
-        result.sessionId,
-        msg.parentSessionId || null,
-        msg.parentSessionId ? "model" : "user",
-      );
-      return result;
-    },
-
-    "pool-resume": async (msg) => {
-      if (!msg.sessionId) throw new Error("sessionId required");
-      return poolResume(msg.sessionId);
-    },
-
-    "pool-followup": async (msg) => {
-      if (!msg.sessionId) throw new Error("sessionId required");
-      if (!msg.prompt) throw new Error("prompt required");
-      return withPoolLock(async () => {
-        const { pool, slot } = findSlotBySessionId(msg.sessionId);
-
-        const status = await getEffectiveSlotStatus(slot);
-        if (status !== "idle")
-          throw new Error(`Session is ${status}, expected idle`);
-
-        await sendPromptToTerminal(slot.termId, msg.prompt);
-        slot.status = "busy";
-        writePool(pool);
-
-        return {
-          type: "started",
-          sessionId: slot.sessionId,
-          termId: slot.termId,
-          slotIndex: slot.index,
-        };
-      });
-    },
-
-    "pool-wait": async (msg) => {
-      const timeout = msg.timeout || 300000;
-
-      if (msg.sessionId) {
-        validateSessionId(msg.sessionId);
-        try {
-          const { slot } = findSlotBySessionId(msg.sessionId);
-          await waitForSessionIdle(msg.sessionId, timeout);
-          const buffer = await getTerminalBuffer(slot.termId);
-          return { type: "result", sessionId: msg.sessionId, buffer };
-        } catch (err) {
-          return { type: "error", error: err.message, id: msg.id };
-        }
-      }
-
-      // Wait by slot index (used by resume --block where session ID changes)
-      if (msg.slotIndex !== undefined) {
-        // Validate slot exists before entering poll loop
-        findSlotByIndex(msg.slotIndex);
-        try {
-          const result = await poll(
-            async () => {
-              // Re-read pool each iteration: sessionId changes after /resume
-              const pool = readPool();
-              const slot = pool?.slots?.[msg.slotIndex];
-              if (!slot?.sessionId) return null;
-              const sessions = await getSessions();
-              const session = sessions.find(
-                (s) => s.sessionId === slot.sessionId,
-              );
-              if (session && session.status === "idle") return slot;
-              if (session && !session.alive)
-                throw new Error("Session process died");
-              return null;
-            },
-            {
-              interval: 1000,
-              initialDelay: 1000,
-              timeout,
-              label: "waiting for slot to become idle",
-            },
-          );
-          const buffer = await getTerminalBuffer(result.termId);
-          return { type: "result", sessionId: result.sessionId, buffer };
-        } catch (err) {
-          return { type: "error", error: err.message, id: msg.id };
-        }
-      }
-
-      // No sessionId or slotIndex: wait for any busy session to become idle
-      const pool = readPool();
-      if (!pool) throw new Error("Pool not initialized");
-      const busySlots = pool.slots.filter((s) => s.status === "busy");
-      if (busySlots.length === 0)
-        throw new Error("No busy sessions to wait for");
-
-      const finished = await poll(
-        async () => {
-          const sessions = await getSessions();
-          for (const s of busySlots) {
-            const session = sessions.find(
-              (sess) => sess.sessionId === s.sessionId,
-            );
-            if (session && session.status === "idle") return s;
-          }
-          return null;
-        },
-        {
-          interval: 1000,
-          initialDelay: 1000,
-          timeout,
-          label: "waiting for session to become idle",
-        },
-      );
-
-      const buffer = await getTerminalBuffer(finished.termId);
-      return { type: "result", sessionId: finished.sessionId, buffer };
-    },
-
-    "pool-capture": async (msg) => {
-      const { slot } = resolveSlot(msg);
-      const buffer = await getTerminalBuffer(slot.termId);
-      return {
-        type: "buffer",
-        sessionId: slot.sessionId,
-        slotIndex: slot.index,
-        buffer,
-      };
-    },
-
-    "pool-result": async (msg) => {
-      const { slot } = resolveSlot(msg);
-      const status = await getEffectiveSlotStatus(slot);
-      if (status === "busy" || status === "processing") {
-        throw new Error("Session is still running");
-      }
-      const buffer = await getTerminalBuffer(slot.termId);
-      return {
-        type: "result",
-        sessionId: slot.sessionId,
-        slotIndex: slot.index,
-        buffer,
-      };
-    },
-
-    "pool-input": async (msg) => {
-      if (msg.data === undefined) throw new Error("data required");
-      const { slot } = resolveSlot(msg);
-      daemonSendSafe({ type: "write", termId: slot.termId, data: msg.data });
-      return { type: "ok" };
-    },
-
-    "pool-clean": async () => {
-      const cleaned = await poolClean();
-      return { type: "cleaned", count: cleaned };
-    },
-
-    "pool-pin": async (msg) => {
-      if (!msg.sessionId) throw new Error("sessionId required");
-      const duration = msg.duration || 120;
-      return withPoolLock(async () => {
-        const { pool, slot } = findSlotBySessionId(msg.sessionId);
-        slot.pinnedUntil = new Date(Date.now() + duration * 1000).toISOString();
-        writePool(pool);
-        return { type: "ok", pinnedUntil: slot.pinnedUntil };
-      });
-    },
-
-    "pool-unpin": async (msg) => {
-      if (!msg.sessionId) throw new Error("sessionId required");
-      return withPoolLock(async () => {
-        const { pool, slot } = findSlotBySessionId(msg.sessionId);
-        delete slot.pinnedUntil;
-        writePool(pool);
+  const apiServer = createApiServer(
+    API_SOCKET,
+    {
+      ping: async () => ({ type: "pong" }),
+      "get-sessions": async () => {
+        const sessions = await getSessions();
+        enrichSessionsWithGraphData(sessions);
+        return { type: "sessions", sessions };
+      },
+      "pool-init": async (msg) => ({
+        type: "pool",
+        pool: await poolInit(msg.size),
+      }),
+      "pool-resize": async (msg) => ({
+        type: "pool",
+        pool: await poolResize(msg.size),
+      }),
+      "pool-health": async () => ({
+        type: "health",
+        health: await getPoolHealth(),
+      }),
+      "pool-read": async () => ({
+        type: "pool",
+        pool: readPool(),
+      }),
+      "pool-destroy": async () => {
+        await poolDestroy();
         return { type: "ok" };
-      });
-    },
+      },
+      "read-intention": async (msg) => {
+        validateSessionId(msg.sessionId);
+        return { type: "intention", content: readIntention(msg.sessionId) };
+      },
+      "write-intention": async (msg) => {
+        validateSessionId(msg.sessionId);
+        writeIntention(msg.sessionId, msg.content);
+        return { type: "ok" };
+      },
+      "pty-list": async () => {
+        const resp = await daemonRequest({ type: "list" });
+        return { type: "ptys", ptys: resp.ptys };
+      },
+      "pty-write": async (msg) => {
+        validateTermId(msg.termId);
+        daemonSendSafe({ type: "write", termId: msg.termId, data: msg.data });
+        triggerPollOnWrite(msg.termId);
+        return { type: "ok" };
+      },
+      "pty-spawn": async (msg) => {
+        const resp = await daemonRequest({
+          type: "spawn",
+          cwd: msg.cwd,
+          cmd: msg.cmd,
+          args: msg.args,
+          sessionId: msg.sessionId,
+        });
+        return { type: "spawned", termId: resp.termId, pid: resp.pid };
+      },
+      "pty-kill": async (msg) => {
+        validateTermId(msg.termId);
+        await daemonRequest({ type: "kill", termId: msg.termId });
+        return { type: "ok" };
+      },
+      "pty-read": async (msg) => {
+        validateTermId(msg.termId);
+        const resp = await daemonRequest({ type: "list" });
+        const p = resp.ptys.find((p) => p.termId === msg.termId);
+        return { type: "buffer", buffer: p ? p.buffer : null };
+      },
 
-    "pool-stop-session": async (msg) => {
-      if (!msg.sessionId) throw new Error("sessionId required");
-      const { slot } = findSlotBySessionId(msg.sessionId);
-      // Escape interrupts Claude generation; send twice to dismiss any menu
-      daemonSendSafe({ type: "write", termId: slot.termId, data: "\x1b" });
-      await new Promise((r) => setTimeout(r, 200));
-      daemonSendSafe({ type: "write", termId: slot.termId, data: "\x1b" });
-      // Write idle signal after delay — the hook's stop trigger defers 5s
-      // and may not fire on interruption. We write at 6s as a fallback,
-      // only if no signal exists yet (hook wins if it fires first).
-      const stopPid = slot.pid;
-      const stopSessionId = msg.sessionId;
-      if (stopPid) {
-        setTimeout(async () => {
-          const sigFile = path.join(IDLE_SIGNALS_DIR, String(stopPid));
-          if (fs.existsSync(sigFile)) return; // hook already wrote it
-          const transcript = (await findJsonlPath(stopSessionId)) || "";
-          const cwd = (await getCwdFromJsonl(stopSessionId)) || "";
-          const signal = JSON.stringify({
-            cwd,
-            session_id: stopSessionId,
-            transcript,
-            ts: Math.floor(Date.now() / 1000),
-            trigger: "api-stop",
-          });
-          try {
-            fs.writeFileSync(sigFile, signal + "\n");
-          } catch {
-            /* ignore — session may be dead */
-          }
-        }, 6000);
-      }
-      return { type: "ok", sessionId: msg.sessionId };
-    },
+      // --- Pool interaction commands (sub-claude compatible) ---
 
-    "archive-session": async (msg) => {
-      if (!msg.sessionId) throw new Error("sessionId required");
-      await archiveSession(msg.sessionId);
-      return { type: "ok" };
-    },
+      "pool-start": async (msg) => {
+        if (!msg.prompt) throw new Error("prompt required");
+        const result = await withFreshSlot(async (pool, slot) => {
+          await sendPromptToTerminal(slot.termId, msg.prompt);
+          slot.status = "busy";
+          writePool(pool);
 
-    "unarchive-session": async (msg) => {
-      if (!msg.sessionId) throw new Error("sessionId required");
-      unarchiveSession(msg.sessionId);
-      return { type: "ok" };
-    },
-
-    "get-session-graph": async () => ({
-      type: "session-graph",
-      graph: readSessionGraph(),
-    }),
-
-    // --- Slot access commands (by index, works without sessionId) ---
-
-    "slot-read": async (msg) => {
-      const { slot } = findSlotByIndex(msg.slotIndex);
-      const buffer = await getTerminalBuffer(slot.termId);
-      return {
-        type: "buffer",
-        slotIndex: slot.index,
-        sessionId: slot.sessionId,
-        buffer,
-      };
-    },
-
-    "slot-write": async (msg) => {
-      if (msg.data === undefined) throw new Error("data required");
-      const { slot } = findSlotByIndex(msg.slotIndex);
-      daemonSendSafe({ type: "write", termId: slot.termId, data: msg.data });
-      return { type: "ok" };
-    },
-
-    "slot-status": async (msg) => {
-      const { slot } = findSlotByIndex(msg.slotIndex);
-      const healthStatus = slot.sessionId
-        ? await getEffectiveSlotStatus(slot)
-        : slot.status;
-      return {
-        type: "slot",
-        slot: {
-          index: slot.index,
-          termId: slot.termId,
-          pid: slot.pid,
-          status: slot.status,
-          sessionId: slot.sessionId,
-          healthStatus,
-          createdAt: slot.createdAt,
-        },
-      };
-    },
-
-    // --- Session terminal access (per-session tab control) ---
-
-    "session-terminals": async (msg) => {
-      if (!msg.sessionId) throw new Error("sessionId required");
-      const terminals = await getSessionTerminals(msg.sessionId);
-      return {
-        type: "terminals",
-        terminals: terminals.map(({ buffer, ...rest }) => rest),
-      };
-    },
-
-    "session-term-read": async (msg) => {
-      if (!msg.sessionId) throw new Error("sessionId required");
-      if (msg.tabIndex === undefined) throw new Error("tabIndex required");
-      const terminals = await getSessionTerminals(msg.sessionId);
-      const tab = terminals[msg.tabIndex];
-      if (!tab) throw new Error(`No terminal at tab index ${msg.tabIndex}`);
-      return { type: "buffer", termId: tab.termId, buffer: tab.buffer };
-    },
-
-    "session-term-write": async (msg) => {
-      if (!msg.sessionId) throw new Error("sessionId required");
-      if (msg.tabIndex === undefined) throw new Error("tabIndex required");
-      if (msg.data === undefined) throw new Error("data required");
-      const terminals = await getSessionTerminals(msg.sessionId);
-      const tab = terminals[msg.tabIndex];
-      if (!tab) throw new Error(`No terminal at tab index ${msg.tabIndex}`);
-      daemonSendSafe({ type: "write", termId: tab.termId, data: msg.data });
-      return { type: "ok" };
-    },
-
-    "session-term-open": async (msg) => {
-      if (!msg.sessionId) throw new Error("sessionId required");
-      validateSessionId(msg.sessionId);
-      let cwd = msg.cwd;
-      if (!cwd) {
-        // Get cwd from existing terminals (cheaper than getSessions)
-        const existing = await getSessionTerminals(msg.sessionId);
-        if (existing.length > 0) cwd = existing[0].cwd;
-      }
-      const resp = await daemonRequest({
-        type: "spawn",
-        cwd: cwd || os.homedir(),
-        sessionId: msg.sessionId,
-      });
-      // New terminal always gets highest termId, so tab index = count of existing
-      const terminals = await getSessionTerminals(msg.sessionId);
-      const newTab = terminals.find((t) => t.termId === resp.termId);
-      // Notify renderer so it can attach and show the tab
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send(
-          "api-term-opened",
-          msg.sessionId,
-          resp.termId,
+          return {
+            type: "started",
+            sessionId: slot.sessionId,
+            termId: slot.termId,
+            slotIndex: slot.index,
+          };
+        });
+        recordSessionRelation(
+          result.sessionId,
+          msg.parentSessionId || null,
+          msg.parentSessionId ? "model" : "user",
         );
-      }
-      return {
-        type: "spawned",
-        termId: resp.termId,
-        tabIndex: newTab ? newTab.index : terminals.length - 1,
-      };
-    },
+        return result;
+      },
 
-    "session-term-run": async (msg) => {
-      if (!msg.sessionId) throw new Error("sessionId required");
-      if (msg.tabIndex === undefined) throw new Error("tabIndex required");
-      if (!msg.command) throw new Error("command required");
-      const timeoutMs = msg.timeout || 30000;
+      "pool-resume": async (msg) => {
+        if (!msg.sessionId) throw new Error("sessionId required");
+        return poolResume(msg.sessionId);
+      },
 
-      const terminals = await getSessionTerminals(msg.sessionId);
-      const tab = terminals[msg.tabIndex];
-      if (!tab) throw new Error(`No terminal at tab index ${msg.tabIndex}`);
-      if (tab.isTui)
-        throw new Error("Cannot run commands in the Claude TUI tab");
+      "pool-followup": async (msg) => {
+        if (!msg.sessionId) throw new Error("sessionId required");
+        if (!msg.prompt) throw new Error("prompt required");
+        return withPoolLock(async () => {
+          const { pool, slot } = findSlotBySessionId(msg.sessionId);
 
-      // Snapshot current buffer
-      const beforeBuffer = tab.buffer;
+          const status = await getEffectiveSlotStatus(slot);
+          if (status !== "idle")
+            throw new Error(`Session is ${status}, expected idle`);
 
-      // Write command + Enter
-      daemonSendSafe({
-        type: "write",
-        termId: tab.termId,
-        data: msg.command + "\r",
-      });
+          await sendPromptToTerminal(slot.termId, msg.prompt);
+          slot.status = "busy";
+          writePool(pool);
 
-      // Poll until a shell prompt appears after the command output
-      const promptRe = /[\$❯%#>] *$/; /* common prompt endings */
-      const deadline = Date.now() + timeoutMs;
+          return {
+            type: "started",
+            sessionId: slot.sessionId,
+            termId: slot.termId,
+            slotIndex: slot.index,
+          };
+        });
+      },
 
-      // Wait a short initial delay for the command to start producing output
-      await new Promise((r) => setTimeout(r, 300));
+      "pool-wait": async (msg) => {
+        const timeout = msg.timeout || 300000;
 
-      while (Date.now() < deadline) {
-        const buf = await readTerminalBuffer(tab.termId);
+        if (msg.sessionId) {
+          validateSessionId(msg.sessionId);
+          try {
+            const { slot } = findSlotBySessionId(msg.sessionId);
+            await waitForSessionIdle(msg.sessionId, timeout);
+            const buffer = await getTerminalBuffer(slot.termId);
+            return { type: "result", sessionId: msg.sessionId, buffer };
+          } catch (err) {
+            return { type: "error", error: err.message, id: msg.id };
+          }
+        }
 
-        // Check if buffer has new content beyond what was there before,
-        // and the last non-empty line looks like a shell prompt
-        if (buf.length > beforeBuffer.length) {
-          const newContent = buf.slice(beforeBuffer.length);
-          const clean = stripAnsi(newContent);
-          const lines = clean.split("\n").filter((l) => l.trim());
-          if (lines.length > 1) {
-            const lastLine = lines[lines.length - 1].trimEnd();
-            if (promptRe.test(lastLine)) {
-              // Extract output: everything between command echo and final prompt
-              // Skip first line (command echo) and last line (prompt)
-              const outputLines = lines.slice(1, -1);
-              return {
-                type: "output",
-                output: outputLines.join("\n"),
-                termId: tab.termId,
-              };
+        // Wait by slot index (used by resume --block where session ID changes)
+        if (msg.slotIndex !== undefined) {
+          // Validate slot exists before entering poll loop
+          findSlotByIndex(msg.slotIndex);
+          try {
+            const result = await poll(
+              async () => {
+                // Re-read pool each iteration: sessionId changes after /resume
+                const pool = readPool();
+                const slot = pool?.slots?.[msg.slotIndex];
+                if (!slot?.sessionId) return null;
+                const sessions = await getSessions();
+                const session = sessions.find(
+                  (s) => s.sessionId === slot.sessionId,
+                );
+                if (session && session.status === "idle") return slot;
+                if (session && !session.alive)
+                  throw new Error("Session process died");
+                return null;
+              },
+              {
+                interval: 1000,
+                initialDelay: 1000,
+                timeout,
+                label: "waiting for slot to become idle",
+              },
+            );
+            const buffer = await getTerminalBuffer(result.termId);
+            return { type: "result", sessionId: result.sessionId, buffer };
+          } catch (err) {
+            return { type: "error", error: err.message, id: msg.id };
+          }
+        }
+
+        // No sessionId or slotIndex: wait for any busy session to become idle
+        const pool = readPool();
+        if (!pool) throw new Error("Pool not initialized");
+        const busySlots = pool.slots.filter((s) => s.status === "busy");
+        if (busySlots.length === 0)
+          throw new Error("No busy sessions to wait for");
+
+        const finished = await poll(
+          async () => {
+            const sessions = await getSessions();
+            for (const s of busySlots) {
+              const session = sessions.find(
+                (sess) => sess.sessionId === s.sessionId,
+              );
+              if (session && session.status === "idle") return s;
+            }
+            return null;
+          },
+          {
+            interval: 1000,
+            initialDelay: 1000,
+            timeout,
+            label: "waiting for session to become idle",
+          },
+        );
+
+        const buffer = await getTerminalBuffer(finished.termId);
+        return { type: "result", sessionId: finished.sessionId, buffer };
+      },
+
+      "pool-capture": async (msg) => {
+        const { slot } = resolveSlot(msg);
+        const buffer = await getTerminalBuffer(slot.termId);
+        return {
+          type: "buffer",
+          sessionId: slot.sessionId,
+          slotIndex: slot.index,
+          buffer,
+        };
+      },
+
+      "pool-result": async (msg) => {
+        const { slot } = resolveSlot(msg);
+        const status = await getEffectiveSlotStatus(slot);
+        if (status === "busy" || status === "processing") {
+          throw new Error("Session is still running");
+        }
+        const buffer = await getTerminalBuffer(slot.termId);
+        return {
+          type: "result",
+          sessionId: slot.sessionId,
+          slotIndex: slot.index,
+          buffer,
+        };
+      },
+
+      "pool-input": async (msg) => {
+        if (msg.data === undefined) throw new Error("data required");
+        const { slot } = resolveSlot(msg);
+        daemonSendSafe({ type: "write", termId: slot.termId, data: msg.data });
+        return { type: "ok" };
+      },
+
+      "pool-clean": async () => {
+        const cleaned = await poolClean();
+        return { type: "cleaned", count: cleaned };
+      },
+
+      "pool-pin": async (msg) => {
+        if (!msg.sessionId) throw new Error("sessionId required");
+        const duration = msg.duration || 120;
+        return withPoolLock(async () => {
+          const { pool, slot } = findSlotBySessionId(msg.sessionId);
+          slot.pinnedUntil = new Date(
+            Date.now() + duration * 1000,
+          ).toISOString();
+          writePool(pool);
+          return { type: "ok", pinnedUntil: slot.pinnedUntil };
+        });
+      },
+
+      "pool-unpin": async (msg) => {
+        if (!msg.sessionId) throw new Error("sessionId required");
+        return withPoolLock(async () => {
+          const { pool, slot } = findSlotBySessionId(msg.sessionId);
+          delete slot.pinnedUntil;
+          writePool(pool);
+          return { type: "ok" };
+        });
+      },
+
+      "pool-stop-session": async (msg) => {
+        if (!msg.sessionId) throw new Error("sessionId required");
+        const { slot } = findSlotBySessionId(msg.sessionId);
+        // Escape interrupts Claude generation; send twice to dismiss any menu
+        daemonSendSafe({ type: "write", termId: slot.termId, data: "\x1b" });
+        await new Promise((r) => setTimeout(r, 200));
+        daemonSendSafe({ type: "write", termId: slot.termId, data: "\x1b" });
+        // Write idle signal after delay — the hook's stop trigger defers 5s
+        // and may not fire on interruption. We write at 6s as a fallback,
+        // only if no signal exists yet (hook wins if it fires first).
+        const stopPid = slot.pid;
+        const stopSessionId = msg.sessionId;
+        if (stopPid) {
+          setTimeout(async () => {
+            const sigFile = path.join(IDLE_SIGNALS_DIR, String(stopPid));
+            if (fs.existsSync(sigFile)) return; // hook already wrote it
+            const transcript = (await findJsonlPath(stopSessionId)) || "";
+            const cwd = (await getCwdFromJsonl(stopSessionId)) || "";
+            const signal = JSON.stringify({
+              cwd,
+              session_id: stopSessionId,
+              transcript,
+              ts: Math.floor(Date.now() / 1000),
+              trigger: "api-stop",
+            });
+            try {
+              fs.writeFileSync(sigFile, signal + "\n");
+            } catch {
+              /* ignore — session may be dead */
+            }
+          }, 6000);
+        }
+        return { type: "ok", sessionId: msg.sessionId };
+      },
+
+      "archive-session": async (msg) => {
+        if (!msg.sessionId) throw new Error("sessionId required");
+        await archiveSession(msg.sessionId);
+        return { type: "ok" };
+      },
+
+      "unarchive-session": async (msg) => {
+        if (!msg.sessionId) throw new Error("sessionId required");
+        unarchiveSession(msg.sessionId);
+        return { type: "ok" };
+      },
+
+      "get-session-graph": async () => ({
+        type: "session-graph",
+        graph: readSessionGraph(),
+      }),
+
+      // --- Slot access commands (by index, works without sessionId) ---
+
+      "slot-read": async (msg) => {
+        const { slot } = findSlotByIndex(msg.slotIndex);
+        const buffer = await getTerminalBuffer(slot.termId);
+        return {
+          type: "buffer",
+          slotIndex: slot.index,
+          sessionId: slot.sessionId,
+          buffer,
+        };
+      },
+
+      "slot-write": async (msg) => {
+        if (msg.data === undefined) throw new Error("data required");
+        const { slot } = findSlotByIndex(msg.slotIndex);
+        daemonSendSafe({ type: "write", termId: slot.termId, data: msg.data });
+        return { type: "ok" };
+      },
+
+      "slot-status": async (msg) => {
+        const { slot } = findSlotByIndex(msg.slotIndex);
+        const healthStatus = slot.sessionId
+          ? await getEffectiveSlotStatus(slot)
+          : slot.status;
+        return {
+          type: "slot",
+          slot: {
+            index: slot.index,
+            termId: slot.termId,
+            pid: slot.pid,
+            status: slot.status,
+            sessionId: slot.sessionId,
+            healthStatus,
+            createdAt: slot.createdAt,
+          },
+        };
+      },
+
+      // --- Session terminal access (per-session tab control) ---
+
+      "session-terminals": async (msg) => {
+        if (!msg.sessionId) throw new Error("sessionId required");
+        const terminals = await getSessionTerminals(msg.sessionId);
+        return {
+          type: "terminals",
+          terminals: terminals.map(({ buffer, ...rest }) => rest),
+        };
+      },
+
+      "session-term-read": async (msg) => {
+        if (!msg.sessionId) throw new Error("sessionId required");
+        if (msg.tabIndex === undefined) throw new Error("tabIndex required");
+        const terminals = await getSessionTerminals(msg.sessionId);
+        const tab = terminals[msg.tabIndex];
+        if (!tab) throw new Error(`No terminal at tab index ${msg.tabIndex}`);
+        return { type: "buffer", termId: tab.termId, buffer: tab.buffer };
+      },
+
+      "session-term-write": async (msg) => {
+        if (!msg.sessionId) throw new Error("sessionId required");
+        if (msg.tabIndex === undefined) throw new Error("tabIndex required");
+        if (msg.data === undefined) throw new Error("data required");
+        const terminals = await getSessionTerminals(msg.sessionId);
+        const tab = terminals[msg.tabIndex];
+        if (!tab) throw new Error(`No terminal at tab index ${msg.tabIndex}`);
+        daemonSendSafe({ type: "write", termId: tab.termId, data: msg.data });
+        return { type: "ok" };
+      },
+
+      "session-term-open": async (msg) => {
+        if (!msg.sessionId) throw new Error("sessionId required");
+        validateSessionId(msg.sessionId);
+        let cwd = msg.cwd;
+        if (!cwd) {
+          // Get cwd from existing terminals (cheaper than getSessions)
+          const existing = await getSessionTerminals(msg.sessionId);
+          if (existing.length > 0) cwd = existing[0].cwd;
+        }
+        const resp = await daemonRequest({
+          type: "spawn",
+          cwd: cwd || os.homedir(),
+          sessionId: msg.sessionId,
+        });
+        // New terminal always gets highest termId, so tab index = count of existing
+        const terminals = await getSessionTerminals(msg.sessionId);
+        const newTab = terminals.find((t) => t.termId === resp.termId);
+        // Notify renderer so it can attach and show the tab
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send(
+            "api-term-opened",
+            msg.sessionId,
+            resp.termId,
+          );
+        }
+        return {
+          type: "spawned",
+          termId: resp.termId,
+          tabIndex: newTab ? newTab.index : terminals.length - 1,
+        };
+      },
+
+      "session-term-run": async (msg) => {
+        if (!msg.sessionId) throw new Error("sessionId required");
+        if (msg.tabIndex === undefined) throw new Error("tabIndex required");
+        if (!msg.command) throw new Error("command required");
+        const timeoutMs = msg.timeout || 30000;
+
+        const terminals = await getSessionTerminals(msg.sessionId);
+        const tab = terminals[msg.tabIndex];
+        if (!tab) throw new Error(`No terminal at tab index ${msg.tabIndex}`);
+        if (tab.isTui)
+          throw new Error("Cannot run commands in the Claude TUI tab");
+
+        // Snapshot current buffer
+        const beforeBuffer = tab.buffer;
+
+        // Write command + Enter
+        daemonSendSafe({
+          type: "write",
+          termId: tab.termId,
+          data: msg.command + "\r",
+        });
+
+        // Poll until a shell prompt appears after the command output
+        const promptRe = /[\$❯%#>] *$/; /* common prompt endings */
+        const deadline = Date.now() + timeoutMs;
+
+        // Wait a short initial delay for the command to start producing output
+        await new Promise((r) => setTimeout(r, 300));
+
+        while (Date.now() < deadline) {
+          const buf = await readTerminalBuffer(tab.termId);
+
+          // Check if buffer has new content beyond what was there before,
+          // and the last non-empty line looks like a shell prompt
+          if (buf.length > beforeBuffer.length) {
+            const newContent = buf.slice(beforeBuffer.length);
+            const clean = stripAnsi(newContent);
+            const lines = clean.split("\n").filter((l) => l.trim());
+            if (lines.length > 1) {
+              const lastLine = lines[lines.length - 1].trimEnd();
+              if (promptRe.test(lastLine)) {
+                // Extract output: everything between command echo and final prompt
+                // Skip first line (command echo) and last line (prompt)
+                const outputLines = lines.slice(1, -1);
+                return {
+                  type: "output",
+                  output: outputLines.join("\n"),
+                  termId: tab.termId,
+                };
+              }
             }
           }
+
+          await new Promise((r) => setTimeout(r, 200));
         }
 
-        await new Promise((r) => setTimeout(r, 200));
-      }
-
-      // Timeout — return whatever we have
-      const finalBuf = await readTerminalBuffer(tab.termId);
-      const delta = finalBuf.slice(beforeBuffer.length);
-      throw new Error(
-        `Command timed out after ${timeoutMs}ms. Partial output: ${stripAnsi(delta).trim()}`,
-      );
-    },
-
-    "session-term-close": async (msg) => {
-      if (!msg.sessionId) throw new Error("sessionId required");
-      if (msg.tabIndex === undefined) throw new Error("tabIndex required");
-      const terminals = await getSessionTerminals(msg.sessionId);
-      const tab = terminals[msg.tabIndex];
-      if (!tab) throw new Error(`No terminal at tab index ${msg.tabIndex}`);
-      if (tab.isTui) {
-        throw new Error("Cannot close the Claude TUI tab");
-      }
-      await daemonRequest({ type: "kill", termId: tab.termId });
-      // Notify renderer so it can remove the tab
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send(
-          "api-term-closed",
-          msg.sessionId,
-          tab.termId,
+        // Timeout — return whatever we have
+        const finalBuf = await readTerminalBuffer(tab.termId);
+        const delta = finalBuf.slice(beforeBuffer.length);
+        throw new Error(
+          `Command timed out after ${timeoutMs}ms. Partial output: ${stripAnsi(delta).trim()}`,
         );
-      }
-      return { type: "ok" };
+      },
+
+      "session-term-close": async (msg) => {
+        if (!msg.sessionId) throw new Error("sessionId required");
+        if (msg.tabIndex === undefined) throw new Error("tabIndex required");
+        const terminals = await getSessionTerminals(msg.sessionId);
+        const tab = terminals[msg.tabIndex];
+        if (!tab) throw new Error(`No terminal at tab index ${msg.tabIndex}`);
+        if (tab.isTui) {
+          throw new Error("Cannot close the Claude TUI tab");
+        }
+        await daemonRequest({ type: "kill", termId: tab.termId });
+        // Notify renderer so it can remove the tab
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send(
+            "api-term-closed",
+            msg.sessionId,
+            tab.termId,
+          );
+        }
+        return { type: "ok" };
+      },
     },
-  });
+    {
+      onListening: () => {
+        ownsApiSocket = true;
+      },
+    },
+  );
 
   const send = (channel, ...args) => {
     if (mainWindow && !mainWindow.isDestroyed()) {
@@ -3730,6 +3740,7 @@ app.whenReady().then(async () => {
 });
 
 let ownPoolDestroyed = false;
+let ownsApiSocket = false;
 app.on("before-quit", (e) => {
   // Dev instances with --own-pool auto-destroy their pool on quit.
   // Production instances intentionally leave the daemon and pool alive —
@@ -3759,11 +3770,13 @@ app.on("before-quit", (e) => {
   }
   for (const entry of pendingPolls) entry.cancel();
   pendingPolls.clear();
-  // Clean up API socket
-  try {
-    fs.unlinkSync(API_SOCKET);
-  } catch {
-    /* ENOENT expected — socket may not exist */
+  // Clean up API socket — only if this instance created it
+  if (ownsApiSocket) {
+    try {
+      fs.unlinkSync(API_SOCKET);
+    } catch {
+      /* ENOENT expected — socket may not exist */
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

- A second Electron instance could steal and orphan the first instance's API socket by blindly unlinking it, leaving the surviving instance without CLI access
- Now probes existing socket before replacing — refuses to steal a live one, with a 2s timeout for hung sockets
- Adds `server.on("error")` handler to prevent crashes on `EADDRINUSE`
- Only cleans up socket on quit if this instance created it (`ownsApiSocket` flag)
- CLI exits early with clear error message when no socket exists
- Skill rewrite: removes alias (doesn't persist across Bash tool calls), adds key concepts (tab 0 is TUI, `term run` vs `exec` output quality), adds troubleshooting section

## Test plan

- [x] Second instance detects live socket, logs "in use", skips API server
- [x] Second instance quit doesn't delete first instance's socket
- [x] First instance API still works after second quits
- [x] Owning instance cleans up socket on quit
- [x] CLI shows clear error when no socket exists
- [x] Production socket unaffected during dev testing
- [x] All 220 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)