### PR TITLE
Document nested worktree isolation warning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,8 @@ Git hooks live in `.githooks/` (version-controlled). `core.hooksPath` is set aut
 
 Worktrees auto-setup via the `post-checkout` hook — just `git worktree add` and it's ready.
 
+> ⚠️ **Never use the Agent tool with `isolation: "worktree"` from inside a worktree (`.wt/`).** This creates nested `.wt/` directories, which causes git confusion, test duplication (vitest picks up tests from nested paths), and file watching issues. Only use worktree isolation from the main repo root.
+
 ### Merging worktree PRs
 
 `gh pr merge --delete-branch` fails from worktrees. Always merge from the **root worktree** without `--delete-branch`, then clean up:


### PR DESCRIPTION
## Summary

- Adds warning to CLAUDE.md that Agent tool's `isolation: "worktree"` should not be used from inside an existing worktree (`.wt/`)
- Prevents nested `.wt/` directories that cause git confusion and test duplication

Fixes #115

## Test plan

- [x] All 220 tests pass
- [x] Documentation-only change, no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)