### PR TITLE
Fix destroySessionTerminals triggering unnecessary dock re-render

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -755,7 +755,8 @@ function destroySessionTerminals(sessionId, { keepAlive = false } = {}) {
     if (!entry.isPoolTui && !keepAlive) {
       window.api.ptyKill(entry.termId).catch(() => {});
     }
-    disposeTerminalEntry(entry, dock);
+    const activeDock = sessionId === currentSessionId ? dock : null;
+    disposeTerminalEntry(entry, activeDock);
   }
   sessionTerminals.delete(sessionId);
 }


### PR DESCRIPTION
Closes #196

## Summary
- Passes null instead of dock to disposeTerminalEntry for non-current sessions
- Prevents pointless re-renders when cleaning up background session terminals

## Review
✅ Reviewed by agent — ship it

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>