### PR TITLE
Fix #210: restrict ~/.open-cockpit/ file permissions to owner-only

### DIFF
--- a/hooks/common.sh
+++ b/hooks/common.sh
@@ -7,6 +7,9 @@
 #
 # This sources log-error.sh automatically — no need to source both.
 
+# Restrict all file/dir creation to owner-only (security: #210)
+umask 077
+
 source "$(dirname "${BASH_SOURCE[0]}")/log-error.sh"
 
 # --- Directory constants (used by sourcing scripts) ---

--- a/src/main.js
+++ b/src/main.js
@@ -37,15 +37,7 @@ const {
 } = require("./pool");
 const { Terminal: HeadlessTerminal } = require("@xterm/headless");
 const { createPoolLock } = require("./pool-lock");
-
-// Secure file helpers — restrict to owner-only access
-function secureMkdirSync(dirPath, opts = {}) {
-  fs.mkdirSync(dirPath, { ...opts, mode: 0o700 });
-}
-function secureWriteFileSync(filePath, data, opts) {
-  fs.writeFileSync(filePath, data, opts);
-  fs.chmodSync(filePath, 0o600);
-}
+const { secureMkdirSync, secureWriteFileSync } = require("./secure-fs");
 
 const IS_DEV = process.argv.includes("--dev");
 const OPEN_COCKPIT_DIR = path.join(os.homedir(), ".open-cockpit");
@@ -1251,8 +1243,7 @@ function readSessionGraph() {
 function writeSessionGraph(graph) {
   const data = JSON.stringify(graph, null, 2);
   const tmp = SESSION_GRAPH_FILE + ".tmp";
-  fs.writeFileSync(tmp, data);
-  fs.chmodSync(tmp, 0o600);
+  fs.writeFileSync(tmp, data, { mode: 0o600 });
   fs.renameSync(tmp, SESSION_GRAPH_FILE);
 }
 
@@ -3288,7 +3279,7 @@ app.whenReady().then(async () => {
               trigger: "api-stop",
             });
             try {
-              fs.writeFileSync(sigFile, signal + "\n");
+              secureWriteFileSync(sigFile, signal + "\n");
             } catch {
               /* ignore — session may be dead */
             }

--- a/src/pty-daemon.js
+++ b/src/pty-daemon.js
@@ -13,6 +13,7 @@ const net = require("net");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
+const { secureMkdirSync, secureWriteFileSync } = require("./secure-fs");
 const pty = require("node-pty");
 
 const OPEN_COCKPIT_DIR = path.join(os.homedir(), ".open-cockpit");
@@ -362,7 +363,7 @@ function handleMessage(socket, msg) {
 }
 
 function startServer() {
-  fs.mkdirSync(OPEN_COCKPIT_DIR, { recursive: true });
+  secureMkdirSync(OPEN_COCKPIT_DIR, { recursive: true });
 
   // Remove stale socket — ENOENT expected on first run
   try {
@@ -423,7 +424,7 @@ function startServer() {
     fs.chmodSync(SOCKET_PATH, 0o600);
     console.log(`[pty-daemon] Listening on ${SOCKET_PATH}`);
     // Write PID file so clients can check if daemon is alive
-    fs.writeFileSync(
+    secureWriteFileSync(
       path.join(OPEN_COCKPIT_DIR, "pty-daemon.pid"),
       String(process.pid),
     );

--- a/src/secure-fs.js
+++ b/src/secure-fs.js
@@ -1,0 +1,12 @@
+// Secure file helpers — restrict to owner-only access (#210)
+const fs = require("fs");
+
+function secureMkdirSync(dirPath, opts = {}) {
+  fs.mkdirSync(dirPath, { ...opts, mode: 0o700 });
+}
+
+function secureWriteFileSync(filePath, data, opts) {
+  fs.writeFileSync(filePath, data, { ...opts, mode: 0o600 });
+}
+
+module.exports = { secureMkdirSync, secureWriteFileSync };

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -5,6 +5,7 @@
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+const { secureMkdirSync, secureWriteFileSync } = require("./secure-fs");
 
 const SHORTCUTS_FILE = path.join(
   os.homedir(),
@@ -80,8 +81,8 @@ function loadShortcuts() {
 
 function saveShortcuts() {
   try {
-    fs.mkdirSync(path.dirname(SHORTCUTS_FILE), { recursive: true });
-    fs.writeFileSync(SHORTCUTS_FILE, JSON.stringify(userOverrides, null, 2));
+    secureMkdirSync(path.dirname(SHORTCUTS_FILE), { recursive: true });
+    secureWriteFileSync(SHORTCUTS_FILE, JSON.stringify(userOverrides, null, 2));
   } catch (err) {
     console.error("[shortcuts] Failed to save:", err.message);
   }


### PR DESCRIPTION
## Summary

- Extract `secureMkdirSync`/`secureWriteFileSync` to shared `src/secure-fs.js` module (uses `mode:` option to avoid write-then-chmod TOCTOU race)
- Import shared helpers in `main.js`, `pty-daemon.js`, and `shortcuts.js`
- Add `umask 077` in `hooks/common.sh` so all shell hook file/dir creation is restricted
- Fix `writeSessionGraph` TOCTOU (was write + chmod, now uses `{ mode: 0o600 }`)

Closes #210

## Test plan

- [x] All 220 tests pass
- [ ] Verify new files in `~/.open-cockpit/` are created with `0o600`/`0o700` permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)