### PR TITLE
Fix renderTerminalTabs() undefined ReferenceError on resume

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1327,9 +1327,16 @@ async function resumeOffloadedSession(session) {
           p.termId !== result.termId,
       );
       for (const p of extraPtys) {
-        terminals.push(await reconnectTerminal(p));
+        const entry = await reconnectTerminal(p);
+        terminals.push(entry);
+        dockRegisterTerminal(entry);
+        if (dock) {
+          const tuiTab = terminals.find((t) => t.isPoolTui)?.dockTabId;
+          const leaf =
+            (tuiTab && dock.getTabLeafId(tuiTab)) || dock.getFirstLeafId();
+          dock.addTab(entry.dockTabId, leaf);
+        }
       }
-      if (extraPtys.length > 0) renderTerminalTabs();
     } catch (err) {
       debugLog("pool", `re-attach orphaned terminals failed: ${err.message}`);
     }


### PR DESCRIPTION
Closes #193

## Summary
- Replaces undefined `renderTerminalTabs()` call with inline dock registration
- Matches existing pattern at shell tab creation sites

## Review
✅ Reviewed by agent — ship it

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>