### PR TITLE
Fix syncPoolStatuses not awaited in get-sessions IPC

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2760,7 +2760,7 @@ app.whenReady().then(async () => {
   });
   ipcMain.handle("get-sessions", async () => {
     const sessions = await getSessions();
-    syncPoolStatuses(sessions);
+    await syncPoolStatuses(sessions);
     // Enrich with pinned status and session graph
     const pool = readPool();
     if (pool) {


### PR DESCRIPTION
Closes #187

## Summary
- Adds `await` to `syncPoolStatuses()` call in get-sessions handler
- One-word fix preventing stale pool status data in responses

## Review
✅ Reviewed by agent — ship it

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>