### PR TITLE
Extract duplicated watch poll+diff logic into shared module

### DIFF
--- a/bin/cockpit-cli
+++ b/bin/cockpit-cli
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OC_DIR="$HOME/.open-cockpit"
 PROD_SOCKET="$OC_DIR/api.sock"
 DEV_SOCKET="$OC_DIR/api-dev.sock"
@@ -405,86 +406,7 @@ case "$CMD" in
     [[ -n "$FIRST_ERR" ]] && { echo "Error: $FIRST_ERR" >&2; exit 1; }
 
     echo "Watching ${RESOLVED_TYPE}=${RESOLVED_VALUE} (Ctrl+C to stop)..." >&2
-    # Use node for robust line-based diffing (handles buffer wraps/scrolls)
-    node -e '
-      const net = require("net");
-      const interval = parseInt(process.argv[1]) * 1000;
-      const json = process.argv[2];
-      const sock = process.argv[3];
-
-      function stripAnsi(s) {
-        return s
-          .replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "")
-          .replace(/\x1b\][^\x07]*\x07/g, "")
-          .replace(/\x1b[()][AB012]/g, "")
-          .replace(/\x1b\[?\??[0-9;]*[a-zA-Z]/g, "")
-          .replace(/\x1b[>=]/g, "")
-          .replace(/\r\n/g, "\n")
-          .replace(/\r/g, "\n");
-      }
-
-      function query() {
-        return new Promise((resolve, reject) => {
-          let buf = "";
-          const c = net.createConnection(sock);
-          c.on("connect", () => c.write(json + "\n"));
-          c.on("data", d => {
-            buf += d;
-            const i = buf.indexOf("\n");
-            if (i !== -1) { c.destroy(); resolve(buf.slice(0, i)); }
-          });
-          c.on("error", reject);
-          setTimeout(() => { c.destroy(); reject(new Error("timeout")); }, 5000);
-        });
-      }
-
-      let prevLines = [];
-      async function poll() {
-        try {
-          const resp = JSON.parse(await query());
-          if (resp.error) { process.stderr.write("Error: " + resp.error + "\n"); process.exit(1); }
-          const raw = resp.buffer || "";
-          const clean = stripAnsi(raw).split("\n").map(l => l.trimEnd());
-
-          if (prevLines.length === 0) {
-            // First poll: print everything
-            process.stdout.write(clean.join("\n") + "\n");
-          } else {
-            // Find longest suffix of prevLines that matches a suffix of clean
-            // This handles both appended lines AND buffer scroll/wrap
-            let matchLen = 0;
-            for (let tryLen = Math.min(prevLines.length, clean.length); tryLen > 0; tryLen--) {
-              const prevSuffix = prevLines.slice(-tryLen).join("\n");
-              // Search for this suffix in clean
-              for (let start = 0; start <= clean.length - tryLen; start++) {
-                if (clean.slice(start, start + tryLen).join("\n") === prevSuffix) {
-                  const newStart = start + tryLen;
-                  if (newStart < clean.length) {
-                    matchLen = tryLen;
-                    const newLines = clean.slice(newStart);
-                    process.stdout.write(newLines.join("\n") + "\n");
-                  }
-                  // Found best match
-                  prevLines = clean;
-                  return;
-                }
-              }
-            }
-            // No overlap found — buffer completely changed, print all
-            if (matchLen === 0 && clean.join("\n") !== prevLines.join("\n")) {
-              process.stdout.write("\n--- buffer changed ---\n" + clean.join("\n") + "\n");
-            }
-          }
-          prevLines = clean;
-        } catch (e) {
-          process.stderr.write("Connection lost: " + e.message + "\n");
-          process.exit(1);
-        }
-      }
-
-      poll();
-      setInterval(poll, interval);
-    ' "$INTERVAL" "$json" "$SOCKET"
+    node "$SCRIPT_DIR/watch-poll.js" "$INTERVAL" "$json" "$SOCKET"
     ;;
 
   log)
@@ -1096,79 +1018,7 @@ case "$CMD" in
         [[ -n "$FIRST_ERR" ]] && { echo "Error: $FIRST_ERR" >&2; exit 1; }
 
         echo "Watching $TARGET tab $TAB_INDEX (Ctrl+C to stop)..." >&2
-        node -e '
-          const net = require("net");
-          const interval = parseInt(process.argv[1]) * 1000;
-          const json = process.argv[2];
-          const sock = process.argv[3];
-
-          function stripAnsi(s) {
-            return s
-              .replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "")
-              .replace(/\x1b\][^\x07]*\x07/g, "")
-              .replace(/\x1b[()][AB012]/g, "")
-              .replace(/\x1b\[?\??[0-9;]*[a-zA-Z]/g, "")
-              .replace(/\x1b[>=]/g, "")
-              .replace(/\r\n/g, "\n")
-              .replace(/\r/g, "\n");
-          }
-
-          function query() {
-            return new Promise((resolve, reject) => {
-              let buf = "";
-              const c = net.createConnection(sock);
-              c.on("connect", () => c.write(json + "\n"));
-              c.on("data", d => {
-                buf += d;
-                const i = buf.indexOf("\n");
-                if (i !== -1) { c.destroy(); resolve(buf.slice(0, i)); }
-              });
-              c.on("error", reject);
-              setTimeout(() => { c.destroy(); reject(new Error("timeout")); }, 5000);
-            });
-          }
-
-          let prevLines = [];
-          async function poll() {
-            try {
-              const resp = JSON.parse(await query());
-              if (resp.error) { process.stderr.write("Error: " + resp.error + "\n"); process.exit(1); }
-              const raw = resp.buffer || "";
-              const clean = stripAnsi(raw).split("\n").map(l => l.trimEnd());
-
-              if (prevLines.length === 0) {
-                process.stdout.write(clean.join("\n") + "\n");
-              } else {
-                let matchLen = 0;
-                for (let tryLen = Math.min(prevLines.length, clean.length); tryLen > 0; tryLen--) {
-                  const prevSuffix = prevLines.slice(-tryLen).join("\n");
-                  for (let start = 0; start <= clean.length - tryLen; start++) {
-                    if (clean.slice(start, start + tryLen).join("\n") === prevSuffix) {
-                      const newStart = start + tryLen;
-                      if (newStart < clean.length) {
-                        matchLen = tryLen;
-                        const newLines = clean.slice(newStart);
-                        process.stdout.write(newLines.join("\n") + "\n");
-                      }
-                      prevLines = clean;
-                      return;
-                    }
-                  }
-                }
-                if (matchLen === 0 && clean.join("\n") !== prevLines.join("\n")) {
-                  process.stdout.write("\n--- buffer changed ---\n" + clean.join("\n") + "\n");
-                }
-              }
-              prevLines = clean;
-            } catch (e) {
-              process.stderr.write("Connection lost: " + e.message + "\n");
-              process.exit(1);
-            }
-          }
-
-          poll();
-          setInterval(poll, interval);
-        ' "$INTERVAL" "$json" "$SOCKET"
+        node "$SCRIPT_DIR/watch-poll.js" "$INTERVAL" "$json" "$SOCKET"
         ;;
 
       open)

--- a/bin/watch-poll.js
+++ b/bin/watch-poll.js
@@ -1,0 +1,91 @@
+// Shared poll-and-diff logic for `watch` and `term watch` commands.
+// Usage: node watch-poll.js <intervalSec> <apiJson> <socketPath>
+
+const net = require("net");
+const interval = parseInt(process.argv[2]) * 1000;
+const json = process.argv[3];
+const sock = process.argv[4];
+
+function stripAnsi(s) {
+  return s
+    .replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "")
+    .replace(/\x1b\][^\x07]*\x07/g, "")
+    .replace(/\x1b[()][AB012]/g, "")
+    .replace(/\x1b\[?\??[0-9;]*[a-zA-Z]/g, "")
+    .replace(/\x1b[>=]/g, "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
+}
+
+function query() {
+  return new Promise((resolve, reject) => {
+    let buf = "";
+    const c = net.createConnection(sock);
+    c.on("connect", () => c.write(json + "\n"));
+    c.on("data", (d) => {
+      buf += d;
+      const i = buf.indexOf("\n");
+      if (i !== -1) {
+        c.destroy();
+        resolve(buf.slice(0, i));
+      }
+    });
+    c.on("error", reject);
+    setTimeout(() => {
+      c.destroy();
+      reject(new Error("timeout"));
+    }, 5000);
+  });
+}
+
+let prevLines = [];
+async function poll() {
+  try {
+    const resp = JSON.parse(await query());
+    if (resp.error) {
+      process.stderr.write("Error: " + resp.error + "\n");
+      process.exit(1);
+    }
+    const raw = resp.buffer || "";
+    const clean = stripAnsi(raw)
+      .split("\n")
+      .map((l) => l.trimEnd());
+
+    if (prevLines.length === 0) {
+      process.stdout.write(clean.join("\n") + "\n");
+    } else {
+      let matchLen = 0;
+      for (
+        let tryLen = Math.min(prevLines.length, clean.length);
+        tryLen > 0;
+        tryLen--
+      ) {
+        const prevSuffix = prevLines.slice(-tryLen).join("\n");
+        for (let start = 0; start <= clean.length - tryLen; start++) {
+          if (clean.slice(start, start + tryLen).join("\n") === prevSuffix) {
+            const newStart = start + tryLen;
+            if (newStart < clean.length) {
+              matchLen = tryLen;
+              const newLines = clean.slice(newStart);
+              process.stdout.write(newLines.join("\n") + "\n");
+            }
+            prevLines = clean;
+            return;
+          }
+        }
+      }
+      if (matchLen === 0 && clean.join("\n") !== prevLines.join("\n")) {
+        process.stdout.write(
+          "\n--- buffer changed ---\n" + clean.join("\n") + "\n",
+        );
+      }
+    }
+    prevLines = clean;
+  } catch (e) {
+    process.stderr.write("Connection lost: " + e.message + "\n");
+    process.exit(1);
+  }
+}
+
+poll();
+setInterval(poll, interval);


### PR DESCRIPTION
## Summary

- Extract ~75 lines of duplicated inline Node.js code from `watch` and `term watch` commands into `bin/watch-poll.js`
- Both call sites now invoke `node "$SCRIPT_DIR/watch-poll.js"` instead of embedding identical code inline

Closes #211

## Test plan

- [x] All 220 existing tests pass (including 49 cockpit-cli tests)
- [ ] Manual: `cockpit-cli watch <session>` streams diff output correctly
- [ ] Manual: `cockpit-cli term watch <session> <tab>` streams diff output correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)