### PR TITLE
Fix API-opened terminals missing wireTerminalInput

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -2229,7 +2229,7 @@ window.api.onApiTermOpened(async (sessionId, termId) => {
   }
   pendingTerminals.delete(termId);
 
-  term.onData((data) => window.api.ptyWrite(termId, data));
+  wireTerminalInput(term, termId);
   setupTerminalResize(entry);
 
   dockRegisterTerminal(entry);


### PR DESCRIPTION
Closes #194

## Summary
- Adds wireTerminalInput call for terminals opened via API
- Fixes Shift+Enter broken in API-created terminal tabs

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>