### PR TITLE
Fix api-server.js missing server error handler

### DIFF
--- a/src/api-server.js
+++ b/src/api-server.js
@@ -72,6 +72,10 @@ function createApiServer(socketPath, handlers) {
     if (!socket.destroyed) socket.write(JSON.stringify(msg) + "\n");
   }
 
+  server.on("error", (err) => {
+    console.error(`[api-server] Server error on ${socketPath}:`, err.message);
+  });
+
   // Clean up stale socket
   try {
     fs.unlinkSync(socketPath);


### PR DESCRIPTION
Closes #191

## Summary
- Adds `server.on('error')` handler before `listen()` call
- Prevents unhandled exceptions from crashing the process

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>