### PR TITLE
Split renderer.js into focused modules (#133)

### DIFF
--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -1,0 +1,388 @@
+// Command palette: COMMANDS registry, shortcut display, pane navigation, palette UI
+import { state, dom } from "./renderer-state.js";
+import {
+  getFocusedTabId,
+  focusLeafContent,
+  TAB_EDITOR,
+  TAB_SNAPSHOT,
+} from "./dock-helpers.js";
+
+// --- Cross-module dependencies (set via initCommandPalette) ---
+let _actions = {};
+let shortcutConfig = {};
+let COMMANDS = [];
+
+export function initCommandPalette(actions) {
+  _actions = actions;
+
+  // Build COMMANDS array with action references
+  COMMANDS = [
+    {
+      id: "next-session",
+      label: "Next Session",
+      shortcutAction: "next-session",
+      action: () => _actions.switchSession(1),
+    },
+    {
+      id: "prev-session",
+      label: "Previous Session",
+      shortcutAction: "prev-session",
+      action: () => _actions.switchSession(-1),
+    },
+    {
+      id: "new-session",
+      label: "New Claude Session",
+      shortcutAction: "new-session",
+      action: () => dom.newSessionBtn.click(),
+    },
+    {
+      id: "new-terminal",
+      label: "New Terminal Tab",
+      shortcutAction: "new-terminal-tab",
+      action: () => {
+        if (state.currentSessionId)
+          _actions.spawnTerminal(state.currentSessionCwd);
+      },
+    },
+    {
+      id: "close-terminal",
+      label: "Close Terminal Tab",
+      shortcutAction: "close-terminal-tab",
+      action: () => {
+        const i = _actions.getActiveTermIndex();
+        if (i >= 0) _actions.closeTerminal(i);
+      },
+    },
+    {
+      id: "next-tab",
+      label: "Next Terminal Tab",
+      shortcutAction: "next-tab",
+      action: () => {
+        if (state.terminals.length > 1)
+          _actions.switchToTerminal(
+            (_actions.getActiveTermIndex() + 1) % state.terminals.length,
+          );
+      },
+    },
+    {
+      id: "prev-tab",
+      label: "Previous Terminal Tab",
+      shortcutAction: "prev-tab",
+      action: () => {
+        if (state.terminals.length > 1)
+          _actions.switchToTerminal(
+            (_actions.getActiveTermIndex() - 1 + state.terminals.length) %
+              state.terminals.length,
+          );
+      },
+    },
+    {
+      id: "jump-recent-idle",
+      label: "Jump to Recent Idle",
+      shortcutAction: "jump-recent-idle",
+      action: () => _actions.jumpToRecentIdle(),
+    },
+    {
+      id: "archive-current-session",
+      label: "Archive Current Session",
+      shortcutAction: "archive-current-session",
+      action: () => _actions.archiveCurrentSession(),
+    },
+    {
+      id: "toggle-sidebar",
+      label: "Toggle Sidebar",
+      shortcutAction: "toggle-sidebar",
+      action: () => _actions.toggleSidebar(),
+    },
+    {
+      id: "cycle-pane",
+      label: "Cycle Pane Focus",
+      shortcutAction: "cycle-pane",
+      action: cyclePane,
+    },
+    {
+      id: "focus-next-pane",
+      label: "Focus Next Pane",
+      shortcutAction: "focus-next-pane",
+      action: () => focusAdjacentPane(1),
+    },
+    {
+      id: "focus-prev-pane",
+      label: "Focus Previous Pane",
+      shortcutAction: "focus-prev-pane",
+      action: () => focusAdjacentPane(-1),
+    },
+    {
+      id: "split-right",
+      label: "Split Right",
+      shortcutAction: "split-right",
+      action: () => splitFocusedTab("right"),
+    },
+    {
+      id: "split-down",
+      label: "Split Down",
+      shortcutAction: "split-down",
+      action: () => splitFocusedTab("down"),
+    },
+    {
+      id: "toggle-pane-focus",
+      label: "Toggle Pane Focus",
+      shortcutAction: "toggle-pane-focus",
+      action: () => _actions.togglePaneFocus(),
+    },
+    {
+      id: "focus-editor",
+      label: "Focus Editor",
+      shortcutAction: "focus-editor",
+      action: () => _actions.focusEditor(),
+    },
+    {
+      id: "focus-terminal",
+      label: "Focus Terminal",
+      shortcutAction: "focus-terminal",
+      action: () => _actions.focusTerminal(),
+    },
+    {
+      id: "focus-external-terminal",
+      label: "Focus External Terminal",
+      shortcutAction: "focus-external",
+      action: () => _actions.focusCurrentExternalTerminal(),
+    },
+    {
+      id: "open-in-cursor",
+      label: "Open in Cursor",
+      shortcutAction: "open-in-cursor",
+      action: () => {
+        if (state.currentSessionCwd)
+          window.api.openInCursor(state.currentSessionCwd);
+      },
+    },
+    {
+      id: "refresh",
+      label: "Refresh Sessions",
+      action: () => {
+        _actions.loadDirColors();
+        _actions.loadSessions();
+      },
+    },
+    {
+      id: "command-palette",
+      label: "Command Palette",
+      shortcutAction: "toggle-command-palette",
+      action: () => toggleCommandPalette(),
+    },
+    {
+      id: "pool-settings",
+      label: "Pool Settings",
+      shortcutAction: "open-pool-settings",
+      action: () => _actions.showPoolSettings(),
+    },
+    {
+      id: "shortcut-settings",
+      label: "Keyboard Shortcuts",
+      action: () => _actions.showShortcutSettings(),
+    },
+  ];
+
+  // Also add Tab 1-9 commands
+  for (let i = 0; i < 9; i++) {
+    COMMANDS.push({
+      id: `tab-${i + 1}`,
+      label: `Switch to Tab ${i + 1}`,
+      shortcut: `⌘${i + 1}`,
+      action: () => {
+        if (i < state.terminals.length) _actions.switchToTerminal(i);
+      },
+    });
+  }
+
+  // Wire palette input events
+  dom.commandPaletteInput.addEventListener("input", () => {
+    paletteSelectedIndex = 0;
+    renderPaletteList(dom.commandPaletteInput.value);
+  });
+
+  dom.commandPaletteInput.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closeCommandPalette();
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      updatePaletteSelection(
+        Math.min(paletteSelectedIndex + 1, filteredCommands.length - 1),
+      );
+      return;
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      updatePaletteSelection(Math.max(paletteSelectedIndex - 1, 0));
+      return;
+    }
+    if (e.key === "Enter" && filteredCommands.length > 0) {
+      e.preventDefault();
+      const cmd = filteredCommands[paletteSelectedIndex];
+      closeCommandPalette();
+      cmd.action();
+      return;
+    }
+  });
+
+  // Click outside palette to close
+  dom.commandPalette.addEventListener("click", (e) => {
+    if (e.target === dom.commandPalette) closeCommandPalette();
+  });
+}
+
+// --- Shortcut display helpers ---
+// Convert Electron accelerator to display string (e.g. "CmdOrCtrl+N" → "⌘N")
+export function formatShortcutDisplay(accel) {
+  if (!accel) return "";
+  return accel
+    .replace(/CmdOrCtrl\+/gi, "⌘")
+    .replace(/Cmd\+/gi, "⌘")
+    .replace(/Ctrl\+/gi, "⌃")
+    .replace(/Shift\+/gi, "⇧")
+    .replace(/Alt\+/gi, "⌥")
+    .replace(/\+/g, "")
+    .replace(/Tab/gi, "⇥")
+    .replace(/Up/gi, "↑")
+    .replace(/Down/gi, "↓")
+    .replace(/Left/gi, "←")
+    .replace(/Right/gi, "→");
+}
+
+export function setShortcutConfig(config) {
+  shortcutConfig = config;
+}
+
+// --- Pane navigation ---
+
+// Cycle pane focus: editor → terminal tabs (round-robin) → back to editor
+function cyclePane() {
+  const activeIdx = _actions.getActiveTermIndex();
+  if (state.editorMount && state.editorMount.contains(document.activeElement)) {
+    _actions.focusTerminal();
+  } else if (activeIdx >= 0 && state.terminals.length > 1) {
+    const nextIdx = activeIdx + 1;
+    if (nextIdx < state.terminals.length) {
+      _actions.switchToTerminal(nextIdx);
+    } else {
+      _actions.focusEditor();
+    }
+  } else {
+    _actions.focusEditor();
+  }
+}
+
+// Navigate between dock leaves (panels)
+function focusAdjacentPane(delta) {
+  if (!state.dock) return;
+  const leafIds = state.dock.getLeafIds();
+  if (leafIds.length < 2) return;
+
+  // Find which leaf currently has focus
+  const focusedTabId = getFocusedTabId(state.dock, dom.dockContainer);
+  let currentLeafId = focusedTabId
+    ? state.dock.getTabLeafId(focusedTabId)
+    : null;
+  if (!currentLeafId) currentLeafId = leafIds[0];
+
+  const idx = leafIds.indexOf(currentLeafId);
+  const nextIdx = (idx + delta + leafIds.length) % leafIds.length;
+  const nextLeafId = leafIds[nextIdx];
+
+  const activeTabId = state.dock.getActiveTabInLeaf(nextLeafId);
+  if (activeTabId === TAB_EDITOR || activeTabId === TAB_SNAPSHOT) {
+    state.dock.activateTab(activeTabId);
+    if (activeTabId === TAB_EDITOR && state.editorView)
+      state.editorView.focus();
+  } else {
+    focusLeafContent(state.dock, nextLeafId, state.terminals);
+  }
+}
+
+// Move the focused tab to a new split in the given direction
+function splitFocusedTab(direction) {
+  if (!state.dock) return;
+  const focusedTabId = getFocusedTabId(state.dock, dom.dockContainer);
+  if (!focusedTabId) return;
+  state.dock.moveTabToSplit(focusedTabId, direction);
+}
+
+// --- Palette state ---
+let paletteSelectedIndex = 0;
+let filteredCommands = [];
+
+export function toggleCommandPalette() {
+  if (dom.commandPalette.classList.contains("visible")) {
+    closeCommandPalette();
+  } else {
+    openCommandPalette();
+  }
+}
+
+function openCommandPalette() {
+  dom.commandPalette.classList.add("visible");
+  dom.commandPaletteInput.value = "";
+  paletteSelectedIndex = 0;
+  renderPaletteList("");
+  dom.commandPaletteInput.focus();
+}
+
+function closeCommandPalette() {
+  dom.commandPalette.classList.remove("visible");
+  dom.commandPaletteInput.value = "";
+  // Return focus to terminal
+  _actions.focusTerminal();
+}
+
+// Get display shortcut for a command (dynamic from config)
+function getCommandShortcut(cmd) {
+  if (!cmd.shortcutAction) return "";
+  return formatShortcutDisplay(shortcutConfig[cmd.shortcutAction] || "");
+}
+
+function renderPaletteList(query) {
+  const q = query.toLowerCase();
+  filteredCommands = q
+    ? COMMANDS.filter(
+        (c) =>
+          c.label.toLowerCase().includes(q) ||
+          getCommandShortcut(c).toLowerCase().includes(q),
+      )
+    : COMMANDS.filter((c) => !c.id.startsWith("tab-")); // Hide tab-N from unfiltered list
+
+  paletteSelectedIndex = Math.min(
+    paletteSelectedIndex,
+    Math.max(0, filteredCommands.length - 1),
+  );
+
+  dom.commandPaletteList.innerHTML = "";
+  filteredCommands.forEach((cmd, i) => {
+    const item = document.createElement("div");
+    item.className = `command-palette-item${i === paletteSelectedIndex ? " selected" : ""}`;
+    const shortcut = getCommandShortcut(cmd);
+    item.innerHTML = `<span class="command-palette-label">${cmd.label}</span><span class="command-palette-shortcut">${shortcut}</span>`;
+    item.addEventListener("click", () => {
+      closeCommandPalette();
+      cmd.action();
+    });
+    item.addEventListener("mouseenter", () => updatePaletteSelection(i));
+    dom.commandPaletteList.appendChild(item);
+  });
+}
+
+function updatePaletteSelection(newIndex) {
+  const items = dom.commandPaletteList.children;
+  if (items[paletteSelectedIndex])
+    items[paletteSelectedIndex].classList.remove("selected");
+  paletteSelectedIndex = newIndex;
+  if (items[paletteSelectedIndex]) {
+    items[paletteSelectedIndex].classList.add("selected");
+    items[paletteSelectedIndex].scrollIntoView({ block: "nearest" });
+  }
+}
+
+export { COMMANDS, cyclePane, focusAdjacentPane, splitFocusedTab };

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,0 +1,304 @@
+import { EditorState } from "@codemirror/state";
+import {
+  EditorView,
+  keymap,
+  Decoration,
+  ViewPlugin,
+  WidgetType,
+} from "@codemirror/view";
+import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { syntaxTree } from "@codemirror/language";
+import { state } from "./renderer-state.js";
+
+// --- Callback for doc changes (set by renderer.js) ---
+let _onDocChange = null;
+export function setOnDocChange(fn) {
+  _onDocChange = fn;
+}
+
+// --- Bullet widget: replaces "- " / "* " / "1. " with rendered bullet ---
+class BulletWidget extends WidgetType {
+  constructor(ordered, index) {
+    super();
+    this.ordered = ordered;
+    this.index = index;
+  }
+  toDOM() {
+    const span = document.createElement("span");
+    span.className = "cm-md-bullet-char";
+    span.textContent = this.ordered ? `${this.index}.  ` : "•  ";
+    return span;
+  }
+  ignoreEvent() {
+    return false;
+  }
+}
+
+// --- Live preview theme ---
+const livePreviewTheme = EditorView.theme({
+  "&": {
+    fontSize: "14px",
+    fontFamily:
+      "-apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif",
+  },
+  ".cm-content": {
+    padding: "16px 24px",
+    maxWidth: "800px",
+    lineHeight: "1.7",
+  },
+  ".cm-line": {
+    padding: "1px 0",
+  },
+  ".cm-md-heading1": {
+    fontSize: "1.8em",
+    fontWeight: "700",
+    color: "#ff1a1a",
+    marginTop: "8px",
+  },
+  ".cm-md-heading2": {
+    fontSize: "1.4em",
+    fontWeight: "600",
+    color: "#ff4444",
+    marginTop: "6px",
+  },
+  ".cm-md-heading3": {
+    fontSize: "1.2em",
+    fontWeight: "600",
+    color: "#ff6666",
+    marginTop: "4px",
+  },
+  ".cm-md-bold": { fontWeight: "700" },
+  ".cm-md-italic": { fontStyle: "italic" },
+  ".cm-md-code": {
+    fontFamily: "'SF Mono', Menlo, monospace",
+    fontSize: "13px",
+    background: "#252525",
+    padding: "1px 5px",
+    borderRadius: "3px",
+    color: "#ff6666",
+  },
+  ".cm-md-link": { color: "#ff4444", textDecoration: "underline" },
+  ".cm-md-strikethrough": { textDecoration: "line-through", color: "#808080" },
+  ".cm-md-bullet-char": {
+    color: "#ff1a1a",
+    fontWeight: "600",
+    marginRight: "2px",
+  },
+  ".cm-md-list-line": { paddingLeft: "8px" },
+  ".cm-md-blockquote": {
+    borderLeft: "3px solid #ff1a1a",
+    paddingLeft: "14px",
+    color: "#999999",
+  },
+  ".cm-md-hr": {
+    display: "block",
+    borderTop: "1px solid #252525",
+    margin: "12px 0",
+  },
+  ".cm-md-checkbox": { marginRight: "4px" },
+});
+
+const INLINE_STYLES = {
+  StrongEmphasis: "cm-md-bold",
+  Emphasis: "cm-md-italic",
+  InlineCode: "cm-md-code",
+  Strikethrough: "cm-md-strikethrough",
+};
+
+const SYNTAX_MARKS = new Set([
+  "HeaderMark",
+  "EmphasisMark",
+  "CodeMark",
+  "StrikethroughMark",
+  "QuoteMark",
+]);
+
+function getActiveLines(state) {
+  const lines = new Set();
+  for (const range of state.selection.ranges) {
+    const startLine = state.doc.lineAt(range.from).number;
+    const endLine = state.doc.lineAt(range.to).number;
+    for (let i = startLine; i <= endLine; i++) {
+      lines.add(i);
+    }
+  }
+  return lines;
+}
+
+function buildDecorations(view) {
+  const { state } = view;
+  const activeLines = getActiveLines(state);
+  const decorations = [];
+  const tree = syntaxTree(state);
+  const processedLines = new Set();
+  let orderedIndex = 0;
+  let linkDepth = 0;
+  const isLinkContainer = (n) => n === "Link" || n === "Image";
+
+  tree.iterate({
+    leave(node) {
+      if (isLinkContainer(node.name)) linkDepth--;
+    },
+    enter(node) {
+      if (isLinkContainer(node.name)) linkDepth++;
+      const line = state.doc.lineAt(node.from);
+      const isActive = activeLines.has(line.number);
+
+      if (node.name.startsWith("ATXHeading") && !node.name.includes("Mark")) {
+        const level = node.name.match(/(\d)$/)?.[1] || "1";
+        if (!processedLines.has(`heading-${line.number}`)) {
+          decorations.push(
+            Decoration.line({ class: `cm-md-heading${level}` }).range(
+              line.from,
+            ),
+          );
+          processedLines.add(`heading-${line.number}`);
+        }
+        if (isActive) return;
+      }
+
+      if (isActive) return;
+
+      if (node.name === "Blockquote") {
+        const startLine = state.doc.lineAt(node.from).number;
+        const endLine = state.doc.lineAt(node.to).number;
+        for (let i = startLine; i <= endLine; i++) {
+          if (!activeLines.has(i) && !processedLines.has(`bq-${i}`)) {
+            decorations.push(
+              Decoration.line({ class: "cm-md-blockquote" }).range(
+                state.doc.line(i).from,
+              ),
+            );
+            processedLines.add(`bq-${i}`);
+          }
+        }
+      }
+
+      if (node.name === "ListMark") {
+        const text = state.doc.sliceString(node.from, node.to);
+        const isOrdered = /^\d+[.)]$/.test(text);
+        if (isOrdered) {
+          orderedIndex++;
+        } else {
+          orderedIndex = 0;
+        }
+        let end = node.to;
+        if (
+          end < state.doc.length &&
+          state.doc.sliceString(end, end + 1) === " "
+        ) {
+          end += 1;
+        }
+        decorations.push(
+          Decoration.replace({
+            widget: new BulletWidget(isOrdered, orderedIndex),
+          }).range(node.from, end),
+        );
+        if (!processedLines.has(`list-${line.number}`)) {
+          decorations.push(
+            Decoration.line({ class: "cm-md-list-line" }).range(line.from),
+          );
+          processedLines.add(`list-${line.number}`);
+        }
+        return;
+      }
+
+      if (SYNTAX_MARKS.has(node.name) && node.from < node.to) {
+        decorations.push(Decoration.replace({}).range(node.from, node.to));
+      }
+      if (node.name === "LinkMark" && node.from < node.to) {
+        decorations.push(Decoration.replace({}).range(node.from, node.to));
+      }
+      // Only hide URL nodes inside Link/Image (e.g. [text](url)), not standalone bare URLs
+      if (node.name === "URL" && node.from < node.to && linkDepth > 0) {
+        decorations.push(Decoration.replace({}).range(node.from, node.to));
+      }
+
+      const styleClass = INLINE_STYLES[node.name];
+      if (styleClass && node.from < node.to) {
+        decorations.push(
+          Decoration.mark({ class: styleClass }).range(node.from, node.to),
+        );
+      }
+      if (
+        (node.name === "Link" ||
+          node.name === "Autolink" ||
+          (node.name === "URL" && linkDepth === 0)) &&
+        node.from < node.to
+      ) {
+        decorations.push(
+          Decoration.mark({ class: "cm-md-link" }).range(node.from, node.to),
+        );
+      }
+      if (node.name === "HorizontalRule") {
+        decorations.push(
+          Decoration.line({ class: "cm-md-hr" }).range(line.from),
+        );
+      }
+    },
+  });
+
+  decorations.sort((a, b) => a.from - b.from || a.startSide - b.startSide);
+  return Decoration.set(decorations, true);
+}
+
+const livePreviewPlugin = ViewPlugin.fromClass(
+  class {
+    constructor(view) {
+      this.decorations = buildDecorations(view);
+    }
+    update(update) {
+      if (update.docChanged || update.selectionSet || update.viewportChanged) {
+        this.decorations = buildDecorations(update.view);
+      }
+    }
+  },
+  { decorations: (v) => v.decorations },
+);
+
+const darkTheme = EditorView.theme(
+  {
+    "&": {
+      backgroundColor: "#0a0a0a",
+      color: "#e0e0e0",
+      height: "100%",
+    },
+    ".cm-cursor": { borderLeftColor: "#c0c0c0" },
+    ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
+      backgroundColor: "#2a0808",
+    },
+    ".cm-gutters": { display: "none" },
+    ".cm-activeLine": { backgroundColor: "#121212" },
+    "&.cm-focused": { outline: "none" },
+    ".cm-scroller": { overflow: "auto" },
+  },
+  { dark: true },
+);
+
+function createEditor(content) {
+  if (state.editorView) state.editorView.destroy();
+
+  const editorState = EditorState.create({
+    doc: content,
+    extensions: [
+      history(),
+      keymap.of([...defaultKeymap, ...historyKeymap]),
+      markdown({ base: markdownLanguage }),
+      livePreviewPlugin,
+      livePreviewTheme,
+      darkTheme,
+      EditorView.lineWrapping,
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged && _onDocChange) _onDocChange();
+      }),
+    ],
+  });
+
+  state.editorView = new EditorView({
+    state: editorState,
+    parent: state.editorMount,
+  });
+}
+
+export { createEditor };

--- a/src/pool-ui.js
+++ b/src/pool-ui.js
@@ -1,0 +1,752 @@
+import {
+  showNotification,
+  STATUS_CLASSES,
+  escapeHtml,
+} from "./renderer-state.js";
+import { STATUS, POOL_STATUS } from "./session-statuses.js";
+import { FitAddon } from "@xterm/addon-fit";
+import {
+  createTerminal,
+  wireTerminalInput,
+  popupTerminals,
+  findTerminalEntry,
+} from "./terminal-manager.js";
+import { formatShortcutDisplay } from "./command-palette.js";
+
+// --- Cross-module dependencies (set via initPoolUi) ---
+let _actions = {};
+
+/**
+ * Initialize pool UI with dependencies from the main renderer module.
+ *
+ * @param {Object} actions
+ * @param {Function} actions.loadSessions — refresh session sidebar
+ * @param {Function} actions.focusTerminal — focus a terminal tab
+ * @param {Function} actions.loadDirColors — reload directory colors
+ * @param {Array} actions.COMMANDS — command palette commands array
+ */
+export function initPoolUi(actions) {
+  _actions = actions;
+
+  // Build shortcut labels from COMMANDS entries
+  if (_actions.COMMANDS) {
+    for (const cmd of _actions.COMMANDS) {
+      if (cmd.shortcutAction) SHORTCUT_LABELS[cmd.shortcutAction] = cmd.label;
+    }
+  }
+  // Actions only reachable via input events (no COMMANDS entry)
+  SHORTCUT_LABELS["next-terminal-tab-alt"] = "Next Tab (Alt)";
+  SHORTCUT_LABELS["prev-terminal-tab-alt"] = "Previous Tab (Alt)";
+
+  // Wire up the pool settings button
+  const poolSettingsBtn = document.getElementById("pool-settings-btn");
+  poolSettingsBtn.addEventListener("click", () => showPoolSettings());
+}
+
+// --- Module-local state ---
+let poolSettingsInterval = null;
+let poolSettingsVisible = false;
+let shortcutConfig = {};
+const SHORTCUT_LABELS = {};
+
+function poolStatusDot(status) {
+  const cls = STATUS_CLASSES[status] || "dead";
+  return `<span class="session-status ${cls}" style="display:inline-block;vertical-align:middle;margin-right:6px;"></span>`;
+}
+
+// --- Slot Terminal Popup (interactive) ---
+async function openSlotTerminalPopup(slot) {
+  // Don't open popup for dead/unknown slots — no terminal to attach to
+  const status = slot.healthStatus || slot.status;
+  if (status === STATUS.DEAD || !slot.termId) {
+    showNotification("Cannot open terminal for dead slot");
+    return;
+  }
+
+  // Close existing popup if any (run its cleanup)
+  const existingPopup = document.getElementById("slot-terminal-popup");
+  if (existingPopup && existingPopup._cleanup) existingPopup._cleanup();
+  else if (existingPopup) existingPopup.remove();
+
+  const overlay = document.createElement("div");
+  overlay.id = "slot-terminal-popup";
+  overlay.className = "offload-menu-overlay";
+
+  const label =
+    slot.intentionHeading ||
+    slot.sessionId?.slice(0, 8) ||
+    `slot-${slot.index}`;
+
+  overlay.innerHTML = `
+    <div class="slot-terminal-dialog">
+      <div class="slot-terminal-header">
+        <span class="slot-terminal-title">${escapeHtml(label)}</span>
+        <button class="snapshot-close slot-terminal-close">\u2715</button>
+      </div>
+      <div class="slot-terminal-mount"></div>
+    </div>
+  `;
+
+  document.body.appendChild(overlay);
+
+  const mountEl = overlay.querySelector(".slot-terminal-mount");
+  const closeBtn = overlay.querySelector(".slot-terminal-close");
+
+  const term = createTerminal();
+
+  const fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.open(mountEl);
+
+  // Wire input to the PTY so the popup is interactive
+  wireTerminalInput(term, slot.termId);
+
+  // Register in popupTerminals so global data handlers can route data here.
+  // Data is forwarded to both the main terminal entry (if any) and the popup entry.
+  const popupEntry = { termId: slot.termId, term, fitAddon };
+  popupTerminals.set(slot.termId, popupEntry);
+
+  try {
+    await window.api.ptyAttach(slot.termId);
+  } catch (err) {
+    showNotification(`Failed to attach: ${err.message}`);
+    popupTerminals.delete(slot.termId);
+    term.dispose();
+    overlay.remove();
+    return;
+  }
+
+  // Fit after a frame so dimensions are correct
+  requestAnimationFrame(() => {
+    fitAddon.fit();
+    window.api.ptyResize(slot.termId, term.cols, term.rows);
+    term.focus();
+  });
+
+  const resizeObserver = new ResizeObserver(() => {
+    fitAddon.fit();
+    window.api.ptyResize(slot.termId, term.cols, term.rows);
+  });
+  resizeObserver.observe(mountEl);
+
+  // Cleanup function — also stored on overlay for programmatic close
+  const cleanup = () => {
+    resizeObserver.disconnect();
+    popupTerminals.delete(slot.termId);
+    // Only detach if there's no other terminal entry still using this termId
+    // (i.e. the session might be open in the main view)
+    const otherEntry = findTerminalEntry(slot.termId);
+    if (otherEntry) {
+      // Restore PTY size to the main tab's dimensions
+      window.api.ptyResize(
+        slot.termId,
+        otherEntry.term.cols,
+        otherEntry.term.rows,
+      );
+    } else {
+      window.api.ptyDetach(slot.termId).catch(() => {});
+    }
+    term.dispose();
+    overlay.remove();
+  };
+  overlay._cleanup = cleanup;
+
+  closeBtn.addEventListener("click", cleanup);
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay) cleanup();
+  });
+}
+
+// --- Pool Health Badge ---
+async function updatePoolHealthBadge() {
+  const poolSettingsBtn = document.getElementById("pool-settings-btn");
+  const pool = await window.api.poolRead();
+  const errors = pool
+    ? pool.slots.filter((s) => s.status === POOL_STATUS.ERROR).length
+    : 0;
+  poolSettingsBtn.dataset.errors = errors;
+  poolSettingsBtn.title =
+    errors > 0
+      ? `Pool settings — ${errors} slot${errors > 1 ? "s" : ""} in error`
+      : "Pool settings";
+}
+
+function stopPoolSettingsPolling() {
+  if (poolSettingsInterval) {
+    clearInterval(poolSettingsInterval);
+    poolSettingsInterval = null;
+  }
+}
+
+// --- Pool slot rendering ---
+function renderPoolSlotsHtml(health) {
+  if (!health.initialized) return "";
+  return health.slots
+    .map((slot) => {
+      const status = slot.healthStatus || slot.status;
+      const label =
+        slot.intentionHeading ||
+        slot.sessionId?.slice(0, 8) ||
+        `slot-${slot.index}`;
+      const pinned =
+        slot.pinnedUntil && new Date(slot.pinnedUntil) > new Date();
+      const pinBadge = pinned
+        ? '<span class="pool-slot-pin" title="Pinned">📌</span>'
+        : "";
+      return `<div class="pool-slot-row pool-slot-clickable" data-slot-index="${slot.index}">
+        ${poolStatusDot(status)}
+        <span class="pool-slot-label">${escapeHtml(label)}</span>
+        ${pinBadge}
+        <span class="pool-slot-status">${status}</span>
+      </div>`;
+    })
+    .join("");
+}
+
+function renderPoolCountsHtml(health) {
+  if (!health.initialized) return "Pool not initialized";
+  return Object.entries(health.counts)
+    .map(([k, v]) => `${poolStatusDot(k)} ${k}: ${v}`)
+    .join("&nbsp;&nbsp;&nbsp;");
+}
+
+function closePoolSettings(overlay) {
+  stopPoolSettingsPolling();
+  if (overlay._keyHandler) {
+    document.removeEventListener("keydown", overlay._keyHandler, true);
+  }
+  overlay.remove();
+}
+
+// --- Pool Settings Panel ---
+async function showPoolSettings() {
+  stopPoolSettingsPolling();
+  const existing = document.getElementById("pool-settings");
+  if (existing) closePoolSettings(existing);
+
+  const health = await window.api.poolHealth();
+
+  const overlay = document.createElement("div");
+  overlay.id = "pool-settings";
+  overlay.className = "offload-menu-overlay";
+
+  const slotsHtml = renderPoolSlotsHtml(health);
+  const countsHtml = renderPoolCountsHtml(health);
+
+  overlay.innerHTML = `
+    <div class="pool-settings-dialog">
+      <div class="pool-settings-header">
+        <span>Pool Settings</span>
+        <button class="snapshot-close pool-close">\u2715</button>
+      </div>
+      <div class="pool-settings-body">
+        <div class="pool-health-summary">${countsHtml}</div>
+        ${
+          health.initialized
+            ? `
+          <div class="pool-slots-list">${slotsHtml}</div>
+          <div class="pool-controls">
+            <label class="pool-size-label">
+              Pool size:
+              <input type="number" class="pool-size-input" value="${health.poolSize}" min="1" max="20">
+            </label>
+            <button class="offload-menu-btn pool-resize-btn">Resize</button>
+            <button class="offload-menu-btn pool-reload-btn">Reload Sessions</button>
+            <button class="offload-menu-btn pool-clean-btn">Clean Idle</button>
+            <button class="offload-menu-btn pool-destroy-btn">Destroy</button>
+            <button class="offload-menu-btn pool-reinit-btn">Reinitialize</button>
+          </div>
+        `
+            : `
+          <div class="pool-controls">
+            <label class="pool-size-label">
+              Pool size:
+              <input type="number" class="pool-size-input" value="10" min="1" max="20">
+            </label>
+            <button class="offload-menu-btn offload-menu-load pool-init-btn">Initialize Pool</button>
+          </div>
+        `
+        }
+      </div>
+    </div>
+  `;
+
+  document.body.appendChild(overlay);
+
+  // --- Keyboard navigation state ---
+  // "top" = navigating between pool-slots-block and buttons
+  // "slots" = navigating individual pool slots
+  let navLevel = "top";
+  let topIndex = 0;
+  let slotIndex = 0;
+
+  // Returns the list of top-level navigable items (pool-slots-list + buttons)
+  function getTopItems() {
+    const items = [];
+    const slotsList = overlay.querySelector(".pool-slots-list");
+    if (slotsList) items.push(slotsList);
+    for (const btn of overlay.querySelectorAll(
+      ".pool-controls .offload-menu-btn",
+    ))
+      items.push(btn);
+    return items;
+  }
+
+  function getSlotRows() {
+    return Array.from(
+      overlay.querySelectorAll(".pool-slots-list .pool-slot-row"),
+    );
+  }
+
+  function clearAllSelection() {
+    for (const el of overlay.querySelectorAll(".kb-selected"))
+      el.classList.remove("kb-selected");
+  }
+
+  function applySelection() {
+    clearAllSelection();
+    if (navLevel === "top") {
+      const items = getTopItems();
+      if (items[topIndex]) items[topIndex].classList.add("kb-selected");
+    } else {
+      const rows = getSlotRows();
+      // Clamp index after poll refresh may have removed slots
+      if (rows.length > 0) slotIndex = Math.min(slotIndex, rows.length - 1);
+      if (rows[slotIndex]) {
+        rows[slotIndex].classList.add("kb-selected");
+        rows[slotIndex].scrollIntoView({ block: "nearest" });
+      }
+    }
+  }
+
+  // Apply initial selection
+  applySelection();
+
+  overlay._keyHandler = (e) => {
+    // Skip if a terminal popup is open on top
+    if (document.getElementById("slot-terminal-popup")) return;
+    // Skip if an input is focused (e.g. pool size number input)
+    if (overlay.querySelector("input:focus")) return;
+
+    const { key } = e;
+
+    if (key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      if (navLevel === "slots") {
+        navLevel = "top";
+        applySelection();
+      } else {
+        closePoolSettings(overlay);
+      }
+      return;
+    }
+
+    if (key === "ArrowDown" || key === "ArrowUp") {
+      e.preventDefault();
+      e.stopPropagation();
+      const delta = key === "ArrowDown" ? 1 : -1;
+      if (navLevel === "top") {
+        const items = getTopItems();
+        if (items.length === 0) return;
+        topIndex = Math.max(0, Math.min(items.length - 1, topIndex + delta));
+        applySelection();
+      } else {
+        const rows = getSlotRows();
+        if (rows.length === 0) return;
+        slotIndex = Math.max(0, Math.min(rows.length - 1, slotIndex + delta));
+        applySelection();
+      }
+      return;
+    }
+
+    if (key === "Enter") {
+      e.preventDefault();
+      e.stopPropagation();
+      if (navLevel === "top") {
+        const items = getTopItems();
+        const item = items[topIndex];
+        if (!item) return;
+        if (item.classList.contains("pool-slots-list")) {
+          // Enter the slots block
+          navLevel = "slots";
+          slotIndex = 0;
+          applySelection();
+        } else {
+          // It's a button — click it
+          item.click();
+        }
+      } else {
+        // Inside slots — open terminal popup for selected slot
+        const rows = getSlotRows();
+        const row = rows[slotIndex];
+        if (row) row.click();
+      }
+      return;
+    }
+  };
+  document.addEventListener("keydown", overlay._keyHandler, true);
+
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay) closePoolSettings(overlay);
+  });
+  overlay
+    .querySelector(".pool-close")
+    .addEventListener("click", () => closePoolSettings(overlay));
+
+  // Poll for health updates while dialog is open
+  poolSettingsInterval = setInterval(async () => {
+    // Stop polling if dialog was removed externally
+    if (!document.getElementById("pool-settings")) {
+      stopPoolSettingsPolling();
+      return;
+    }
+    try {
+      const h = await window.api.poolHealth();
+      const summaryEl = overlay.querySelector(".pool-health-summary");
+      if (summaryEl) summaryEl.innerHTML = renderPoolCountsHtml(h);
+      const slotsEl = overlay.querySelector(".pool-slots-list");
+      if (slotsEl) {
+        slotsEl.innerHTML = renderPoolSlotsHtml(h);
+        // Re-apply selection after poll refresh (innerHTML wipes classes)
+        applySelection();
+      }
+    } catch {
+      // Ignore transient errors — next poll will retry
+    }
+  }, 3000);
+
+  // Slot row click → open terminal popup (delegated to survive innerHTML poll updates)
+  const slotsListEl = overlay.querySelector(".pool-slots-list");
+  if (slotsListEl) {
+    slotsListEl.addEventListener("click", async (e) => {
+      const row = e.target.closest(".pool-slot-clickable");
+      if (!row) return;
+      const clickedSlotIndex = parseInt(row.dataset.slotIndex, 10);
+      const currentHealth = await window.api.poolHealth();
+      const slot = currentHealth.slots.find(
+        (s) => s.index === clickedSlotIndex,
+      );
+      if (slot) openSlotTerminalPopup(slot);
+    });
+  }
+
+  // Init button
+  const initBtn = overlay.querySelector(".pool-init-btn");
+  if (initBtn) {
+    initBtn.addEventListener("click", async () => {
+      const size = parseInt(
+        overlay.querySelector(".pool-size-input").value,
+        10,
+      );
+      if (isNaN(size) || size < 1 || size > 20) {
+        showNotification("Pool size must be between 1 and 20");
+        return;
+      }
+      initBtn.textContent = "Initializing...";
+      initBtn.disabled = true;
+      try {
+        await window.api.poolInit(size);
+        showNotification(`Pool initialized (${size} slots)`);
+        await _actions.loadSessions();
+        showPoolSettings();
+      } catch (err) {
+        initBtn.textContent = "Initialize Pool";
+        initBtn.disabled = false;
+        showNotification(`Error: ${err.message}`);
+      }
+    });
+  }
+
+  // Resize button
+  const resizeBtn = overlay.querySelector(".pool-resize-btn");
+  if (resizeBtn) {
+    resizeBtn.addEventListener("click", async () => {
+      const newSize = parseInt(
+        overlay.querySelector(".pool-size-input").value,
+        10,
+      );
+      if (isNaN(newSize) || newSize < 1 || newSize > 20) {
+        showNotification("Pool size must be between 1 and 20");
+        return;
+      }
+      resizeBtn.textContent = "Resizing...";
+      resizeBtn.disabled = true;
+      try {
+        await window.api.poolResize(newSize);
+        showNotification(`Pool resized to ${newSize} slots`);
+        await _actions.loadSessions();
+        showPoolSettings();
+      } catch (err) {
+        resizeBtn.textContent = "Resize";
+        resizeBtn.disabled = false;
+        showNotification(`Error: ${err.message}`);
+      }
+    });
+  }
+
+  // Reload button
+  const reloadBtn = overlay.querySelector(".pool-reload-btn");
+  if (reloadBtn) {
+    reloadBtn.addEventListener("click", async () => {
+      closePoolSettings(overlay);
+      await _actions.loadDirColors();
+      await _actions.loadSessions();
+      showNotification("Sessions reloaded");
+    });
+  }
+
+  // Clean idle button
+  const cleanBtn = overlay.querySelector(".pool-clean-btn");
+  if (cleanBtn) {
+    cleanBtn.addEventListener("click", async () => {
+      cleanBtn.textContent = "Cleaning...";
+      cleanBtn.disabled = true;
+      try {
+        const cleaned = await window.api.poolClean();
+        showNotification(
+          `Cleaned ${cleaned} idle session${cleaned !== 1 ? "s" : ""}`,
+        );
+        await _actions.loadSessions();
+        showPoolSettings();
+      } catch (err) {
+        cleanBtn.textContent = "Clean Idle";
+        cleanBtn.disabled = false;
+        showNotification(`Error: ${err.message}`);
+      }
+    });
+  }
+
+  // Destroy button
+  const destroyBtn = overlay.querySelector(".pool-destroy-btn");
+  if (destroyBtn) {
+    destroyBtn.addEventListener("click", async () => {
+      destroyBtn.textContent = "Destroying...";
+      destroyBtn.disabled = true;
+      try {
+        await window.api.poolDestroy();
+        showNotification("Pool destroyed");
+        await _actions.loadSessions();
+        showPoolSettings();
+      } catch (err) {
+        destroyBtn.textContent = "Destroy";
+        destroyBtn.disabled = false;
+        showNotification(`Error: ${err.message}`);
+      }
+    });
+  }
+
+  // Reinitialize button (destroy + init)
+  const reinitBtn = overlay.querySelector(".pool-reinit-btn");
+  if (reinitBtn) {
+    reinitBtn.addEventListener("click", async () => {
+      const size = parseInt(
+        overlay.querySelector(".pool-size-input").value,
+        10,
+      );
+      if (isNaN(size) || size < 1 || size > 20) {
+        showNotification("Pool size must be between 1 and 20");
+        return;
+      }
+      reinitBtn.textContent = "Reinitializing...";
+      reinitBtn.disabled = true;
+      try {
+        await window.api.poolDestroy();
+      } catch (err) {
+        reinitBtn.textContent = "Reinitialize";
+        reinitBtn.disabled = false;
+        showNotification(`Destroy failed: ${err.message}`);
+        return;
+      }
+      try {
+        await window.api.poolInit(size);
+        showNotification(`Pool reinitialized (${size} slots)`);
+      } catch (err) {
+        showNotification(`Pool destroyed but re-init failed: ${err.message}`);
+      }
+      await _actions.loadSessions();
+      showPoolSettings();
+    });
+  }
+}
+
+// --- Shortcut Settings UI ---
+async function showShortcutSettings() {
+  const existing = document.getElementById("shortcut-settings");
+  if (existing) existing.remove();
+
+  const shortcuts = await window.api.getShortcuts();
+  shortcutConfig = shortcuts;
+
+  // Track active keydown listener for cleanup
+  let activeKeyHandler = null;
+
+  function cleanupRecording() {
+    if (activeKeyHandler) {
+      document.removeEventListener("keydown", activeKeyHandler, true);
+      activeKeyHandler = null;
+    }
+  }
+
+  const overlay = document.createElement("div");
+  overlay.id = "shortcut-settings";
+  overlay.className = "offload-menu-overlay";
+
+  const actionIds = Object.keys(SHORTCUT_LABELS);
+  const rows = actionIds
+    .map((id) => {
+      const label = SHORTCUT_LABELS[id];
+      const current = shortcuts[id] || "";
+      const display = formatShortcutDisplay(current) || "—";
+      return `<div class="shortcut-row" data-action="${id}">
+        <span class="shortcut-label">${label}</span>
+        <button class="shortcut-key-btn" title="Click to rebind">${display}</button>
+        <button class="shortcut-reset-btn" title="Reset to default">↺</button>
+      </div>`;
+    })
+    .join("");
+
+  overlay.innerHTML = `
+    <div class="shortcut-settings-dialog">
+      <div class="pool-settings-header">
+        <span>Keyboard Shortcuts</span>
+        <button class="close-dialog-btn">✕</button>
+      </div>
+      <div class="shortcut-settings-body">
+        ${rows}
+      </div>
+    </div>
+  `;
+
+  document.body.appendChild(overlay);
+
+  function closeDialog() {
+    cleanupRecording();
+    document.removeEventListener("keydown", escHandler, true);
+    overlay.remove();
+  }
+
+  // Close on Escape (only when not recording a shortcut)
+  function escHandler(e) {
+    if (e.key === "Escape" && !activeKeyHandler) {
+      e.preventDefault();
+      e.stopPropagation();
+      closeDialog();
+    }
+  }
+  document.addEventListener("keydown", escHandler, true);
+
+  // Close on overlay click or close button
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay) closeDialog();
+  });
+  overlay
+    .querySelector(".close-dialog-btn")
+    .addEventListener("click", closeDialog);
+
+  // Rebind: click key button → enter recording mode
+  overlay.querySelectorAll(".shortcut-key-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      // Cancel any existing recording
+      cleanupRecording();
+      const existingBtn = overlay.querySelector(".shortcut-key-btn.recording");
+      if (existingBtn && existingBtn !== btn) {
+        existingBtn.classList.remove("recording");
+        const oldAction = existingBtn.closest(".shortcut-row").dataset.action;
+        existingBtn.textContent =
+          formatShortcutDisplay(shortcuts[oldAction]) || "\u2014";
+      }
+
+      btn.classList.add("recording");
+      btn.textContent = "Press keys...";
+
+      function onKeyDown(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        // Ignore lone modifier keys
+        if (["Meta", "Control", "Shift", "Alt"].includes(e.key)) return;
+
+        // Escape cancels recording
+        if (e.key === "Escape") {
+          btn.classList.remove("recording");
+          const actionId = btn.closest(".shortcut-row").dataset.action;
+          btn.textContent =
+            formatShortcutDisplay(shortcuts[actionId]) || "\u2014";
+          cleanupRecording();
+          return;
+        }
+
+        // Build Electron accelerator from the event
+        const parts = [];
+        if (e.metaKey) parts.push("CmdOrCtrl");
+        if (e.ctrlKey && !e.metaKey) parts.push("Ctrl");
+        if (e.shiftKey) parts.push("Shift");
+        if (e.altKey) parts.push("Alt");
+
+        const keyMap = {
+          ArrowUp: "Up",
+          ArrowDown: "Down",
+          ArrowLeft: "Left",
+          ArrowRight: "Right",
+          " ": "Space",
+          Backspace: "Backspace",
+          Delete: "Delete",
+          Enter: "Return",
+          Tab: "Tab",
+        };
+        const key = keyMap[e.key] || e.key.toUpperCase();
+        parts.push(key);
+
+        const accelerator = parts.join("+");
+        const actionId = btn.closest(".shortcut-row").dataset.action;
+
+        btn.classList.remove("recording");
+        btn.textContent = formatShortcutDisplay(accelerator);
+        shortcuts[actionId] = accelerator;
+        shortcutConfig = { ...shortcuts };
+
+        window.api.setShortcut(actionId, accelerator);
+        cleanupRecording();
+      }
+
+      activeKeyHandler = onKeyDown;
+      document.addEventListener("keydown", onKeyDown, true);
+    });
+  });
+
+  // Reset buttons
+  overlay.querySelectorAll(".shortcut-reset-btn").forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      const row = btn.closest(".shortcut-row");
+      const actionId = row.dataset.action;
+      await window.api.resetShortcut(actionId);
+      const defaultVal = await window.api.getDefaultShortcut(actionId);
+      shortcuts[actionId] = defaultVal;
+      shortcutConfig = { ...shortcuts };
+      const keyBtn = row.querySelector(".shortcut-key-btn");
+      keyBtn.textContent = formatShortcutDisplay(defaultVal) || "—";
+    });
+  });
+
+  // Unbind: button to clear a shortcut
+  overlay.querySelectorAll(".shortcut-key-btn").forEach((btn) => {
+    btn.addEventListener("contextmenu", async (e) => {
+      e.preventDefault();
+      const row = btn.closest(".shortcut-row");
+      const actionId = row.dataset.action;
+      await window.api.setShortcut(actionId, "");
+      shortcuts[actionId] = "";
+      shortcutConfig = { ...shortcuts };
+      btn.textContent = "—";
+    });
+  });
+}
+
+export {
+  showPoolSettings,
+  openSlotTerminalPopup,
+  showShortcutSettings,
+  updatePoolHealthBadge,
+  stopPoolSettingsPolling,
+};

--- a/src/renderer-state.js
+++ b/src/renderer-state.js
@@ -1,0 +1,97 @@
+// Shared mutable state for renderer modules.
+// All renderer modules import from here instead of passing state through params.
+
+import { STATUS, POOL_STATUS } from "./session-statuses.js";
+
+// --- Status CSS classes (shared across sidebar and pool UI) ---
+export const STATUS_CLASSES = {
+  [STATUS.IDLE]: "idle",
+  [STATUS.PROCESSING]: "processing",
+  [STATUS.FRESH]: "fresh",
+  [STATUS.TYPING]: "typing",
+  [STATUS.DEAD]: "dead",
+  [STATUS.OFFLOADED]: "offloaded",
+  [STATUS.ARCHIVED]: "archived",
+};
+
+// --- Shared utilities ---
+export function escapeHtml(str) {
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+// --- Debug logging ---
+export function debugLog(tag, ...args) {
+  window.api?.debugLog?.(`renderer:${tag}`, ...args);
+}
+
+// --- DOM refs (populated in renderer.js init) ---
+export const dom = {
+  sessionList: null,
+  refreshBtn: null,
+  newSessionBtn: null,
+  emptyState: null,
+  sessionView: null,
+  dockContainer: null,
+  sidebar: null,
+  commandPalette: null,
+  commandPaletteInput: null,
+  commandPaletteList: null,
+};
+
+// --- Mutable state ---
+export const state = {
+  dock: null,
+  editorContainer: null,
+  editorMount: null,
+  editorProject: null,
+  saveStatus: null,
+  shellCounter: 0,
+  cachedSessions: [],
+  currentSessionId: null,
+  currentSessionCwd: null,
+  saveTimeout: null,
+  editorView: null,
+  sessionGeneration: 0,
+  previousSessionId: null,
+  terminals: [], // active view into current session's terminals
+};
+
+// Session terminal cache: Map<sessionId, { terminals: [], lastAccessed: number }>
+export const sessionTerminals = new Map();
+export const CLEANUP_AFTER_MS = 30 * 60 * 1000; // 30 minutes
+
+// --- Notification helpers ---
+
+export function showNotification(msg) {
+  if (!state.saveStatus) return;
+  state.saveStatus.textContent = msg;
+  setTimeout(() => {
+    if (state.saveStatus && state.saveStatus.textContent === msg)
+      state.saveStatus.textContent = "";
+  }, 3000);
+}
+
+export function showToast(msg, level = "info") {
+  let container = document.getElementById("toast-container");
+  if (!container) {
+    container = document.createElement("div");
+    container.id = "toast-container";
+    document.body.appendChild(container);
+  }
+  const toast = document.createElement("div");
+  toast.className = `toast toast-${level}`;
+  toast.textContent = msg;
+  container.appendChild(toast);
+  function dismiss() {
+    toast.classList.add("toast-exit");
+    toast.addEventListener("animationend", () => toast.remove(), {
+      once: true,
+    });
+    setTimeout(() => toast.remove(), 300);
+  }
+  const autoId = setTimeout(dismiss, 8000);
+  toast.addEventListener("click", () => {
+    clearTimeout(autoId);
+    dismiss();
+  });
+}

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,1201 +1,214 @@
-import { EditorState } from "@codemirror/state";
+// Renderer orchestrator: wires all modules together, handles session lifecycle and IPC events.
+
 import {
-  EditorView,
-  keymap,
-  Decoration,
-  ViewPlugin,
-  WidgetType,
-} from "@codemirror/view";
-import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
-import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
-import { syntaxTree } from "@codemirror/language";
-import { Terminal } from "@xterm/xterm";
-import { FitAddon } from "@xterm/addon-fit";
+  state,
+  dom,
+  debugLog,
+  sessionTerminals,
+  showNotification,
+  showToast,
+} from "./renderer-state.js";
+import { STATUS } from "./session-statuses.js";
 import {
-  DockLayout,
   createDefaultLayout,
-  newLeafId,
   TAB_EDITOR,
-  TAB_SNAPSHOT,
-  createEditorContainer,
-  registerTerminalTab,
-  registerEditorTab,
-  setupTerminalResize,
-  teardownTerminalResize,
   disposeTerminalEntry,
-  getFocusedTabId,
-  focusLeafContent,
 } from "./dock-helpers.js";
-import { STATUS, POOL_STATUS } from "./session-statuses.js";
+import { createEditor, setOnDocChange } from "./editor.js";
+import {
+  initSidebar,
+  loadDirColors,
+  getDirColor,
+  displayPath,
+  loadSessions,
+  invalidateSidebar,
+  updateTypingState,
+  showInlineSnapshot,
+  removeInlineSnapshot,
+} from "./session-sidebar.js";
+import {
+  initTerminals,
+  ensureEditorContainer,
+  ensureDock,
+  initDockLayout,
+  syncSessionCache,
+  spawnTerminal,
+  attachPoolTerminal,
+  switchToTerminal,
+  closeTerminal,
+  hideCurrentTerminals,
+  restoreSessionTerminals,
+  destroySessionTerminals,
+  killAllTerminals,
+  cleanupStaleTerminals,
+  reconnectTerminal,
+  reconnectAllPtys,
+  focusTerminal,
+  getActiveTermIndex,
+  dockRegisterTerminal,
+} from "./terminal-manager.js";
+import {
+  initPoolUi,
+  showPoolSettings,
+  updatePoolHealthBadge,
+  showShortcutSettings,
+} from "./pool-ui.js";
+import {
+  initCommandPalette,
+  toggleCommandPalette,
+  setShortcutConfig,
+  COMMANDS,
+  cyclePane,
+  focusAdjacentPane,
+  splitFocusedTab,
+} from "./command-palette.js";
 
-// --- Debug logging (writes to ~/.open-cockpit/debug.log via main process) ---
-function debugLog(tag, ...args) {
-  window.api?.debugLog?.(`renderer:${tag}`, ...args);
+// --- Populate DOM refs ---
+dom.sessionList = document.getElementById("session-list");
+dom.refreshBtn = document.getElementById("refresh-btn");
+dom.newSessionBtn = document.getElementById("new-session-btn");
+dom.emptyState = document.getElementById("empty-state");
+dom.sessionView = document.getElementById("session-view");
+dom.dockContainer = document.getElementById("dock-container");
+dom.sidebar = document.getElementById("sidebar");
+dom.commandPalette = document.getElementById("command-palette");
+dom.commandPaletteInput = document.getElementById("command-palette-input");
+dom.commandPaletteList = document.getElementById("command-palette-list");
+
+// --- Focus management ---
+
+function focusEditor() {
+  if (state.editorView) state.editorView.focus();
 }
 
-// --- Bullet widget: replaces "- " / "* " / "1. " with rendered bullet ---
-class BulletWidget extends WidgetType {
-  constructor(ordered, index) {
-    super();
-    this.ordered = ordered;
-    this.index = index;
-  }
-  toDOM() {
-    const span = document.createElement("span");
-    span.className = "cm-md-bullet-char";
-    span.textContent = this.ordered ? `${this.index}.  ` : "•  ";
-    return span;
-  }
-  ignoreEvent() {
-    return false;
+function togglePaneFocus() {
+  if (state.editorMount && state.editorMount.contains(document.activeElement)) {
+    focusTerminal();
+  } else {
+    focusEditor();
   }
 }
 
-// --- Live preview theme ---
-const livePreviewTheme = EditorView.theme({
-  "&": {
-    fontSize: "14px",
-    fontFamily:
-      "-apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif",
-  },
-  ".cm-content": {
-    padding: "16px 24px",
-    maxWidth: "800px",
-    lineHeight: "1.7",
-  },
-  ".cm-line": {
-    padding: "1px 0",
-  },
-  ".cm-md-heading1": {
-    fontSize: "1.8em",
-    fontWeight: "700",
-    color: "#ff1a1a",
-    marginTop: "8px",
-  },
-  ".cm-md-heading2": {
-    fontSize: "1.4em",
-    fontWeight: "600",
-    color: "#ff4444",
-    marginTop: "6px",
-  },
-  ".cm-md-heading3": {
-    fontSize: "1.2em",
-    fontWeight: "600",
-    color: "#ff6666",
-    marginTop: "4px",
-  },
-  ".cm-md-bold": { fontWeight: "700" },
-  ".cm-md-italic": { fontStyle: "italic" },
-  ".cm-md-code": {
-    fontFamily: "'SF Mono', Menlo, monospace",
-    fontSize: "13px",
-    background: "#252525",
-    padding: "1px 5px",
-    borderRadius: "3px",
-    color: "#ff6666",
-  },
-  ".cm-md-link": { color: "#ff4444", textDecoration: "underline" },
-  ".cm-md-strikethrough": { textDecoration: "line-through", color: "#808080" },
-  ".cm-md-bullet-char": {
-    color: "#ff1a1a",
-    fontWeight: "600",
-    marginRight: "2px",
-  },
-  ".cm-md-list-line": { paddingLeft: "8px" },
-  ".cm-md-blockquote": {
-    borderLeft: "3px solid #ff1a1a",
-    paddingLeft: "14px",
-    color: "#999999",
-  },
-  ".cm-md-hr": {
-    display: "block",
-    borderTop: "1px solid #252525",
-    margin: "12px 0",
-  },
-  ".cm-md-checkbox": { marginRight: "4px" },
-});
-
-const INLINE_STYLES = {
-  StrongEmphasis: "cm-md-bold",
-  Emphasis: "cm-md-italic",
-  InlineCode: "cm-md-code",
-  Strikethrough: "cm-md-strikethrough",
-};
-
-const SYNTAX_MARKS = new Set([
-  "HeaderMark",
-  "EmphasisMark",
-  "CodeMark",
-  "StrikethroughMark",
-  "QuoteMark",
-]);
-
-function getActiveLines(state) {
-  const lines = new Set();
-  for (const range of state.selection.ranges) {
-    const startLine = state.doc.lineAt(range.from).number;
-    const endLine = state.doc.lineAt(range.to).number;
-    for (let i = startLine; i <= endLine; i++) {
-      lines.add(i);
-    }
-  }
-  return lines;
+function toggleSidebar() {
+  dom.sidebar.classList.toggle("collapsed");
 }
 
-function buildDecorations(view) {
-  const { state } = view;
-  const activeLines = getActiveLines(state);
-  const decorations = [];
-  const tree = syntaxTree(state);
-  const processedLines = new Set();
-  let orderedIndex = 0;
-  let linkDepth = 0;
-  const isLinkContainer = (n) => n === "Link" || n === "Image";
+// --- Session selection ---
 
-  tree.iterate({
-    leave(node) {
-      if (isLinkContainer(node.name)) linkDepth--;
-    },
-    enter(node) {
-      if (isLinkContainer(node.name)) linkDepth++;
-      const line = state.doc.lineAt(node.from);
-      const isActive = activeLines.has(line.number);
+async function selectSession(session) {
+  // If already viewing this session, nothing to do
+  if (session.sessionId === state.currentSessionId) return;
 
-      if (node.name.startsWith("ATXHeading") && !node.name.includes("Mark")) {
-        const level = node.name.match(/(\d)$/)?.[1] || "1";
-        if (!processedLines.has(`heading-${line.number}`)) {
-          decorations.push(
-            Decoration.line({ class: `cm-md-heading${level}` }).range(
-              line.from,
-            ),
-          );
-          processedLines.add(`heading-${line.number}`);
-        }
-        if (isActive) return;
-      }
+  hideCurrentTerminals();
 
-      if (isActive) return;
+  state.currentSessionId = session.sessionId;
+  state.currentSessionCwd = session.cwd;
+  const gen = ++state.sessionGeneration;
+  debugLog(
+    "session",
+    `select ${session.sessionId} gen=${gen} origin=${session.origin}`,
+  );
 
-      if (node.name === "Blockquote") {
-        const startLine = state.doc.lineAt(node.from).number;
-        const endLine = state.doc.lineAt(node.to).number;
-        for (let i = startLine; i <= endLine; i++) {
-          if (!activeLines.has(i) && !processedLines.has(`bq-${i}`)) {
-            decorations.push(
-              Decoration.line({ class: "cm-md-blockquote" }).range(
-                state.doc.line(i).from,
-              ),
-            );
-            processedLines.add(`bq-${i}`);
-          }
-        }
-      }
+  document.querySelectorAll(".session-item").forEach((el) => {
+    el.classList.toggle("active", el.dataset.sessionId === session.sessionId);
+  });
 
-      if (node.name === "ListMark") {
-        const text = state.doc.sliceString(node.from, node.to);
-        const isOrdered = /^\d+[.)]$/.test(text);
-        if (isOrdered) {
-          orderedIndex++;
-        } else {
-          orderedIndex = 0;
-        }
-        let end = node.to;
-        if (
-          end < state.doc.length &&
-          state.doc.sliceString(end, end + 1) === " "
-        ) {
-          end += 1;
-        }
-        decorations.push(
-          Decoration.replace({
-            widget: new BulletWidget(isOrdered, orderedIndex),
-          }).range(node.from, end),
-        );
-        if (!processedLines.has(`list-${line.number}`)) {
-          decorations.push(
-            Decoration.line({ class: "cm-md-list-line" }).range(line.from),
-          );
-          processedLines.add(`list-${line.number}`);
-        }
+  dom.emptyState.classList.add("hidden");
+  dom.sessionView.classList.remove("hidden");
+
+  // Ensure editor container exists
+  ensureEditorContainer();
+  state.editorProject.textContent = session.project
+    ? `${session.project} — ${displayPath(session)}`
+    : session.sessionId;
+
+  // Apply directory color to editor header
+  const dirColor = getDirColor(session);
+  const header = state.editorContainer.querySelector(".dock-editor-header");
+  const existingBar = header.querySelector(".dock-editor-header-color-bar");
+  if (existingBar) existingBar.remove();
+  if (dirColor) {
+    const colorBar = document.createElement("div");
+    colorBar.className = "dock-editor-header-color-bar";
+    colorBar.style.background = dirColor;
+    colorBar.style.boxShadow = `0 0 8px ${dirColor}`;
+    header.appendChild(colorBar);
+  }
+
+  // Offloaded/archived: show snapshot inline instead of a terminal
+  if (
+    session.status === STATUS.OFFLOADED ||
+    session.status === STATUS.ARCHIVED
+  ) {
+    showInlineSnapshot(session, gen);
+  } else if (!restoreSessionTerminals(session.sessionId)) {
+    // No cached terminals — set up fresh dock + terminals
+    initDockLayout();
+
+    if (session.origin === "pool") {
+      // Pool session: attach to the pool slot's existing Claude TUI
+      const pool = await window.api.poolRead();
+      if (gen !== state.sessionGeneration) {
+        debugLog("session", `race abort gen=${gen} at poolRead`);
         return;
       }
-
-      if (SYNTAX_MARKS.has(node.name) && node.from < node.to) {
-        decorations.push(Decoration.replace({}).range(node.from, node.to));
-      }
-      if (node.name === "LinkMark" && node.from < node.to) {
-        decorations.push(Decoration.replace({}).range(node.from, node.to));
-      }
-      // Only hide URL nodes inside Link/Image (e.g. [text](url)), not standalone bare URLs
-      if (node.name === "URL" && node.from < node.to && linkDepth > 0) {
-        decorations.push(Decoration.replace({}).range(node.from, node.to));
-      }
-
-      const styleClass = INLINE_STYLES[node.name];
-      if (styleClass && node.from < node.to) {
-        decorations.push(
-          Decoration.mark({ class: styleClass }).range(node.from, node.to),
-        );
-      }
-      if (
-        (node.name === "Link" ||
-          node.name === "Autolink" ||
-          (node.name === "URL" && linkDepth === 0)) &&
-        node.from < node.to
-      ) {
-        decorations.push(
-          Decoration.mark({ class: "cm-md-link" }).range(node.from, node.to),
-        );
-      }
-      if (node.name === "HorizontalRule") {
-        decorations.push(
-          Decoration.line({ class: "cm-md-hr" }).range(line.from),
-        );
-      }
-    },
-  });
-
-  decorations.sort((a, b) => a.from - b.from || a.startSide - b.startSide);
-  return Decoration.set(decorations, true);
-}
-
-const livePreviewPlugin = ViewPlugin.fromClass(
-  class {
-    constructor(view) {
-      this.decorations = buildDecorations(view);
-    }
-    update(update) {
-      if (update.docChanged || update.selectionSet || update.viewportChanged) {
-        this.decorations = buildDecorations(update.view);
-      }
-    }
-  },
-  { decorations: (v) => v.decorations },
-);
-
-const darkTheme = EditorView.theme(
-  {
-    "&": {
-      backgroundColor: "#0a0a0a",
-      color: "#e0e0e0",
-      height: "100%",
-    },
-    ".cm-cursor": { borderLeftColor: "#c0c0c0" },
-    ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
-      backgroundColor: "#2a0808",
-    },
-    ".cm-gutters": { display: "none" },
-    ".cm-activeLine": { backgroundColor: "#121212" },
-    "&.cm-focused": { outline: "none" },
-    ".cm-scroller": { overflow: "auto" },
-  },
-  { dark: true },
-);
-
-// --- xterm.js theme (minimal — let shell theme handle ANSI colors) ---
-const TERM_THEME = {
-  background: "#0a0a0a",
-};
-
-function createTerminal(extraOpts = {}) {
-  return new Terminal({
-    theme: TERM_THEME,
-    fontFamily: "'SF Mono', Menlo, monospace",
-    fontSize: 13,
-    cursorBlink: false,
-    ...extraOpts,
-  });
-}
-
-// xterm.js sends \r for both Enter and Shift+Enter (ignores shift modifier).
-// Claude Code expects CSI u encoding (\x1b[13;2u) for Shift+Enter to trigger
-// multi-line input. This handler intercepts modified Enter and sends the correct
-// escape sequence directly to the PTY.
-function wireTerminalInput(term, termId) {
-  term.attachCustomKeyEventHandler((ev) => {
-    if (ev.key !== "Enter") return true;
-    if (!ev.shiftKey && !ev.ctrlKey) return true; // plain Enter or Alt+Enter: let xterm handle
-    // Must return false for ALL event types (keydown, keypress, keyup) to fully
-    // block xterm.js — otherwise keypress also sends \r alongside the CSI u.
-    if (ev.type === "keydown") {
-      const mod =
-        (ev.shiftKey ? 1 : 0) | (ev.altKey ? 2 : 0) | (ev.ctrlKey ? 4 : 0);
-      window.api.ptyWrite(termId, `\x1b[13;${mod + 1}u`);
-    }
-    return false;
-  });
-  term.onData((data) => window.api.ptyWrite(termId, data));
-}
-
-// --- Directory color coding ---
-// Neon-friendly palette for directory indicators
-const DIR_COLORS = [
-  "#ff1a1a", // neon red
-  "#00ff41", // neon green
-  "#ff6600", // neon orange
-  "#00ccff", // neon cyan
-  "#ff00ff", // neon magenta
-  "#ffff00", // neon yellow
-  "#7b68ee", // neon purple
-  "#ff69b4", // neon pink
-  "#00ff88", // neon mint
-  "#ff4500", // neon vermillion
-];
-
-// User-configured colors from ~/.open-cockpit/colors.json
-// Format: { "~/Documents/Projects/foo": "#ff00ff" }
-// null value = no color (transparent)
-let userDirColors = {};
-
-async function loadDirColors() {
-  userDirColors = await window.api.getDirColors();
-}
-
-function hashString(str) {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
-  }
-  return Math.abs(hash);
-}
-
-// Get the path used for color hashing.
-// - Worktrees (.claude/worktrees/xxx) → parent project dir
-// - Inside a git repo → git root
-// - Otherwise → exact cwd (each folder gets its own color)
-function getColorKey(session) {
-  const { cwd, gitRoot, home } = session;
-  if (!cwd) return "";
-  // Strip worktree suffix (.claude/worktrees/xxx or .wt/xxx)
-  const wtMatch = cwd.match(/^(.+?)\/(?:\.claude\/worktrees|\.wt)\/.+$/);
-  const resolved = wtMatch ? wtMatch[1] : cwd;
-  // If inside a git repo, use the git root
-  if (gitRoot) {
-    // Also handle worktree: if the worktree-stripped path has a git root,
-    // use the worktree-stripped path (it IS the git root)
-    if (wtMatch) return wtMatch[1];
-    return gitRoot;
-  }
-  return resolved;
-}
-
-function getDirColor(session) {
-  const { cwd, home } = session;
-  if (!cwd) return null;
-  // Home directory exactly → no color
-  if (cwd === home) return null;
-
-  const colorKey = getColorKey(session);
-
-  // Check user config — match longest prefix first
-  const configKeys = Object.keys(userDirColors).sort(
-    (a, b) => b.length - a.length,
-  );
-  for (const key of configKeys) {
-    const expandedKey = home ? key.replace(/^~/, home) : key;
-    if (colorKey === expandedKey || colorKey.startsWith(expandedKey + "/")) {
-      return userDirColors[key]; // null = no color, string = exact color
-    }
-  }
-
-  return DIR_COLORS[hashString(colorKey) % DIR_COLORS.length];
-}
-
-// --- App logic ---
-const sessionList = document.getElementById("session-list");
-const refreshBtn = document.getElementById("refresh-btn");
-const newSessionBtn = document.getElementById("new-session-btn");
-const emptyState = document.getElementById("empty-state");
-const sessionView = document.getElementById("session-view");
-const dockContainer = document.getElementById("dock-container");
-const sidebar = document.getElementById("sidebar");
-const commandPalette = document.getElementById("command-palette");
-const commandPaletteInput = document.getElementById("command-palette-input");
-const commandPaletteList = document.getElementById("command-palette-list");
-
-// Dock layout system
-let dock = null;
-let editorContainer = null; // persistent editor content element
-let editorMount = null; // reference into editorContainer
-let editorProject = null;
-let saveStatus = null;
-let shellCounter = 0; // monotonic counter for terminal labels
-
-// Keep a cached copy of sessions for keyboard navigation
-let cachedSessions = [];
-
-let currentSessionId = null;
-let currentSessionCwd = null;
-let saveTimeout = null;
-let editorView = null;
-
-// Terminal state: per-session cache for persistent terminals
-// Map<sessionId, { terminals: [], lastAccessed: number }>
-const sessionTerminals = new Map();
-const CLEANUP_AFTER_MS = 30 * 60 * 1000; // 30 minutes
-
-// Active view into current session's terminals
-let terminals = [];
-
-// Derive active terminal index from dock state (no separate state to desync)
-function getActiveTermIndex() {
-  if (!dock || terminals.length === 0) return -1;
-  // Check all leaves for a terminal tab that is active
-  for (let i = 0; i < terminals.length; i++) {
-    const tabId = terminals[i].dockTabId;
-    if (!tabId) continue;
-    const leafId = dock.getTabLeafId(tabId);
-    if (leafId && dock.getActiveTabInLeaf(leafId) === tabId) return i;
-  }
-  return -1;
-}
-// Generation counter to detect stale async operations after session switches
-let sessionGeneration = 0;
-
-// --- Dock helpers ---
-
-function ensureEditorContainer() {
-  if (editorContainer) return;
-  const result = createEditorContainer();
-  editorContainer = result.editorContainer;
-  editorMount = result.editorMount;
-  editorProject = result.editorProject;
-  saveStatus = result.saveStatus;
-}
-
-function ensureDock() {
-  if (dock) dock.destroy();
-  dock = new DockLayout(dockContainer, {
-    onTabClose: (tabId) => {
-      const entry = terminals.find((t) => t.dockTabId === tabId);
-      if (entry) {
-        const idx = terminals.indexOf(entry);
-        if (idx !== -1) closeTerminal(idx);
-      }
-    },
-    onTabActivate: (tabId) => {
-      // Focus the activated tab's content — resize is handled by dock-resize event
-      const entry = terminals.find((t) => t.dockTabId === tabId);
-      if (entry) {
-        entry.term.focus();
-      }
-      if (tabId === TAB_EDITOR && editorView) {
-        editorView.focus();
-      }
-    },
-    onNewTerminal: (leafId) => {
-      if (currentSessionId)
-        spawnTerminal(currentSessionCwd, null, null, leafId);
-    },
-    onLayoutChange: () => {
-      syncSessionCache();
-    },
-  });
-}
-
-function dockRegisterTerminal(entry) {
-  if (!dock) return;
-  const label = entry.isPoolTui ? "Claude" : `Terminal ${++shellCounter}`;
-  registerTerminalTab(dock, entry, label);
-}
-
-// Initialize dock with optional existing terminals and saved layout.
-// If no terminals/layout provided, caller adds tabs and sets layout after.
-function initDockLayout(existingTerminals, savedLayout) {
-  ensureEditorContainer();
-  ensureDock();
-  shellCounter = 0;
-  if (existingTerminals) {
-    for (const t of existingTerminals) dockRegisterTerminal(t);
-  }
-  registerEditorTab(dock, editorContainer);
-  if (savedLayout) {
-    dock.setLayout(savedLayout);
-  } else if (existingTerminals && existingTerminals.length > 0) {
-    const termTabIds = existingTerminals.map((t) => t.dockTabId);
-    dock.setLayout(createDefaultLayout(termTabIds, [TAB_EDITOR]));
-  }
-}
-
-// Sync current terminals into the session cache (renderer + main process)
-function syncSessionCache() {
-  if (!currentSessionId) return;
-  if (terminals.length === 0) {
-    sessionTerminals.delete(currentSessionId);
-  } else {
-    sessionTerminals.set(currentSessionId, {
-      terminals: [...terminals],
-      dockLayout: dock ? dock.getLayout() : null,
-      lastAccessed: Date.now(),
-    });
-    // Keep main process metadata in sync
-    for (const t of terminals) {
-      window.api.ptySetSession(t.termId, currentSessionId);
-    }
-  }
-}
-
-function createEditor(content) {
-  if (editorView) editorView.destroy();
-
-  const state = EditorState.create({
-    doc: content,
-    extensions: [
-      history(),
-      keymap.of([...defaultKeymap, ...historyKeymap]),
-      markdown({ base: markdownLanguage }),
-      livePreviewPlugin,
-      livePreviewTheme,
-      darkTheme,
-      EditorView.lineWrapping,
-      EditorView.updateListener.of((update) => {
-        if (update.docChanged) scheduleSave();
-      }),
-    ],
-  });
-
-  editorView = new EditorView({ state, parent: editorMount });
-}
-
-async function spawnTerminal(cwd, cmd, args, targetLeafId) {
-  const container = document.createElement("div");
-  container.style.cssText = "width:100%;height:100%;";
-
-  const term = createTerminal();
-
-  const fitAddon = new FitAddon();
-  term.loadAddon(fitAddon);
-  term.open(container);
-
-  let termId, pid;
-  try {
-    ({ termId, pid } = await window.api.ptySpawn({
-      cwd: cwd || undefined,
-      cmd: cmd || undefined,
-      args: args || undefined,
-      sessionId: currentSessionId || undefined,
-    }));
-  } catch (err) {
-    term.dispose();
-    container.remove();
-    throw err;
-  }
-
-  const entry = {
-    termId,
-    pid,
-    term,
-    fitAddon,
-    container,
-    isPoolTui: false,
-    dockTabId: null,
-    _resizeHandler: null,
-  };
-  terminals.push(entry);
-
-  // Register before attach so replay/data can find this terminal
-  pendingTerminals.set(termId, entry);
-  try {
-    await window.api.ptyAttach(termId);
-  } catch (err) {
-    debugLog("term", `attach failed termId=${termId}`, err.message);
-    const idx = terminals.indexOf(entry);
-    if (idx !== -1) terminals.splice(idx, 1);
-    term.dispose();
-    container.remove();
-    pendingTerminals.delete(termId);
-    throw err;
-  }
-  pendingTerminals.delete(termId);
-
-  wireTerminalInput(term, termId);
-  setupTerminalResize(entry);
-
-  // Register with dock
-  dockRegisterTerminal(entry);
-  if (dock) {
-    // Add to target leaf or next to Claude tab
-    const tuiTab = terminals.find((t) => t.isPoolTui)?.dockTabId;
-    const leaf =
-      targetLeafId ||
-      (tuiTab && dock.getTabLeafId(tuiTab)) ||
-      dock.getFirstLeafId();
-    dock.addTab(entry.dockTabId, leaf);
-  }
-
-  // Focus the new terminal so user can type immediately
-  entry.term.focus();
-
-  syncSessionCache();
-  return entry;
-}
-
-// Attach to an existing pool slot's PTY (no spawn — the Claude TUI is already running)
-async function attachPoolTerminal(poolTermId) {
-  const container = document.createElement("div");
-  container.style.cssText = "width:100%;height:100%;";
-
-  const term = createTerminal();
-
-  const fitAddon = new FitAddon();
-  term.loadAddon(fitAddon);
-  term.open(container);
-
-  const entry = {
-    termId: poolTermId,
-    pid: null,
-    term,
-    fitAddon,
-    container,
-    isPoolTui: true,
-    dockTabId: null,
-    _resizeHandler: null,
-  };
-  terminals.push(entry);
-
-  // Register before attach so replay/data can find this terminal
-  pendingTerminals.set(poolTermId, entry);
-  try {
-    await window.api.ptyAttach(poolTermId);
-  } catch (err) {
-    debugLog("pool", `attach failed poolTermId=${poolTermId}`, err.message);
-    const idx = terminals.indexOf(entry);
-    if (idx !== -1) terminals.splice(idx, 1);
-    term.dispose();
-    container.remove();
-    pendingTerminals.delete(poolTermId);
-    throw err;
-  }
-  pendingTerminals.delete(poolTermId);
-
-  wireTerminalInput(term, poolTermId);
-  setupTerminalResize(entry);
-
-  // Register with dock
-  dockRegisterTerminal(entry);
-  if (dock) {
-    const leaf = dock.getFirstLeafId();
-    dock.addTab(entry.dockTabId, leaf);
-  }
-
-  // Focus the new terminal so user can type immediately
-  entry.term.focus();
-
-  syncSessionCache();
-  return entry;
-}
-
-function switchToTerminal(index) {
-  if (index < 0 || index >= terminals.length) return;
-  const entry = terminals[index];
-  if (entry.dockTabId && dock) {
-    dock.activateTab(entry.dockTabId);
-  }
-}
-
-async function closeTerminal(index) {
-  if (index < 0 || index >= terminals.length) return;
-
-  const entry = terminals[index];
-  if (entry.isPoolTui) return; // Can't close the main Claude terminal
-  await window.api.ptyDetach(entry.termId).catch(() => {});
-  await window.api.ptyKill(entry.termId);
-  disposeTerminalEntry(entry, dock);
-  terminals.splice(index, 1);
-
-  if (terminals.length === 0) {
-    sessionView.classList.add("hidden");
-    emptyState.classList.remove("hidden");
-  } else {
-    // Focus the remaining active terminal (or first terminal)
-    focusTerminal();
-  }
-
-  syncSessionCache();
-}
-
-// Hide current session's terminals (preserve them in cache)
-function hideCurrentTerminals() {
-  removeInlineSnapshot();
-  if (currentSessionId && terminals.length > 0) {
-    syncSessionCache();
-    for (const entry of terminals) teardownTerminalResize(entry);
-  }
-  terminals = [];
-  shellCounter = 0;
-}
-
-// Restore cached terminals for a session, returns true if restored
-function restoreSessionTerminals(sessionId) {
-  const cached = sessionTerminals.get(sessionId);
-  if (!cached || cached.terminals.length === 0) return false;
-
-  cached.lastAccessed = Date.now();
-  terminals = cached.terminals;
-
-  initDockLayout(terminals, cached.dockLayout);
-  for (const entry of terminals) setupTerminalResize(entry);
-
-  // initDockLayout dispatches dock-resize before listeners are registered —
-  // fire again so restored terminals adapt to the current container size
-  window.dispatchEvent(new Event("dock-resize"));
-
-  return true;
-}
-
-// Kill and fully dispose terminals for a specific session.
-// keepAlive: if true, extra shell terminals stay alive in the daemon (detach only, no kill).
-// Used during offload so terminals can be re-attached on resume.
-function destroySessionTerminals(sessionId, { keepAlive = false } = {}) {
-  const cached = sessionTerminals.get(sessionId);
-  if (!cached) return;
-  for (const entry of cached.terminals) {
-    window.api.ptyDetach(entry.termId).catch(() => {});
-    // Don't kill pool TUI terminals — the Claude process must stay alive.
-    // With keepAlive, also skip killing extra shells (they survive in daemon).
-    if (!entry.isPoolTui && !keepAlive) {
-      window.api.ptyKill(entry.termId).catch(() => {});
-    }
-    const activeDock = sessionId === currentSessionId ? dock : null;
-    disposeTerminalEntry(entry, activeDock);
-  }
-  sessionTerminals.delete(sessionId);
-}
-
-// Kill ALL terminals across all sessions (used on new-session)
-function killAllTerminals() {
-  for (const [sid] of sessionTerminals) {
-    destroySessionTerminals(sid);
-  }
-  for (const entry of terminals) {
-    window.api.ptyDetach(entry.termId).catch(() => {});
-    if (!entry.isPoolTui) {
-      window.api.ptyKill(entry.termId).catch(() => {});
-    }
-    disposeTerminalEntry(entry, dock);
-  }
-  terminals = [];
-  shellCounter = 0;
-}
-
-// Clean up terminals for dead sessions that haven't been accessed recently
-function cleanupStaleTerminals(liveSessions) {
-  const aliveIds = new Set(
-    liveSessions.filter((s) => s.alive).map((s) => s.sessionId),
-  );
-  const now = Date.now();
-  for (const [sid, cached] of sessionTerminals) {
-    if (sid === currentSessionId) continue; // never clean up active session
-    const isDead = !aliveIds.has(sid);
-    const isStale = now - cached.lastAccessed > CLEANUP_AFTER_MS;
-    if (isDead && isStale) {
-      destroySessionTerminals(sid);
-    }
-  }
-}
-
-// Find a terminal entry across all sessions (active + cached)
-// Temporary lookup for terminals being reconnected (before they're in sessionTerminals)
-const pendingTerminals = new Map(); // termId -> entry
-const popupTerminals = new Map(); // termId -> { term, ... } for slot terminal popups
-
-function findTerminalEntry(termId) {
-  const active = terminals.find((t) => t.termId === termId);
-  if (active) return active;
-  for (const cached of sessionTerminals.values()) {
-    const entry = cached.terminals.find((t) => t.termId === termId);
-    if (entry) return entry;
-  }
-  return pendingTerminals.get(termId) || null;
-}
-
-// Wire PTY output from daemon (via main process)
-window.api.onPtyData((termId, data) => {
-  const entry = findTerminalEntry(termId);
-  if (entry) entry.term.write(data);
-  // Also forward to popup terminal if open (may be same or different entry)
-  const popup = popupTerminals.get(termId);
-  if (popup && popup !== entry) popup.term.write(data);
-});
-
-window.api.onPtyReplay((termId, data) => {
-  const entry = findTerminalEntry(termId);
-  // Skip if buffer was already written directly during reconnect
-  if (entry && !entry.skipReplay) entry.term.write(data);
-  // Popup always receives replay (it never has skipReplay)
-  const popup = popupTerminals.get(termId);
-  if (popup && popup !== entry) popup.term.write(data);
-});
-
-window.api.onPtyExit((termId) => {
-  const entry = findTerminalEntry(termId);
-  if (entry) entry.term.write("\r\n[Process exited]\r\n");
-  const popup = popupTerminals.get(termId);
-  if (popup && popup !== entry) popup.term.write("\r\n[Process exited]\r\n");
-});
-
-const STATUS_CLASSES = {
-  [STATUS.IDLE]: "idle",
-  [STATUS.PROCESSING]: "processing",
-  [STATUS.FRESH]: "fresh",
-  [STATUS.TYPING]: "typing",
-  [STATUS.DEAD]: "dead",
-  [STATUS.OFFLOADED]: "offloaded",
-  [STATUS.ARCHIVED]: "archived",
-};
-
-// Build a fingerprint for a session to detect changes
-function sessionFingerprint(s) {
-  return `${s.sessionId}|${s.status}|${s.staleIdle ? "stale" : ""}|${s.intentionHeading || ""}|${s.intentionPreview || ""}|${s.cwd || ""}|${s.origin || ""}`;
-}
-
-// Track previous session fingerprints for diff-based updates
-let prevSessionFingerprints = null;
-// Play a short bell tone via Web Audio API
-let bellCtx = null;
-function playBell() {
-  try {
-    if (!bellCtx) bellCtx = new AudioContext();
-    if (bellCtx.state === "suspended") bellCtx.resume();
-    const osc = bellCtx.createOscillator();
-    const gain = bellCtx.createGain();
-    osc.connect(gain);
-    gain.connect(bellCtx.destination);
-    osc.type = "sine";
-    osc.frequency.value = 880;
-    gain.gain.setValueAtTime(0.3, bellCtx.currentTime);
-    gain.gain.exponentialRampToValueAtTime(0.001, bellCtx.currentTime + 0.3);
-    osc.start(bellCtx.currentTime);
-    osc.stop(bellCtx.currentTime + 0.3);
-  } catch (_) {
-    // Audio not available — ignore
-  }
-}
-let archiveExpanded = false;
-async function loadSessions() {
-  const sessions = await window.api.getSessions();
-  const oldStatuses = new Map(
-    cachedSessions.map((s) => [s.sessionId, s.status]),
-  );
-  cachedSessions = sessions;
-
-  // Keep CWD in sync (may change as JSONL records cd commands)
-  if (currentSessionId) {
-    const current = sessions.find((s) => s.sessionId === currentSessionId);
-    if (current?.cwd) currentSessionCwd = current.cwd;
-  }
-
-  cleanupStaleTerminals(sessions);
-  updatePoolHealthBadge();
-
-  // Split into sections — pool and external mixed together
-  const typing = sessions.filter((s) => s.status === STATUS.TYPING);
-  const recent = sessions.filter(
-    (s) => s.status === STATUS.IDLE || s.status === STATUS.OFFLOADED,
-  );
-  const processing = sessions.filter((s) => s.status === STATUS.PROCESSING);
-  const archived = sessions.filter((s) => s.status === STATUS.ARCHIVED);
-
-  // Build fingerprint to check if anything changed
-  const allItems = [...typing, ...recent, ...processing, ...archived];
-  const fingerprints = allItems.map(sessionFingerprint).join("\n");
-  if (fingerprints === prevSessionFingerprints) {
-    // Only update active class (selected session may have changed)
-    for (const li of sessionList.querySelectorAll(".session-item")) {
-      li.classList.toggle("active", li.dataset.sessionId === currentSessionId);
-    }
-    return;
-  }
-  prevSessionFingerprints = fingerprints;
-
-  // Bell when a session transitions to idle (finished processing)
-  if (oldStatuses.size > 0) {
-    for (const s of sessions) {
-      if (
-        s.status === STATUS_CLASSES.idle &&
-        oldStatuses.has(s.sessionId) &&
-        oldStatuses.get(s.sessionId) !== STATUS_CLASSES.idle
-      ) {
-        playBell();
-        break;
-      }
-    }
-  }
-
-  // Full rebuild only when sessions actually changed
-  sessionList.innerHTML = "";
-
-  if (
-    typing.length === 0 &&
-    recent.length === 0 &&
-    processing.length === 0 &&
-    archived.length === 0
-  ) {
-    sessionList.innerHTML =
-      '<li style="padding: 12px; color: var(--text-dim); font-size: 13px;">No sessions found</li>';
-    return;
-  }
-
-  function addSection(label, items) {
-    if (items.length === 0) return;
-    const header = document.createElement("li");
-    header.className = "session-section-header";
-    header.textContent = `${label} (${items.length})`;
-    sessionList.appendChild(header);
-    for (const s of items) {
-      sessionList.appendChild(createSessionItem(s));
-    }
-  }
-
-  addSection("Typing", typing);
-  addSection("Recent", recent);
-  addSection("Processing", processing);
-
-  // Archive section: collapsible, shows first 5 by default
-  if (archived.length > 0) {
-    const ARCHIVE_VISIBLE = 5;
-    const header = document.createElement("li");
-    header.className = "session-section-header session-section-collapsible";
-    const collapsed = archived.length > ARCHIVE_VISIBLE && !archiveExpanded;
-    header.innerHTML = `<span class="section-toggle">${archiveExpanded ? "▾" : "▸"}</span> Archive (${archived.length})`;
-    if (archived.length > ARCHIVE_VISIBLE) {
-      header.addEventListener("click", () => {
-        archiveExpanded = !archiveExpanded;
-        loadSessions();
-      });
-    }
-    sessionList.appendChild(header);
-    const visible = collapsed ? archived.slice(0, ARCHIVE_VISIBLE) : archived;
-    for (const s of visible) {
-      sessionList.appendChild(createSessionItem(s));
-    }
-    if (collapsed) {
-      const more = document.createElement("li");
-      more.className = "session-section-more";
-      more.textContent = `+${archived.length - ARCHIVE_VISIBLE} more`;
-      more.addEventListener("click", () => {
-        archiveExpanded = true;
-        loadSessions();
-      });
-      sessionList.appendChild(more);
-    }
-  }
-}
-
-function createSessionItem(s) {
-  const li = document.createElement("li");
-  li.className = `session-item${s.sessionId === currentSessionId ? " active" : ""}${s.status === STATUS.OFFLOADED || s.status === STATUS.ARCHIVED ? " offloaded" : ""}`;
-  li.dataset.sessionId = s.sessionId;
-  const heading = s.intentionHeading || s.intentionPreview || null;
-  const isPreview = !s.intentionHeading && !!s.intentionPreview;
-  const dp = displayPath(s);
-  const dirColor = getDirColor(s);
-  const indicatorStyle = dirColor
-    ? `background: ${dirColor}; box-shadow: 0 0 4px ${dirColor}`
-    : "background: transparent";
-  const showOrigin =
-    s.origin && s.status !== STATUS.OFFLOADED && s.status !== STATUS.ARCHIVED;
-  const originTag = showOrigin
-    ? `<span class="session-origin-tag session-origin-${escapeHtml(s.origin)}">${escapeHtml(s.origin)}</span>`
-    : "";
-  const staleTag = s.staleIdle
-    ? `<span class="session-origin-tag session-origin-stale">stale</span>`
-    : "";
-  const pinned = s.pinnedUntil && new Date(s.pinnedUntil) > new Date();
-  const pinnedTag = pinned
-    ? '<span class="session-origin-tag session-origin-pinned" title="Pinned — won\'t be offloaded">📌</span>'
-    : "";
-  li.innerHTML = `
-    <div class="session-dir-indicator" style="${indicatorStyle}"></div>
-    <div class="session-item-content">
-      <div class="session-project">
-        <span class="session-status ${STATUS_CLASSES[s.status] || "dead"}"></span>
-        <span class="session-title${isPreview ? " session-preview" : ""}">${escapeHtml(heading || "No intention yet")}</span>
-        ${originTag}${staleTag}${pinnedTag}
-      </div>
-      <div class="session-cwd">${escapeHtml(dp)}</div>
-    </div>
-  `;
-  li.addEventListener("click", () => selectSession(s));
-  li.addEventListener("contextmenu", (e) => {
-    e.preventDefault();
-    showSessionContextMenu(e, s);
-  });
-  return li;
-}
-
-// Right-click context menu for sessions
-function showSessionContextMenu(e, session) {
-  const existing = document.getElementById("session-context-menu");
-  if (existing) existing.remove();
-
-  const menu = document.createElement("div");
-  menu.id = "session-context-menu";
-  menu.className = "session-context-menu";
-  menu.style.left = `${e.clientX}px`;
-  menu.style.top = `${e.clientY}px`;
-
-  const isArchived = session.status === STATUS.ARCHIVED;
-  const isOffloaded = session.status === STATUS.OFFLOADED;
-
-  if (isArchived) {
-    menu.innerHTML = `
-      <div class="session-context-item" data-action="restart">Restart</div>
-      <div class="session-context-item" data-action="unarchive">Move to Recent</div>
-    `;
-  } else if (isOffloaded) {
-    menu.innerHTML = `
-      <div class="session-context-item" data-action="resume">Resume</div>
-      <div class="session-context-item" data-action="archive">Archive</div>
-    `;
-  } else {
-    menu.innerHTML = `
-      <div class="session-context-item" data-action="archive">Archive</div>
-    `;
-  }
-
-  document.body.appendChild(menu);
-
-  const close = () => menu.remove();
-  setTimeout(() => document.addEventListener("click", close, { once: true }));
-
-  menu.addEventListener("click", async (ev) => {
-    const action = ev.target.dataset.action;
-    menu.remove();
-    if (action === "archive") {
-      try {
-        await window.api.archiveSession(session.sessionId);
-      } catch (err) {
-        console.error("Failed to archive session:", err);
-      }
-      await loadSessions();
-    } else if (action === "unarchive") {
-      try {
-        await window.api.unarchiveSession(session.sessionId);
-      } catch (err) {
-        console.error("Failed to unarchive session:", err);
-      }
-      await loadSessions();
-    } else if (action === "restart") {
-      try {
-        await window.api.unarchiveSession(session.sessionId);
-      } catch (err) {
-        console.error("Failed to unarchive session for restart:", err);
-      }
-      await resumeOffloadedSession(session);
-    } else if (action === "resume") {
-      await resumeOffloadedSession(session);
-    }
-  });
-}
-
-// Show read-only snapshot viewer
-function showSnapshotViewer(session, snapshotText) {
-  const existing = document.getElementById("snapshot-viewer");
-  if (existing) existing.remove();
-
-  const viewer = document.createElement("div");
-  viewer.id = "snapshot-viewer";
-  viewer.className = "offload-menu-overlay";
-  viewer.innerHTML = `
-    <div class="snapshot-dialog">
-      <div class="snapshot-header">
-        <span>${escapeHtml(session.intentionHeading || "Snapshot")}</span>
-        <button class="snapshot-close">\u2715</button>
-      </div>
-      <pre class="snapshot-content">${snapshotText ? escapeHtml(snapshotText) : "(no snapshot available)"}</pre>
-    </div>
-  `;
-
-  document.body.appendChild(viewer);
-
-  function closeViewer() {
-    document.removeEventListener("keydown", escHandler, true);
-    viewer.remove();
-  }
-  function escHandler(e) {
-    if (e.key === "Escape") {
-      e.preventDefault();
-      e.stopPropagation();
-      closeViewer();
-    }
-  }
-  document.addEventListener("keydown", escHandler, true);
-
-  viewer.addEventListener("click", (e) => {
-    if (e.target === viewer) closeViewer();
-  });
-  viewer
-    .querySelector(".snapshot-close")
-    .addEventListener("click", closeViewer);
-}
-
-// Show snapshot content inline as a dock tab for offloaded/archived sessions
-async function showInlineSnapshot(session, gen) {
-  const isArchived = session.status === STATUS.ARCHIVED;
-  const btnLabel = isArchived ? "Restart" : "Resume";
-
-  let snapshotText = null;
-  if (session.hasSnapshot) {
-    try {
-      snapshotText = await window.api.readOffloadSnapshot(session.sessionId);
-    } catch (err) {
-      debugLog("snapshot", `failed to read snapshot: ${err.message}`);
-    }
-    if (gen !== sessionGeneration) return;
-  }
-
-  // Create snapshot content element
-  const container = document.createElement("div");
-  container.className = "dock-snapshot-content";
-  container.innerHTML = `
-    <div class="inline-snapshot-header">
-      <span class="inline-snapshot-label">${isArchived ? "Archived" : "Offloaded"} Session</span>
-      <button class="inline-snapshot-restart">${btnLabel}</button>
-    </div>
-    <pre class="snapshot-content inline-snapshot-content">${snapshotText ? escapeHtml(snapshotText) : "(no snapshot available)"}</pre>
-  `;
-
-  container
-    .querySelector(".inline-snapshot-restart")
-    .addEventListener("click", async () => {
-      if (isArchived) {
+      const slot = pool?.slots.find((s) => s.sessionId === session.sessionId);
+      if (slot) {
         try {
-          await window.api.unarchiveSession(session.sessionId);
-        } catch (err) {
-          debugLog("snapshot", `unarchive failed: ${err.message}`);
+          await attachPoolTerminal(slot.termId);
+          if (gen !== state.sessionGeneration) {
+            debugLog("session", `race abort gen=${gen} at poolAttach`);
+            destroySessionTerminals(session.sessionId);
+            return;
+          }
+        } catch {
+          debugLog(
+            "session",
+            `pool attach failed for slot ${slot.termId}, falling back to shell`,
+          );
+          await spawnTerminal(session.cwd);
+          if (gen !== state.sessionGeneration) {
+            debugLog("session", `race abort gen=${gen} at spawnFallback`);
+            destroySessionTerminals(session.sessionId);
+            return;
+          }
+        }
+      } else {
+        await spawnTerminal(session.cwd);
+        if (gen !== state.sessionGeneration) {
+          debugLog("session", `race abort gen=${gen} at noSlotSpawn`);
+          destroySessionTerminals(session.sessionId);
+          return;
         }
       }
-      await resumeOffloadedSession(session);
-    });
+    } else {
+      // External session: spawn a fresh shell
+      await spawnTerminal(session.cwd);
+      if (gen !== state.sessionGeneration) {
+        debugLog("session", `race abort gen=${gen} at extSpawn`);
+        destroySessionTerminals(session.sessionId);
+        return;
+      }
+    }
 
-  // Register snapshot as a dock tab
-  ensureEditorContainer();
-  ensureDock();
-  dock.registerTab(TAB_SNAPSHOT, {
-    type: TAB_SNAPSHOT,
-    label: isArchived ? "Archived" : "Snapshot",
-    closable: false,
-    contentEl: container,
-  });
-  registerEditorTab(dock, editorContainer);
-  dock.setLayout(createDefaultLayout([TAB_SNAPSHOT], [TAB_EDITOR]));
-}
-
-// Clean up inline snapshot when switching away from an offloaded/archived session
-function removeInlineSnapshot() {
-  if (dock) {
-    dock.unregisterTab(TAB_SNAPSHOT);
+    // Set the default dock layout
+    const termTabIds = state.terminals.map((t) => t.dockTabId);
+    state.dock.setLayout(createDefaultLayout(termTabIds, [TAB_EDITOR]));
   }
+
+  const content = await window.api.readIntention(session.sessionId);
+  if (gen !== state.sessionGeneration) return;
+  createEditor(content);
+  if (state.saveStatus) state.saveStatus.textContent = "";
+
+  await window.api.watchIntention(session.sessionId);
+  if (gen !== state.sessionGeneration) return;
+
+  // Auto-focus the Claude terminal so the user can type immediately
+  focusTerminal();
 }
 
-function displayPath(session) {
-  return session.cwd ? session.cwd.replace(session.home, "~") : "~";
-}
-
-function escapeHtml(str) {
-  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
+// --- Pool slot acquisition ---
 
 function isFreshPoolSlot(s) {
   return (
@@ -1222,7 +235,7 @@ async function acquireFreshSlot() {
       (s) =>
         s.status === STATUS.IDLE &&
         s.origin === "pool" &&
-        s.sessionId !== currentSessionId,
+        s.sessionId !== state.currentSessionId,
     )
     .sort((a, b) => a.idleTs - b.idleTs);
 
@@ -1275,7 +288,8 @@ async function pollForFreshSlot(timeoutMs) {
   return null;
 }
 
-// Resume an offloaded session into a fresh slot
+// --- Resume offloaded session ---
+
 async function resumeOffloadedSession(session) {
   let result;
   try {
@@ -1298,15 +312,15 @@ async function resumeOffloadedSession(session) {
   }
 
   // Set dock layout after terminal is attached
-  const termTabIds = terminals.map((t) => t.dockTabId);
-  dock.setLayout(createDefaultLayout(termTabIds, [TAB_EDITOR]));
+  const termTabIds = state.terminals.map((t) => t.dockTabId);
+  state.dock.setLayout(createDefaultLayout(termTabIds, [TAB_EDITOR]));
 
   // Poll until the slot gets its new session ID, then update our state
   const oldSessionId = session.sessionId;
   const newSession = await pollForResumedSession(result.termId, 60000);
   if (newSession) {
-    currentSessionId = newSession.sessionId;
-    currentSessionCwd = newSession.cwd;
+    state.currentSessionId = newSession.sessionId;
+    state.currentSessionCwd = newSession.cwd;
 
     // Clean up any renderer-side cached terminals for the old session
     // (e.g. from startup reconnect). The daemon terminals were re-tagged
@@ -1315,7 +329,7 @@ async function resumeOffloadedSession(session) {
     if (oldCached) {
       for (const entry of oldCached.terminals) {
         window.api.ptyDetach(entry.termId).catch(() => {});
-        disposeTerminalEntry(entry, dock);
+        disposeTerminalEntry(entry, state.dock);
       }
     }
     sessionTerminals.delete(oldSessionId);
@@ -1331,23 +345,24 @@ async function resumeOffloadedSession(session) {
       );
       for (const p of extraPtys) {
         const entry = await reconnectTerminal(p);
-        terminals.push(entry);
+        state.terminals.push(entry);
         dockRegisterTerminal(entry);
-        if (dock) {
-          const tuiTab = terminals.find((t) => t.isPoolTui)?.dockTabId;
+        if (state.dock) {
+          const tuiTab = state.terminals.find((t) => t.isPoolTui)?.dockTabId;
           const leaf =
-            (tuiTab && dock.getTabLeafId(tuiTab)) || dock.getFirstLeafId();
-          dock.addTab(entry.dockTabId, leaf);
+            (tuiTab && state.dock.getTabLeafId(tuiTab)) ||
+            state.dock.getFirstLeafId();
+          state.dock.addTab(entry.dockTabId, leaf);
         }
       }
     } catch (err) {
       debugLog("pool", `re-attach orphaned terminals failed: ${err.message}`);
     }
 
-    if (terminals.length > 0) {
+    if (state.terminals.length > 0) {
       sessionTerminals.set(newSession.sessionId, {
-        terminals: [...terminals],
-        dockLayout: dock ? dock.getLayout() : null,
+        terminals: [...state.terminals],
+        dockLayout: state.dock ? state.dock.getLayout() : null,
         lastAccessed: Date.now(),
       });
     }
@@ -1375,157 +390,114 @@ async function pollForResumedSession(termId, timeoutMs) {
   return null;
 }
 
-function showNotification(msg) {
-  if (!saveStatus) return;
-  saveStatus.textContent = msg;
-  setTimeout(() => {
-    if (saveStatus && saveStatus.textContent === msg)
-      saveStatus.textContent = "";
-  }, 3000);
-}
+// --- Auto-save ---
 
-// Corner toast for important system events (auto-recovery, errors)
-function showToast(msg, level = "info") {
-  let container = document.getElementById("toast-container");
-  if (!container) {
-    container = document.createElement("div");
-    container.id = "toast-container";
-    document.body.appendChild(container);
-  }
-  const toast = document.createElement("div");
-  toast.className = `toast toast-${level}`;
-  toast.textContent = msg;
-  container.appendChild(toast);
-  function dismiss() {
-    toast.classList.add("toast-exit");
-    toast.addEventListener("animationend", () => toast.remove(), {
-      once: true,
-    });
-    // Fallback if animation is disabled (prefers-reduced-motion)
-    setTimeout(() => toast.remove(), 300);
-  }
-  const autoId = setTimeout(dismiss, 8000);
-  toast.addEventListener("click", () => {
-    clearTimeout(autoId);
-    dismiss();
-  });
-}
-
-async function selectSession(session) {
-  // If already viewing this session, nothing to do
-  if (session.sessionId === currentSessionId) return;
-
-  hideCurrentTerminals();
-
-  currentSessionId = session.sessionId;
-  currentSessionCwd = session.cwd;
-  const gen = ++sessionGeneration;
-  debugLog(
-    "session",
-    `select ${session.sessionId} gen=${gen} origin=${session.origin}`,
-  );
-
-  document.querySelectorAll(".session-item").forEach((el) => {
-    el.classList.toggle("active", el.dataset.sessionId === session.sessionId);
-  });
-
-  emptyState.classList.add("hidden");
-  sessionView.classList.remove("hidden");
-
-  // Ensure editor container exists
-  ensureEditorContainer();
-  editorProject.textContent = session.project
-    ? `${session.project} — ${displayPath(session)}`
-    : session.sessionId;
-
-  // Apply directory color to editor header
-  const dirColor = getDirColor(session);
-  const header = editorContainer.querySelector(".dock-editor-header");
-  const existingBar = header.querySelector(".dock-editor-header-color-bar");
-  if (existingBar) existingBar.remove();
-  if (dirColor) {
-    const colorBar = document.createElement("div");
-    colorBar.className = "dock-editor-header-color-bar";
-    colorBar.style.background = dirColor;
-    colorBar.style.boxShadow = `0 0 8px ${dirColor}`;
-    header.appendChild(colorBar);
-  }
-
-  // Offloaded/archived: show snapshot inline instead of a terminal
-  if (
-    session.status === STATUS.OFFLOADED ||
-    session.status === STATUS.ARCHIVED
-  ) {
-    showInlineSnapshot(session, gen);
-  } else if (!restoreSessionTerminals(session.sessionId)) {
-    // No cached terminals — set up fresh dock + terminals
-    initDockLayout();
-
-    if (session.origin === "pool") {
-      // Pool session: attach to the pool slot's existing Claude TUI
-      const pool = await window.api.poolRead();
-      if (gen !== sessionGeneration) {
-        debugLog("session", `race abort gen=${gen} at poolRead`);
-        return;
-      }
-      const slot = pool?.slots.find((s) => s.sessionId === session.sessionId);
-      if (slot) {
-        try {
-          await attachPoolTerminal(slot.termId);
-          if (gen !== sessionGeneration) {
-            debugLog("session", `race abort gen=${gen} at poolAttach`);
-            destroySessionTerminals(session.sessionId);
-            return;
-          }
-        } catch {
-          debugLog(
-            "session",
-            `pool attach failed for slot ${slot.termId}, falling back to shell`,
-          );
-          await spawnTerminal(session.cwd);
-          if (gen !== sessionGeneration) {
-            debugLog("session", `race abort gen=${gen} at spawnFallback`);
-            destroySessionTerminals(session.sessionId);
-            return;
-          }
-        }
-      } else {
-        await spawnTerminal(session.cwd);
-        if (gen !== sessionGeneration) {
-          debugLog("session", `race abort gen=${gen} at noSlotSpawn`);
-          destroySessionTerminals(session.sessionId);
-          return;
-        }
-      }
-    } else {
-      // External session: spawn a fresh shell
-      await spawnTerminal(session.cwd);
-      if (gen !== sessionGeneration) {
-        debugLog("session", `race abort gen=${gen} at extSpawn`);
-        destroySessionTerminals(session.sessionId);
-        return;
-      }
+function scheduleSave() {
+  if (!state.currentSessionId || !state.editorView) return;
+  if (state.saveStatus) state.saveStatus.textContent = "Editing...";
+  updateTypingState();
+  clearTimeout(state.saveTimeout);
+  state.saveTimeout = setTimeout(async () => {
+    const content = state.editorView.state.doc.toString();
+    try {
+      await window.api.writeIntention(state.currentSessionId, content);
+      if (state.saveStatus) state.saveStatus.textContent = "Saved";
+      setTimeout(() => {
+        if (state.saveStatus && state.saveStatus.textContent === "Saved")
+          state.saveStatus.textContent = "";
+      }, 2000);
+    } catch (err) {
+      debugLog(
+        "editor",
+        `intention save failed session=${state.currentSessionId}`,
+        err.message,
+      );
+      if (state.saveStatus) state.saveStatus.textContent = "";
     }
-
-    // Set the default dock layout
-    const termTabIds = terminals.map((t) => t.dockTabId);
-    dock.setLayout(createDefaultLayout(termTabIds, [TAB_EDITOR]));
-  }
-
-  const content = await window.api.readIntention(session.sessionId);
-  if (gen !== sessionGeneration) return;
-  createEditor(content);
-  if (saveStatus) saveStatus.textContent = "";
-
-  await window.api.watchIntention(session.sessionId);
-  if (gen !== sessionGeneration) return;
-
-  // Auto-focus the Claude terminal so the user can type immediately
-  focusTerminal();
+  }, 500);
 }
 
-// "+" in sidebar: acquire a fresh slot from the pool (or offload LRU idle)
+// --- Session switching ---
+
+function switchSession(direction) {
+  // Navigate between loaded sessions (idle + processing + typing), skip offloaded/fresh/dead
+  const navigable = state.cachedSessions.filter(
+    (s) =>
+      s.alive &&
+      (s.status === STATUS.IDLE ||
+        s.status === STATUS.PROCESSING ||
+        s.status === STATUS.TYPING),
+  );
+  if (navigable.length === 0) return;
+  const currentIndex = navigable.findIndex(
+    (s) => s.sessionId === state.currentSessionId,
+  );
+  let nextIndex;
+  if (currentIndex === -1) {
+    nextIndex = 0;
+  } else {
+    nextIndex =
+      (currentIndex + direction + navigable.length) % navigable.length;
+  }
+  selectSession(navigable[nextIndex]);
+}
+
+// --- Jump to most recent idle session ---
+
+function jumpToRecentIdle() {
+  const idle = state.cachedSessions.find(
+    (s) => s.status === STATUS.IDLE && s.sessionId !== state.currentSessionId,
+  );
+  if (idle) selectSession(idle);
+}
+
+// --- Focus external terminal for current session ---
+
+async function focusCurrentExternalTerminal() {
+  const session = state.cachedSessions.find(
+    (s) => s.sessionId === state.currentSessionId,
+  );
+  if (!session || !session.alive || session.origin === "pool") return;
+  const result = await window.api.focusExternalTerminal(session.pid);
+  if (result.focused) showNotification(`Focused ${result.app}`);
+}
+
+// --- Archive current session (then jump to recent idle) ---
+
+async function archiveCurrentSession() {
+  if (!state.currentSessionId) return;
+  const session = state.cachedSessions.find(
+    (s) => s.sessionId === state.currentSessionId,
+  );
+  if (!session) return;
+  // Can't archive already-archived sessions
+  if (session.status === STATUS.ARCHIVED) return;
+
+  const archivingSessionId = state.currentSessionId;
+
+  // Jump away immediately — don't wait for the slow offload+/clear
+  const idle = state.cachedSessions.find(
+    (s) =>
+      s.sessionId !== archivingSessionId &&
+      (s.status === STATUS.IDLE ||
+        s.status === STATUS.FRESH ||
+        s.status === STATUS.TYPING),
+  );
+  if (idle) {
+    selectSession(idle);
+  }
+
+  // Archive in background
+  try {
+    await window.api.archiveSession(archivingSessionId);
+  } catch (err) {
+    console.error("Failed to archive session:", err);
+  }
+  await loadSessions();
+}
+
 // --- Setup script picker ---
+
 function showSetupScriptPicker(scripts) {
   return new Promise((resolve) => {
     const overlay = document.createElement("div");
@@ -1619,7 +591,64 @@ async function typeSetupScript(termId, scriptContent) {
   await window.api.ptyWrite(termId, processed);
 }
 
-newSessionBtn.addEventListener("click", async () => {
+// --- Initialize all modules ---
+
+// Terminal manager
+initTerminals({
+  removeInlineSnapshot,
+  displayPath,
+  createEditor,
+});
+
+// Session sidebar
+initSidebar({
+  selectSession,
+  resumeOffloadedSession,
+  cleanupStaleTerminals,
+  updatePoolHealthBadge,
+  ensureEditorContainer,
+  ensureDock,
+});
+
+// Pool UI
+initPoolUi({
+  loadSessions,
+  focusTerminal,
+  loadDirColors,
+  COMMANDS,
+});
+
+// Command palette
+initCommandPalette({
+  switchSession,
+  spawnTerminal,
+  getActiveTermIndex,
+  closeTerminal,
+  switchToTerminal,
+  jumpToRecentIdle,
+  archiveCurrentSession,
+  toggleSidebar,
+  togglePaneFocus,
+  focusEditor,
+  focusTerminal,
+  focusCurrentExternalTerminal,
+  loadDirColors,
+  loadSessions,
+  showPoolSettings,
+  showShortcutSettings,
+});
+
+// Editor doc change callback
+setOnDocChange(scheduleSave);
+
+// --- Button handlers ---
+
+dom.refreshBtn.addEventListener("click", async () => {
+  await loadDirColors();
+  loadSessions();
+});
+
+dom.newSessionBtn.addEventListener("click", async () => {
   // Check pool is initialized
   const pool = await window.api.poolRead();
   if (!pool) {
@@ -1662,540 +691,11 @@ newSessionBtn.addEventListener("click", async () => {
   await loadSessions();
 });
 
-// "+" in terminal tab bar: new terminal at current session's CWD
-// New terminal button removed — dock "+" buttons handle this now
+// --- IPC event handlers ---
 
-function scheduleSave() {
-  if (!currentSessionId || !editorView) return;
-  if (saveStatus) saveStatus.textContent = "Editing...";
-  updateTypingState();
-  clearTimeout(saveTimeout);
-  saveTimeout = setTimeout(async () => {
-    const content = editorView.state.doc.toString();
-    try {
-      await window.api.writeIntention(currentSessionId, content);
-      if (saveStatus) saveStatus.textContent = "Saved";
-      setTimeout(() => {
-        if (saveStatus && saveStatus.textContent === "Saved")
-          saveStatus.textContent = "";
-      }, 2000);
-    } catch (err) {
-      debugLog(
-        "editor",
-        `intention save failed session=${currentSessionId}`,
-        err.message,
-      );
-      if (saveStatus) saveStatus.textContent = "";
-    }
-  }, 500);
-}
-
-let typingRefreshTimeout;
-
-function invalidateSidebar() {
-  prevSessionFingerprints = null;
-  loadSessions();
-}
-
-// After editing a fresh/typing session, refresh sidebar so main re-checks intention file
-function updateTypingState() {
-  if (!currentSessionId) return;
-  const session = cachedSessions.find((s) => s.sessionId === currentSessionId);
-  if (
-    !session ||
-    (session.status !== STATUS.FRESH && session.status !== STATUS.TYPING)
-  ) {
-    return;
-  }
-  // Immediately update sidebar preview from local editor content (no round-trip)
-  updateTypingPreview();
-  // Also schedule full refresh so main process picks up the status change
-  clearTimeout(typingRefreshTimeout);
-  typingRefreshTimeout = setTimeout(invalidateSidebar, 600); // after 500ms save debounce
-}
-
-// Update the current session's sidebar preview directly from local editor content
-function updateTypingPreview() {
-  if (!currentSessionId || !editorView) return;
-  const li = sessionList.querySelector(
-    `[data-session-id="${currentSessionId}"]`,
-  );
-  if (!li) return;
-  const titleSpan = li.querySelector(".session-title");
-  if (!titleSpan) return;
-  const session = cachedSessions.find((s) => s.sessionId === currentSessionId);
-  if (!session || session.intentionHeading) return;
-  const raw = editorView.state.doc.toString().trim();
-  const preview = raw
-    .replace(/^#\s+.*\n?/, "")
-    .trim()
-    .slice(0, 80);
-  titleSpan.textContent = preview || "No intention yet";
-  titleSpan.classList.toggle("session-preview", !!preview);
-}
-
-// Handle external file changes
-window.api.onIntentionChanged((content) => {
-  if (!editorView) return;
-  const current = editorView.state.doc.toString();
-  if (content !== current) {
-    editorView.dispatch({
-      changes: { from: 0, to: current.length, insert: content },
-    });
-    if (saveStatus) saveStatus.textContent = "Updated from disk";
-    setTimeout(() => {
-      if (saveStatus && saveStatus.textContent === "Updated from disk")
-        saveStatus.textContent = "";
-    }, 2000);
-  }
-});
-
-// --- Session switching ---
-function switchSession(direction) {
-  // Navigate between loaded sessions (idle + processing + typing), skip offloaded/fresh/dead
-  const navigable = cachedSessions.filter(
-    (s) =>
-      s.alive &&
-      (s.status === STATUS.IDLE ||
-        s.status === STATUS.PROCESSING ||
-        s.status === STATUS.TYPING),
-  );
-  if (navigable.length === 0) return;
-  const currentIndex = navigable.findIndex(
-    (s) => s.sessionId === currentSessionId,
-  );
-  let nextIndex;
-  if (currentIndex === -1) {
-    nextIndex = 0;
-  } else {
-    nextIndex =
-      (currentIndex + direction + navigable.length) % navigable.length;
-  }
-  selectSession(navigable[nextIndex]);
-}
-
-// --- Jump to most recent idle session ---
-function jumpToRecentIdle() {
-  const idle = cachedSessions.find(
-    (s) => s.status === STATUS.IDLE && s.sessionId !== currentSessionId,
-  );
-  if (idle) selectSession(idle);
-}
-
-// --- Focus external terminal for current session ---
-async function focusCurrentExternalTerminal() {
-  const session = cachedSessions.find((s) => s.sessionId === currentSessionId);
-  if (!session || !session.alive || session.origin === "pool") return;
-  const result = await window.api.focusExternalTerminal(session.pid);
-  if (result.focused) showNotification(`Focused ${result.app}`);
-}
-
-// --- Archive current session (then jump to recent idle) ---
-async function archiveCurrentSession() {
-  if (!currentSessionId) return;
-  const session = cachedSessions.find((s) => s.sessionId === currentSessionId);
-  if (!session) return;
-  // Can't archive already-archived sessions
-  if (session.status === STATUS.ARCHIVED) return;
-
-  const archivingSessionId = currentSessionId;
-
-  // Jump away immediately — don't wait for the slow offload+/clear
-  const idle = cachedSessions.find(
-    (s) =>
-      s.sessionId !== archivingSessionId &&
-      (s.status === STATUS.IDLE ||
-        s.status === STATUS.FRESH ||
-        s.status === STATUS.TYPING),
-  );
-  if (idle) {
-    selectSession(idle);
-  }
-
-  // Archive in background
-  try {
-    await window.api.archiveSession(archivingSessionId);
-  } catch (err) {
-    console.error("Failed to archive session:", err);
-  }
-  await loadSessions();
-}
-
-// --- Sidebar toggle ---
-function toggleSidebar() {
-  sidebar.classList.toggle("collapsed");
-}
-
-// --- Focus management ---
-function focusTerminal() {
-  const idx = getActiveTermIndex();
-  const entry = idx >= 0 ? terminals[idx] : terminals[0];
-  if (entry) {
-    if (entry.dockTabId && dock) dock.activateTab(entry.dockTabId);
-    entry.term.focus();
-  }
-}
-
-function focusEditor() {
-  if (editorView) editorView.focus();
-}
-
-function togglePaneFocus() {
-  if (editorMount && editorMount.contains(document.activeElement)) {
-    focusTerminal();
-  } else {
-    focusEditor();
-  }
-}
-
-// --- Command palette ---
-// --- Shortcut display helpers ---
-// Convert Electron accelerator to display string (e.g. "CmdOrCtrl+N" → "⌘N")
-function formatShortcutDisplay(accel) {
-  if (!accel) return "";
-  return accel
-    .replace(/CmdOrCtrl\+/gi, "⌘")
-    .replace(/Cmd\+/gi, "⌘")
-    .replace(/Ctrl\+/gi, "⌃")
-    .replace(/Shift\+/gi, "⇧")
-    .replace(/Alt\+/gi, "⌥")
-    .replace(/\+/g, "")
-    .replace(/Tab/gi, "⇥")
-    .replace(/Up/gi, "↑")
-    .replace(/Down/gi, "↓")
-    .replace(/Left/gi, "←")
-    .replace(/Right/gi, "→");
-}
-
-// Loaded shortcut config (populated on init)
-let shortcutConfig = {};
-
-// Cycle pane focus: editor → terminal tabs (round-robin) → back to editor
-function cyclePane() {
-  const activeIdx = getActiveTermIndex();
-  if (editorMount && editorMount.contains(document.activeElement)) {
-    focusTerminal();
-  } else if (activeIdx >= 0 && terminals.length > 1) {
-    const nextIdx = activeIdx + 1;
-    if (nextIdx < terminals.length) {
-      switchToTerminal(nextIdx);
-    } else {
-      focusEditor();
-    }
-  } else {
-    focusEditor();
-  }
-}
-
-// Navigate between dock leaves (panels)
-function focusAdjacentPane(delta) {
-  if (!dock) return;
-  const leafIds = dock.getLeafIds();
-  if (leafIds.length < 2) return;
-
-  // Find which leaf currently has focus
-  const focusedTabId = getFocusedTabId(dock, dockContainer);
-  let currentLeafId = focusedTabId ? dock.getTabLeafId(focusedTabId) : null;
-  if (!currentLeafId) currentLeafId = leafIds[0];
-
-  const idx = leafIds.indexOf(currentLeafId);
-  const nextIdx = (idx + delta + leafIds.length) % leafIds.length;
-  const nextLeafId = leafIds[nextIdx];
-
-  const activeTabId = dock.getActiveTabInLeaf(nextLeafId);
-  if (activeTabId === TAB_EDITOR || activeTabId === TAB_SNAPSHOT) {
-    dock.activateTab(activeTabId);
-    if (activeTabId === TAB_EDITOR && editorView) editorView.focus();
-  } else {
-    focusLeafContent(dock, nextLeafId, terminals);
-  }
-}
-
-// Move the focused tab to a new split in the given direction
-function splitFocusedTab(direction) {
-  if (!dock) return;
-  const focusedTabId = getFocusedTabId(dock, dockContainer);
-  if (!focusedTabId) return;
-  dock.moveTabToSplit(focusedTabId, direction);
-}
-
-const COMMANDS = [
-  {
-    id: "next-session",
-    label: "Next Session",
-    shortcutAction: "next-session",
-    action: () => switchSession(1),
-  },
-  {
-    id: "prev-session",
-    label: "Previous Session",
-    shortcutAction: "prev-session",
-    action: () => switchSession(-1),
-  },
-  {
-    id: "new-session",
-    label: "New Claude Session",
-    shortcutAction: "new-session",
-    action: () => newSessionBtn.click(),
-  },
-  {
-    id: "new-terminal",
-    label: "New Terminal Tab",
-    shortcutAction: "new-terminal-tab",
-    action: () => {
-      if (currentSessionId) spawnTerminal(currentSessionCwd);
-    },
-  },
-  {
-    id: "close-terminal",
-    label: "Close Terminal Tab",
-    shortcutAction: "close-terminal-tab",
-    action: () => {
-      const i = getActiveTermIndex();
-      if (i >= 0) closeTerminal(i);
-    },
-  },
-  {
-    id: "next-tab",
-    label: "Next Terminal Tab",
-    shortcutAction: "next-tab",
-    action: () => {
-      if (terminals.length > 1)
-        switchToTerminal((getActiveTermIndex() + 1) % terminals.length);
-    },
-  },
-  {
-    id: "prev-tab",
-    label: "Previous Terminal Tab",
-    shortcutAction: "prev-tab",
-    action: () => {
-      if (terminals.length > 1)
-        switchToTerminal(
-          (getActiveTermIndex() - 1 + terminals.length) % terminals.length,
-        );
-    },
-  },
-  {
-    id: "jump-recent-idle",
-    label: "Jump to Recent Idle",
-    shortcutAction: "jump-recent-idle",
-    action: jumpToRecentIdle,
-  },
-  {
-    id: "archive-current-session",
-    label: "Archive Current Session",
-    shortcutAction: "archive-current-session",
-    action: archiveCurrentSession,
-  },
-  {
-    id: "toggle-sidebar",
-    label: "Toggle Sidebar",
-    shortcutAction: "toggle-sidebar",
-    action: toggleSidebar,
-  },
-  {
-    id: "cycle-pane",
-    label: "Cycle Pane Focus",
-    shortcutAction: "cycle-pane",
-    action: cyclePane,
-  },
-  {
-    id: "focus-next-pane",
-    label: "Focus Next Pane",
-    shortcutAction: "focus-next-pane",
-    action: () => focusAdjacentPane(1),
-  },
-  {
-    id: "focus-prev-pane",
-    label: "Focus Previous Pane",
-    shortcutAction: "focus-prev-pane",
-    action: () => focusAdjacentPane(-1),
-  },
-  {
-    id: "split-right",
-    label: "Split Right",
-    shortcutAction: "split-right",
-    action: () => splitFocusedTab("right"),
-  },
-  {
-    id: "split-down",
-    label: "Split Down",
-    shortcutAction: "split-down",
-    action: () => splitFocusedTab("down"),
-  },
-  {
-    id: "toggle-pane-focus",
-    label: "Toggle Pane Focus",
-    shortcutAction: "toggle-pane-focus",
-    action: togglePaneFocus,
-  },
-  {
-    id: "focus-editor",
-    label: "Focus Editor",
-    shortcutAction: "focus-editor",
-    action: focusEditor,
-  },
-  {
-    id: "focus-terminal",
-    label: "Focus Terminal",
-    shortcutAction: "focus-terminal",
-    action: focusTerminal,
-  },
-  {
-    id: "focus-external-terminal",
-    label: "Focus External Terminal",
-    shortcutAction: "focus-external",
-    action: focusCurrentExternalTerminal,
-  },
-  {
-    id: "open-in-cursor",
-    label: "Open in Cursor",
-    shortcutAction: "open-in-cursor",
-    action: () => {
-      if (currentSessionCwd) window.api.openInCursor(currentSessionCwd);
-    },
-  },
-  {
-    id: "refresh",
-    label: "Refresh Sessions",
-    action: () => {
-      loadDirColors();
-      loadSessions();
-    },
-  },
-  {
-    id: "command-palette",
-    label: "Command Palette",
-    shortcutAction: "toggle-command-palette",
-    action: () => toggleCommandPalette(),
-  },
-];
-
-// Also add Tab 1-9 commands
-for (let i = 0; i < 9; i++) {
-  COMMANDS.push({
-    id: `tab-${i + 1}`,
-    label: `Switch to Tab ${i + 1}`,
-    shortcut: `⌘${i + 1}`,
-    action: () => {
-      if (i < terminals.length) switchToTerminal(i);
-    },
-  });
-}
-
-let paletteSelectedIndex = 0;
-let filteredCommands = [];
-
-function toggleCommandPalette() {
-  if (commandPalette.classList.contains("visible")) {
-    closeCommandPalette();
-  } else {
-    openCommandPalette();
-  }
-}
-
-function openCommandPalette() {
-  commandPalette.classList.add("visible");
-  commandPaletteInput.value = "";
-  paletteSelectedIndex = 0;
-  renderPaletteList("");
-  commandPaletteInput.focus();
-}
-
-function closeCommandPalette() {
-  commandPalette.classList.remove("visible");
-  commandPaletteInput.value = "";
-  // Return focus to terminal
-  focusTerminal();
-}
-
-// Get display shortcut for a command (dynamic from config)
-function getCommandShortcut(cmd) {
-  if (!cmd.shortcutAction) return "";
-  return formatShortcutDisplay(shortcutConfig[cmd.shortcutAction] || "");
-}
-
-function renderPaletteList(query) {
-  const q = query.toLowerCase();
-  filteredCommands = q
-    ? COMMANDS.filter(
-        (c) =>
-          c.label.toLowerCase().includes(q) ||
-          getCommandShortcut(c).toLowerCase().includes(q),
-      )
-    : COMMANDS.filter((c) => !c.id.startsWith("tab-")); // Hide tab-N from unfiltered list
-
-  paletteSelectedIndex = Math.min(
-    paletteSelectedIndex,
-    Math.max(0, filteredCommands.length - 1),
-  );
-
-  commandPaletteList.innerHTML = "";
-  filteredCommands.forEach((cmd, i) => {
-    const item = document.createElement("div");
-    item.className = `command-palette-item${i === paletteSelectedIndex ? " selected" : ""}`;
-    const shortcut = getCommandShortcut(cmd);
-    item.innerHTML = `<span class="command-palette-label">${cmd.label}</span><span class="command-palette-shortcut">${shortcut}</span>`;
-    item.addEventListener("click", () => {
-      closeCommandPalette();
-      cmd.action();
-    });
-    item.addEventListener("mouseenter", () => updatePaletteSelection(i));
-    commandPaletteList.appendChild(item);
-  });
-}
-
-commandPaletteInput.addEventListener("input", () => {
-  paletteSelectedIndex = 0;
-  renderPaletteList(commandPaletteInput.value);
-});
-
-function updatePaletteSelection(newIndex) {
-  const items = commandPaletteList.children;
-  if (items[paletteSelectedIndex])
-    items[paletteSelectedIndex].classList.remove("selected");
-  paletteSelectedIndex = newIndex;
-  if (items[paletteSelectedIndex]) {
-    items[paletteSelectedIndex].classList.add("selected");
-    items[paletteSelectedIndex].scrollIntoView({ block: "nearest" });
-  }
-}
-
-commandPaletteInput.addEventListener("keydown", (e) => {
-  if (e.key === "Escape") {
-    e.preventDefault();
-    closeCommandPalette();
-    return;
-  }
-  if (e.key === "ArrowDown") {
-    e.preventDefault();
-    updatePaletteSelection(
-      Math.min(paletteSelectedIndex + 1, filteredCommands.length - 1),
-    );
-    return;
-  }
-  if (e.key === "ArrowUp") {
-    e.preventDefault();
-    updatePaletteSelection(Math.max(paletteSelectedIndex - 1, 0));
-    return;
-  }
-  if (e.key === "Enter" && filteredCommands.length > 0) {
-    e.preventDefault();
-    const cmd = filteredCommands[paletteSelectedIndex];
-    closeCommandPalette();
-    cmd.action();
-    return;
-  }
-});
-
-// Click outside palette to close
-commandPalette.addEventListener("click", (e) => {
-  if (e.target === commandPalette) closeCommandPalette();
-});
-
-// Menu keyboard shortcuts
+// Menu keyboard shortcuts — terminal tabs
 window.api.onNewTerminalTab(() => {
-  if (currentSessionId) spawnTerminal(currentSessionCwd);
+  if (state.currentSessionId) spawnTerminal(state.currentSessionCwd);
 });
 
 window.api.onCloseTerminalTab(() => {
@@ -2208,103 +708,34 @@ window.api.onCloseTerminalTab(() => {
   if (i >= 0) closeTerminal(i);
 });
 
-// API-spawned terminal: attach to it and show a tab (if it belongs to current session)
-window.api.onApiTermOpened(async (sessionId, termId) => {
-  if (sessionId !== currentSessionId) return;
-  if (terminals.some((t) => t.termId === termId)) return;
-
-  const container = document.createElement("div");
-  container.style.cssText = "width:100%;height:100%;";
-
-  const term = createTerminal();
-  const fitAddon = new FitAddon();
-  term.loadAddon(fitAddon);
-  term.open(container);
-
-  const entry = {
-    termId,
-    pid: null,
-    term,
-    fitAddon,
-    container,
-    isPoolTui: false,
-    dockTabId: null,
-    _resizeHandler: null,
-  };
-  terminals.push(entry);
-
-  pendingTerminals.set(termId, entry);
-  try {
-    await window.api.ptyAttach(termId);
-  } catch (err) {
-    debugLog("api-term", `attach failed termId=${termId}`, err.message);
-    const idx = terminals.indexOf(entry);
-    if (idx !== -1) terminals.splice(idx, 1);
-    term.dispose();
-    container.remove();
-    pendingTerminals.delete(termId);
-    return;
-  }
-  pendingTerminals.delete(termId);
-
-  wireTerminalInput(term, termId);
-  setupTerminalResize(entry);
-
-  dockRegisterTerminal(entry);
-  if (dock) {
-    const tuiTab = terminals.find((t) => t.isPoolTui)?.dockTabId;
-    const leaf = (tuiTab && dock.getTabLeafId(tuiTab)) || dock.getFirstLeafId();
-    dock.addTab(entry.dockTabId, leaf);
-  }
-  syncSessionCache();
-});
-
-// API-closed terminal: clean up the renderer side
-window.api.onApiTermClosed((sessionId, termId) => {
-  if (sessionId !== currentSessionId) return;
-  const idx = terminals.findIndex((t) => t.termId === termId);
-  if (idx === -1) return;
-
-  const entry = terminals[idx];
-  window.api.ptyDetach(entry.termId).catch(() => {});
-  disposeTerminalEntry(entry, dock);
-  terminals.splice(idx, 1);
-
-  if (terminals.length === 0) {
-    sessionView.classList.add("hidden");
-    emptyState.classList.remove("hidden");
-  }
-
-  syncSessionCache();
-});
-
 window.api.onNextTerminalTab(() => {
-  if (terminals.length > 1) {
-    switchToTerminal((getActiveTermIndex() + 1) % terminals.length);
+  if (state.terminals.length > 1) {
+    switchToTerminal((getActiveTermIndex() + 1) % state.terminals.length);
   }
 });
 
 window.api.onPrevTerminalTab(() => {
-  if (terminals.length > 1) {
+  if (state.terminals.length > 1) {
     switchToTerminal(
-      (getActiveTermIndex() - 1 + terminals.length) % terminals.length,
+      (getActiveTermIndex() - 1 + state.terminals.length) %
+        state.terminals.length,
     );
   }
 });
 
 window.api.onSwitchTerminalTab((index) => {
-  if (index < terminals.length) switchToTerminal(index);
+  if (index < state.terminals.length) switchToTerminal(index);
 });
 
 // Navigation shortcuts
-window.api.onNewSession(() => newSessionBtn.click());
+window.api.onNewSession(() => dom.newSessionBtn.click());
 window.api.onNextSession(() => switchSession(1));
 window.api.onPrevSession(() => switchSession(-1));
 window.api.onToggleSidebar(toggleSidebar);
 window.api.onFocusEditor(focusEditor);
 window.api.onFocusTerminal(() => {
   // Don't steal focus from command palette (Escape closes it instead)
-  if (!commandPalette.classList.contains("visible")) focusTerminal();
+  if (!dom.commandPalette.classList.contains("visible")) focusTerminal();
 });
 window.api.onToggleCommandPalette(toggleCommandPalette);
 window.api.onTogglePaneFocus(togglePaneFocus);
@@ -2317,7 +748,7 @@ window.api.onFocusExternalTerminal(focusCurrentExternalTerminal);
 window.api.onJumpRecentIdle(jumpToRecentIdle);
 window.api.onArchiveCurrentSession(archiveCurrentSession);
 window.api.onOpenInCursor(() => {
-  if (currentSessionCwd) window.api.openInCursor(currentSessionCwd);
+  if (state.currentSessionCwd) window.api.openInCursor(state.currentSessionCwd);
 });
 window.api.onOpenPoolSettings(() => showPoolSettings());
 
@@ -2329,860 +760,32 @@ window.api.onPoolSlotsRecovered((slots) => {
   showToast(msg, "warning");
 });
 
-// Reconnect a single PTY from daemon (after app restart or reload)
-async function reconnectTerminal(ptyInfo) {
-  const container = document.createElement("div");
-  container.style.cssText = "width:100%;height:100%;";
-
-  // Match the PTY's current dimensions so replay buffer renders correctly
-  const term = createTerminal({
-    ...(ptyInfo.cols && { cols: ptyInfo.cols }),
-    ...(ptyInfo.rows && { rows: ptyInfo.rows }),
-  });
-
-  const fitAddon = new FitAddon();
-  term.loadAddon(fitAddon);
-  term.open(container);
-
-  const entry = {
-    termId: ptyInfo.termId,
-    pid: ptyInfo.pid,
-    term,
-    fitAddon,
-    container,
-    isPoolTui: !!ptyInfo.isPoolTui,
-    dockTabId: null,
-    _resizeHandler: null,
-  };
-
-  if (ptyInfo.buffer) {
-    term.write(ptyInfo.buffer);
-    entry.skipReplay = true;
-  }
-
-  pendingTerminals.set(ptyInfo.termId, entry);
-
-  try {
-    await window.api.ptyAttach(ptyInfo.termId);
-  } catch (err) {
-    pendingTerminals.delete(ptyInfo.termId);
-    term.dispose();
-    container.remove();
-    throw err;
-  }
-
-  pendingTerminals.delete(ptyInfo.termId);
-
-  if (ptyInfo.exited) term.write("\r\n[Process exited]\r\n");
-
-  wireTerminalInput(term, ptyInfo.termId);
-  setupTerminalResize(entry);
-
-  return entry;
-}
-
-// On app start: reconnect to any PTYs that survived from previous instance
-async function reconnectAllPtys() {
-  const ptys = await window.api.ptyList();
-  debugLog("startup", `reconnecting ${ptys.length} PTYs`);
-  if (ptys.length === 0) return;
-
-  // Identify pool slot termIds so we can tag reconnected terminals
-  const pool = await window.api.poolRead();
-  const poolTermIds = new Set();
-  if (pool) {
-    for (const slot of pool.slots) {
-      poolTermIds.add(slot.termId);
-    }
-  }
-
-  // Group by sessionId
-  const bySession = new Map();
-  for (const p of ptys) {
-    p.isPoolTui = poolTermIds.has(p.termId);
-    const sid = p.sessionId || "__none__";
-    if (!bySession.has(sid)) bySession.set(sid, []);
-    bySession.get(sid).push(p);
-  }
-
-  // Reconnect each session's terminals (skip orphaned terminals with no session)
-  for (const [sid, sessionPtys] of bySession) {
-    if (sid === "__none__") {
-      debugLog("startup", `detaching ${sessionPtys.length} orphaned PTYs`);
-      for (const p of sessionPtys) {
-        window.api.ptyDetach(p.termId).catch(() => {});
-      }
-      continue;
-    }
-    const entries = [];
-    for (const p of sessionPtys) {
-      entries.push(await reconnectTerminal(p));
-    }
-    sessionTerminals.set(sid, {
-      terminals: entries,
-      lastAccessed: Date.now(),
+// Handle external file changes
+window.api.onIntentionChanged((content) => {
+  if (!state.editorView) return;
+  const current = state.editorView.state.doc.toString();
+  if (content !== current) {
+    state.editorView.dispatch({
+      changes: { from: 0, to: current.length, insert: content },
     });
+    if (state.saveStatus) state.saveStatus.textContent = "Updated from disk";
+    setTimeout(() => {
+      if (
+        state.saveStatus &&
+        state.saveStatus.textContent === "Updated from disk"
+      )
+        state.saveStatus.textContent = "";
+    }, 2000);
   }
-
-  // Restore the most recent alive session that has terminals
-  const sessions = await window.api.getSessions();
-  const lastActive = sessions.find(
-    (s) => s.alive && sessionTerminals.has(s.sessionId),
-  );
-  if (lastActive) {
-    currentSessionId = lastActive.sessionId;
-    currentSessionCwd = lastActive.cwd;
-
-    const cached = sessionTerminals.get(lastActive.sessionId);
-    terminals = cached.terminals;
-
-    emptyState.classList.add("hidden");
-    sessionView.classList.remove("hidden");
-
-    ensureEditorContainer();
-    editorProject.textContent = lastActive.project
-      ? `${lastActive.project} — ${displayPath(lastActive)}`
-      : lastActive.sessionId;
-
-    const content = await window.api.readIntention(lastActive.sessionId);
-    createEditor(content);
-    await window.api.watchIntention(lastActive.sessionId);
-
-    // Set up dock with restored terminals
-    initDockLayout(terminals);
-  }
-}
-
-refreshBtn.addEventListener("click", async () => {
-  await loadDirColors();
-  loadSessions();
 });
 
-// --- Slot Terminal Popup (interactive) ---
-async function openSlotTerminalPopup(slot) {
-  // Don't open popup for dead/unknown slots — no terminal to attach to
-  const status = slot.healthStatus || slot.status;
-  if (status === STATUS.DEAD || !slot.termId) {
-    showNotification("Cannot open terminal for dead slot");
-    return;
-  }
-
-  // Close existing popup if any (run its cleanup)
-  const existingPopup = document.getElementById("slot-terminal-popup");
-  if (existingPopup && existingPopup._cleanup) existingPopup._cleanup();
-  else if (existingPopup) existingPopup.remove();
-
-  const overlay = document.createElement("div");
-  overlay.id = "slot-terminal-popup";
-  overlay.className = "offload-menu-overlay";
-
-  const label =
-    slot.intentionHeading ||
-    slot.sessionId?.slice(0, 8) ||
-    `slot-${slot.index}`;
-
-  overlay.innerHTML = `
-    <div class="slot-terminal-dialog">
-      <div class="slot-terminal-header">
-        <span class="slot-terminal-title">${escapeHtml(label)}</span>
-        <button class="snapshot-close slot-terminal-close">\u2715</button>
-      </div>
-      <div class="slot-terminal-mount"></div>
-    </div>
-  `;
-
-  document.body.appendChild(overlay);
-
-  const mountEl = overlay.querySelector(".slot-terminal-mount");
-  const closeBtn = overlay.querySelector(".slot-terminal-close");
-
-  const term = createTerminal();
-
-  const fitAddon = new FitAddon();
-  term.loadAddon(fitAddon);
-  term.open(mountEl);
-
-  // Wire input to the PTY so the popup is interactive
-  wireTerminalInput(term, slot.termId);
-
-  // Register in popupTerminals so global data handlers can route data here.
-  // Data is forwarded to both the main terminal entry (if any) and the popup entry.
-  const popupEntry = { termId: slot.termId, term, fitAddon };
-  popupTerminals.set(slot.termId, popupEntry);
-
-  try {
-    await window.api.ptyAttach(slot.termId);
-  } catch (err) {
-    showNotification(`Failed to attach: ${err.message}`);
-    popupTerminals.delete(slot.termId);
-    term.dispose();
-    overlay.remove();
-    return;
-  }
-
-  // Fit after a frame so dimensions are correct
-  requestAnimationFrame(() => {
-    fitAddon.fit();
-    window.api.ptyResize(slot.termId, term.cols, term.rows);
-    term.focus();
-  });
-
-  const resizeObserver = new ResizeObserver(() => {
-    fitAddon.fit();
-    window.api.ptyResize(slot.termId, term.cols, term.rows);
-  });
-  resizeObserver.observe(mountEl);
-
-  // Cleanup function — also stored on overlay for programmatic close
-  const cleanup = () => {
-    resizeObserver.disconnect();
-    popupTerminals.delete(slot.termId);
-    // Only detach if there's no other terminal entry still using this termId
-    // (i.e. the session might be open in the main view)
-    const otherEntry = findTerminalEntry(slot.termId);
-    if (otherEntry) {
-      // Restore PTY size to the main tab's dimensions
-      window.api.ptyResize(
-        slot.termId,
-        otherEntry.term.cols,
-        otherEntry.term.rows,
-      );
-    } else {
-      window.api.ptyDetach(slot.termId).catch(() => {});
-    }
-    term.dispose();
-    overlay.remove();
-  };
-  overlay._cleanup = cleanup;
-
-  closeBtn.addEventListener("click", cleanup);
-  overlay.addEventListener("click", (e) => {
-    if (e.target === overlay) cleanup();
-  });
-}
-
-// --- Pool Health Badge ---
-const poolSettingsBtn = document.getElementById("pool-settings-btn");
-let poolSettingsInterval = null;
-
-// Show a warning dot on the ⚙ button when pool has error slots
-async function updatePoolHealthBadge() {
-  const pool = await window.api.poolRead();
-  const errors = pool
-    ? pool.slots.filter((s) => s.status === POOL_STATUS.ERROR).length
-    : 0;
-  poolSettingsBtn.dataset.errors = errors;
-  poolSettingsBtn.title =
-    errors > 0
-      ? `Pool settings — ${errors} slot${errors > 1 ? "s" : ""} in error`
-      : "Pool settings";
-}
-
-poolSettingsBtn.addEventListener("click", () => showPoolSettings());
-
-function stopPoolSettingsPolling() {
-  if (poolSettingsInterval) {
-    clearInterval(poolSettingsInterval);
-    poolSettingsInterval = null;
-  }
-}
-
-function poolStatusDot(status) {
-  const cls = STATUS_CLASSES[status] || "dead";
-  return `<span class="session-status ${cls}" style="display:inline-block;vertical-align:middle;margin-right:6px;"></span>`;
-}
-
-function renderPoolSlotsHtml(health) {
-  if (!health.initialized) return "";
-  return health.slots
-    .map((slot) => {
-      const status = slot.healthStatus || slot.status;
-      const label =
-        slot.intentionHeading ||
-        slot.sessionId?.slice(0, 8) ||
-        `slot-${slot.index}`;
-      const pinned =
-        slot.pinnedUntil && new Date(slot.pinnedUntil) > new Date();
-      const pinBadge = pinned
-        ? '<span class="pool-slot-pin" title="Pinned">📌</span>'
-        : "";
-      return `<div class="pool-slot-row pool-slot-clickable" data-slot-index="${slot.index}">
-        ${poolStatusDot(status)}
-        <span class="pool-slot-label">${escapeHtml(label)}</span>
-        ${pinBadge}
-        <span class="pool-slot-status">${status}</span>
-      </div>`;
-    })
-    .join("");
-}
-
-function renderPoolCountsHtml(health) {
-  if (!health.initialized) return "Pool not initialized";
-  return Object.entries(health.counts)
-    .map(([k, v]) => `${poolStatusDot(k)} ${k}: ${v}`)
-    .join("&nbsp;&nbsp;&nbsp;");
-}
-
-function closePoolSettings(overlay) {
-  stopPoolSettingsPolling();
-  if (overlay._keyHandler) {
-    document.removeEventListener("keydown", overlay._keyHandler, true);
-  }
-  overlay.remove();
-}
-
-async function showPoolSettings() {
-  stopPoolSettingsPolling();
-  const existing = document.getElementById("pool-settings");
-  if (existing) closePoolSettings(existing);
-
-  const health = await window.api.poolHealth();
-
-  const overlay = document.createElement("div");
-  overlay.id = "pool-settings";
-  overlay.className = "offload-menu-overlay";
-
-  const slotsHtml = renderPoolSlotsHtml(health);
-  const countsHtml = renderPoolCountsHtml(health);
-
-  overlay.innerHTML = `
-    <div class="pool-settings-dialog">
-      <div class="pool-settings-header">
-        <span>Pool Settings</span>
-        <button class="snapshot-close pool-close">\u2715</button>
-      </div>
-      <div class="pool-settings-body">
-        <div class="pool-health-summary">${countsHtml}</div>
-        ${
-          health.initialized
-            ? `
-          <div class="pool-slots-list">${slotsHtml}</div>
-          <div class="pool-controls">
-            <label class="pool-size-label">
-              Pool size:
-              <input type="number" class="pool-size-input" value="${health.poolSize}" min="1" max="20">
-            </label>
-            <button class="offload-menu-btn pool-resize-btn">Resize</button>
-            <button class="offload-menu-btn pool-reload-btn">Reload Sessions</button>
-            <button class="offload-menu-btn pool-clean-btn">Clean Idle</button>
-            <button class="offload-menu-btn pool-destroy-btn">Destroy</button>
-            <button class="offload-menu-btn pool-reinit-btn">Reinitialize</button>
-          </div>
-        `
-            : `
-          <div class="pool-controls">
-            <label class="pool-size-label">
-              Pool size:
-              <input type="number" class="pool-size-input" value="10" min="1" max="20">
-            </label>
-            <button class="offload-menu-btn offload-menu-load pool-init-btn">Initialize Pool</button>
-          </div>
-        `
-        }
-      </div>
-    </div>
-  `;
-
-  document.body.appendChild(overlay);
-
-  // --- Keyboard navigation state ---
-  // "top" = navigating between pool-slots-block and buttons
-  // "slots" = navigating individual pool slots
-  let navLevel = "top";
-  let topIndex = 0;
-  let slotIndex = 0;
-
-  // Returns the list of top-level navigable items (pool-slots-list + buttons)
-  function getTopItems() {
-    const items = [];
-    const slotsList = overlay.querySelector(".pool-slots-list");
-    if (slotsList) items.push(slotsList);
-    for (const btn of overlay.querySelectorAll(
-      ".pool-controls .offload-menu-btn",
-    ))
-      items.push(btn);
-    return items;
-  }
-
-  function getSlotRows() {
-    return Array.from(
-      overlay.querySelectorAll(".pool-slots-list .pool-slot-row"),
-    );
-  }
-
-  function clearAllSelection() {
-    for (const el of overlay.querySelectorAll(".kb-selected"))
-      el.classList.remove("kb-selected");
-  }
-
-  function applySelection() {
-    clearAllSelection();
-    if (navLevel === "top") {
-      const items = getTopItems();
-      if (items[topIndex]) items[topIndex].classList.add("kb-selected");
-    } else {
-      const rows = getSlotRows();
-      // Clamp index after poll refresh may have removed slots
-      if (rows.length > 0) slotIndex = Math.min(slotIndex, rows.length - 1);
-      if (rows[slotIndex]) {
-        rows[slotIndex].classList.add("kb-selected");
-        rows[slotIndex].scrollIntoView({ block: "nearest" });
-      }
-    }
-  }
-
-  // Apply initial selection
-  applySelection();
-
-  overlay._keyHandler = (e) => {
-    // Skip if a terminal popup is open on top
-    if (document.getElementById("slot-terminal-popup")) return;
-    // Skip if an input is focused (e.g. pool size number input)
-    if (overlay.querySelector("input:focus")) return;
-
-    const { key } = e;
-
-    if (key === "Escape") {
-      e.preventDefault();
-      e.stopPropagation();
-      if (navLevel === "slots") {
-        navLevel = "top";
-        applySelection();
-      } else {
-        closePoolSettings(overlay);
-      }
-      return;
-    }
-
-    if (key === "ArrowDown" || key === "ArrowUp") {
-      e.preventDefault();
-      e.stopPropagation();
-      const delta = key === "ArrowDown" ? 1 : -1;
-      if (navLevel === "top") {
-        const items = getTopItems();
-        if (items.length === 0) return;
-        topIndex = Math.max(0, Math.min(items.length - 1, topIndex + delta));
-        applySelection();
-      } else {
-        const rows = getSlotRows();
-        if (rows.length === 0) return;
-        slotIndex = Math.max(0, Math.min(rows.length - 1, slotIndex + delta));
-        applySelection();
-      }
-      return;
-    }
-
-    if (key === "Enter") {
-      e.preventDefault();
-      e.stopPropagation();
-      if (navLevel === "top") {
-        const items = getTopItems();
-        const item = items[topIndex];
-        if (!item) return;
-        if (item.classList.contains("pool-slots-list")) {
-          // Enter the slots block
-          navLevel = "slots";
-          slotIndex = 0;
-          applySelection();
-        } else {
-          // It's a button — click it
-          item.click();
-        }
-      } else {
-        // Inside slots — open terminal popup for selected slot
-        const rows = getSlotRows();
-        const row = rows[slotIndex];
-        if (row) row.click();
-      }
-      return;
-    }
-  };
-  document.addEventListener("keydown", overlay._keyHandler, true);
-
-  overlay.addEventListener("click", (e) => {
-    if (e.target === overlay) closePoolSettings(overlay);
-  });
-  overlay
-    .querySelector(".pool-close")
-    .addEventListener("click", () => closePoolSettings(overlay));
-
-  // Poll for health updates while dialog is open
-  poolSettingsInterval = setInterval(async () => {
-    // Stop polling if dialog was removed externally
-    if (!document.getElementById("pool-settings")) {
-      stopPoolSettingsPolling();
-      return;
-    }
-    try {
-      const h = await window.api.poolHealth();
-      const summaryEl = overlay.querySelector(".pool-health-summary");
-      if (summaryEl) summaryEl.innerHTML = renderPoolCountsHtml(h);
-      const slotsEl = overlay.querySelector(".pool-slots-list");
-      if (slotsEl) {
-        slotsEl.innerHTML = renderPoolSlotsHtml(h);
-        // Re-apply selection after poll refresh (innerHTML wipes classes)
-        applySelection();
-      }
-    } catch {
-      // Ignore transient errors — next poll will retry
-    }
-  }, 3000);
-
-  // Slot row click → open terminal popup (delegated to survive innerHTML poll updates)
-  const slotsListEl = overlay.querySelector(".pool-slots-list");
-  if (slotsListEl) {
-    slotsListEl.addEventListener("click", async (e) => {
-      const row = e.target.closest(".pool-slot-clickable");
-      if (!row) return;
-      const clickedSlotIndex = parseInt(row.dataset.slotIndex, 10);
-      const currentHealth = await window.api.poolHealth();
-      const slot = currentHealth.slots.find(
-        (s) => s.index === clickedSlotIndex,
-      );
-      if (slot) openSlotTerminalPopup(slot);
-    });
-  }
-
-  // Init button
-  const initBtn = overlay.querySelector(".pool-init-btn");
-  if (initBtn) {
-    initBtn.addEventListener("click", async () => {
-      const size = parseInt(
-        overlay.querySelector(".pool-size-input").value,
-        10,
-      );
-      if (isNaN(size) || size < 1 || size > 20) {
-        showNotification("Pool size must be between 1 and 20");
-        return;
-      }
-      initBtn.textContent = "Initializing...";
-      initBtn.disabled = true;
-      try {
-        await window.api.poolInit(size);
-        showNotification(`Pool initialized (${size} slots)`);
-        await loadSessions();
-        showPoolSettings();
-      } catch (err) {
-        initBtn.textContent = "Initialize Pool";
-        initBtn.disabled = false;
-        showNotification(`Error: ${err.message}`);
-      }
-    });
-  }
-
-  // Resize button
-  const resizeBtn = overlay.querySelector(".pool-resize-btn");
-  if (resizeBtn) {
-    resizeBtn.addEventListener("click", async () => {
-      const newSize = parseInt(
-        overlay.querySelector(".pool-size-input").value,
-        10,
-      );
-      if (isNaN(newSize) || newSize < 1 || newSize > 20) {
-        showNotification("Pool size must be between 1 and 20");
-        return;
-      }
-      resizeBtn.textContent = "Resizing...";
-      resizeBtn.disabled = true;
-      try {
-        await window.api.poolResize(newSize);
-        showNotification(`Pool resized to ${newSize} slots`);
-        await loadSessions();
-        showPoolSettings();
-      } catch (err) {
-        resizeBtn.textContent = "Resize";
-        resizeBtn.disabled = false;
-        showNotification(`Error: ${err.message}`);
-      }
-    });
-  }
-
-  // Reload button
-  const reloadBtn = overlay.querySelector(".pool-reload-btn");
-  if (reloadBtn) {
-    reloadBtn.addEventListener("click", async () => {
-      closePoolSettings(overlay);
-      await loadDirColors();
-      await loadSessions();
-      showNotification("Sessions reloaded");
-    });
-  }
-
-  // Clean idle button
-  const cleanBtn = overlay.querySelector(".pool-clean-btn");
-  if (cleanBtn) {
-    cleanBtn.addEventListener("click", async () => {
-      cleanBtn.textContent = "Cleaning...";
-      cleanBtn.disabled = true;
-      try {
-        const cleaned = await window.api.poolClean();
-        showNotification(
-          `Cleaned ${cleaned} idle session${cleaned !== 1 ? "s" : ""}`,
-        );
-        await loadSessions();
-        showPoolSettings();
-      } catch (err) {
-        cleanBtn.textContent = "Clean Idle";
-        cleanBtn.disabled = false;
-        showNotification(`Error: ${err.message}`);
-      }
-    });
-  }
-
-  // Destroy button
-  const destroyBtn = overlay.querySelector(".pool-destroy-btn");
-  if (destroyBtn) {
-    destroyBtn.addEventListener("click", async () => {
-      destroyBtn.textContent = "Destroying...";
-      destroyBtn.disabled = true;
-      try {
-        await window.api.poolDestroy();
-        showNotification("Pool destroyed");
-        await loadSessions();
-        showPoolSettings();
-      } catch (err) {
-        destroyBtn.textContent = "Destroy";
-        destroyBtn.disabled = false;
-        showNotification(`Error: ${err.message}`);
-      }
-    });
-  }
-
-  // Reinitialize button (destroy + init)
-  const reinitBtn = overlay.querySelector(".pool-reinit-btn");
-  if (reinitBtn) {
-    reinitBtn.addEventListener("click", async () => {
-      const size = parseInt(
-        overlay.querySelector(".pool-size-input").value,
-        10,
-      );
-      if (isNaN(size) || size < 1 || size > 20) {
-        showNotification("Pool size must be between 1 and 20");
-        return;
-      }
-      reinitBtn.textContent = "Reinitializing...";
-      reinitBtn.disabled = true;
-      try {
-        await window.api.poolDestroy();
-      } catch (err) {
-        reinitBtn.textContent = "Reinitialize";
-        reinitBtn.disabled = false;
-        showNotification(`Destroy failed: ${err.message}`);
-        return;
-      }
-      try {
-        await window.api.poolInit(size);
-        showNotification(`Pool reinitialized (${size} slots)`);
-      } catch (err) {
-        showNotification(`Pool destroyed but re-init failed: ${err.message}`);
-      }
-      await loadSessions();
-      showPoolSettings();
-    });
-  }
-}
-
-// Add pool settings to command palette
-COMMANDS.push({
-  id: "pool-settings",
-  label: "Pool Settings",
-  shortcutAction: "open-pool-settings",
-  action: () => showPoolSettings(),
-});
-
-// --- Shortcut Settings UI ---
-// Build labels from COMMANDS entries (avoids duplicating labels)
-const SHORTCUT_LABELS = {};
-for (const cmd of COMMANDS) {
-  if (cmd.shortcutAction) SHORTCUT_LABELS[cmd.shortcutAction] = cmd.label;
-}
-// Actions only reachable via input events (no COMMANDS entry)
-SHORTCUT_LABELS["next-terminal-tab-alt"] = "Next Tab (Alt)";
-SHORTCUT_LABELS["prev-terminal-tab-alt"] = "Previous Tab (Alt)";
-
-async function showShortcutSettings() {
-  const existing = document.getElementById("shortcut-settings");
-  if (existing) existing.remove();
-
-  const shortcuts = await window.api.getShortcuts();
-  shortcutConfig = shortcuts;
-
-  // Track active keydown listener for cleanup
-  let activeKeyHandler = null;
-
-  function cleanupRecording() {
-    if (activeKeyHandler) {
-      document.removeEventListener("keydown", activeKeyHandler, true);
-      activeKeyHandler = null;
-    }
-  }
-
-  const overlay = document.createElement("div");
-  overlay.id = "shortcut-settings";
-  overlay.className = "offload-menu-overlay";
-
-  const actionIds = Object.keys(SHORTCUT_LABELS);
-  const rows = actionIds
-    .map((id) => {
-      const label = SHORTCUT_LABELS[id];
-      const current = shortcuts[id] || "";
-      const display = formatShortcutDisplay(current) || "—";
-      return `<div class="shortcut-row" data-action="${id}">
-        <span class="shortcut-label">${label}</span>
-        <button class="shortcut-key-btn" title="Click to rebind">${display}</button>
-        <button class="shortcut-reset-btn" title="Reset to default">↺</button>
-      </div>`;
-    })
-    .join("");
-
-  overlay.innerHTML = `
-    <div class="shortcut-settings-dialog">
-      <div class="pool-settings-header">
-        <span>Keyboard Shortcuts</span>
-        <button class="close-dialog-btn">✕</button>
-      </div>
-      <div class="shortcut-settings-body">
-        ${rows}
-      </div>
-    </div>
-  `;
-
-  document.body.appendChild(overlay);
-
-  function closeDialog() {
-    cleanupRecording();
-    document.removeEventListener("keydown", escHandler, true);
-    overlay.remove();
-  }
-
-  // Close on Escape (only when not recording a shortcut)
-  function escHandler(e) {
-    if (e.key === "Escape" && !activeKeyHandler) {
-      e.preventDefault();
-      e.stopPropagation();
-      closeDialog();
-    }
-  }
-  document.addEventListener("keydown", escHandler, true);
-
-  // Close on overlay click or close button
-  overlay.addEventListener("click", (e) => {
-    if (e.target === overlay) closeDialog();
-  });
-  overlay
-    .querySelector(".close-dialog-btn")
-    .addEventListener("click", closeDialog);
-
-  // Rebind: click key button → enter recording mode
-  overlay.querySelectorAll(".shortcut-key-btn").forEach((btn) => {
-    btn.addEventListener("click", () => {
-      // Cancel any existing recording
-      cleanupRecording();
-      const existingBtn = overlay.querySelector(".shortcut-key-btn.recording");
-      if (existingBtn && existingBtn !== btn) {
-        existingBtn.classList.remove("recording");
-        const oldAction = existingBtn.closest(".shortcut-row").dataset.action;
-        existingBtn.textContent =
-          formatShortcutDisplay(shortcuts[oldAction]) || "\u2014";
-      }
-
-      btn.classList.add("recording");
-      btn.textContent = "Press keys...";
-
-      function onKeyDown(e) {
-        e.preventDefault();
-        e.stopPropagation();
-
-        // Ignore lone modifier keys
-        if (["Meta", "Control", "Shift", "Alt"].includes(e.key)) return;
-
-        // Escape cancels recording
-        if (e.key === "Escape") {
-          btn.classList.remove("recording");
-          const actionId = btn.closest(".shortcut-row").dataset.action;
-          btn.textContent =
-            formatShortcutDisplay(shortcuts[actionId]) || "\u2014";
-          cleanupRecording();
-          return;
-        }
-
-        // Build Electron accelerator from the event
-        const parts = [];
-        if (e.metaKey) parts.push("CmdOrCtrl");
-        if (e.ctrlKey && !e.metaKey) parts.push("Ctrl");
-        if (e.shiftKey) parts.push("Shift");
-        if (e.altKey) parts.push("Alt");
-
-        const keyMap = {
-          ArrowUp: "Up",
-          ArrowDown: "Down",
-          ArrowLeft: "Left",
-          ArrowRight: "Right",
-          " ": "Space",
-          Backspace: "Backspace",
-          Delete: "Delete",
-          Enter: "Return",
-          Tab: "Tab",
-        };
-        const key = keyMap[e.key] || e.key.toUpperCase();
-        parts.push(key);
-
-        const accelerator = parts.join("+");
-        const actionId = btn.closest(".shortcut-row").dataset.action;
-
-        btn.classList.remove("recording");
-        btn.textContent = formatShortcutDisplay(accelerator);
-        shortcuts[actionId] = accelerator;
-        shortcutConfig = { ...shortcuts };
-
-        window.api.setShortcut(actionId, accelerator);
-        cleanupRecording();
-      }
-
-      activeKeyHandler = onKeyDown;
-      document.addEventListener("keydown", onKeyDown, true);
-    });
-  });
-
-  // Reset buttons
-  overlay.querySelectorAll(".shortcut-reset-btn").forEach((btn) => {
-    btn.addEventListener("click", async () => {
-      const row = btn.closest(".shortcut-row");
-      const actionId = row.dataset.action;
-      await window.api.resetShortcut(actionId);
-      const defaultVal = await window.api.getDefaultShortcut(actionId);
-      shortcuts[actionId] = defaultVal;
-      shortcutConfig = { ...shortcuts };
-      const keyBtn = row.querySelector(".shortcut-key-btn");
-      keyBtn.textContent = formatShortcutDisplay(defaultVal) || "—";
-    });
-  });
-
-  // Unbind: button to clear a shortcut
-  overlay.querySelectorAll(".shortcut-key-btn").forEach((btn) => {
-    btn.addEventListener("contextmenu", async (e) => {
-      e.preventDefault();
-      const row = btn.closest(".shortcut-row");
-      const actionId = row.dataset.action;
-      await window.api.setShortcut(actionId, "");
-      shortcuts[actionId] = "";
-      shortcutConfig = { ...shortcuts };
-      btn.textContent = "—";
-    });
-  });
-}
-
-// Add shortcut settings to command palette
-COMMANDS.push({
-  id: "shortcut-settings",
-  label: "Keyboard Shortcuts",
-  action: () => showShortcutSettings(),
-});
+// --- Startup ---
 
 loadDirColors().then(async () => {
   // Load shortcut config for command palette display
   try {
-    shortcutConfig = await window.api.getShortcuts();
+    const shortcuts = await window.api.getShortcuts();
+    setShortcutConfig(shortcuts);
   } catch {}
 
   await reconnectAllPtys();

--- a/src/session-sidebar.js
+++ b/src/session-sidebar.js
@@ -1,0 +1,516 @@
+// Session sidebar: directory colors, session list, context menu, snapshot viewer
+import {
+  state,
+  dom,
+  debugLog,
+  STATUS_CLASSES,
+  escapeHtml,
+} from "./renderer-state.js";
+import { STATUS } from "./session-statuses.js";
+import {
+  createDefaultLayout,
+  TAB_EDITOR,
+  TAB_SNAPSHOT,
+  registerEditorTab,
+} from "./dock-helpers.js";
+
+// --- Callbacks into renderer.js (set via initSidebar) ---
+let _actions = {};
+export function initSidebar(actions) {
+  _actions = actions;
+}
+
+// --- Directory color coding ---
+// Neon-friendly palette for directory indicators
+const DIR_COLORS = [
+  "#ff1a1a", // neon red
+  "#00ff41", // neon green
+  "#ff6600", // neon orange
+  "#00ccff", // neon cyan
+  "#ff00ff", // neon magenta
+  "#ffff00", // neon yellow
+  "#7b68ee", // neon purple
+  "#ff69b4", // neon pink
+  "#00ff88", // neon mint
+  "#ff4500", // neon vermillion
+];
+
+// User-configured colors from ~/.open-cockpit/colors.json
+// Format: { "~/Documents/Projects/foo": "#ff00ff" }
+// null value = no color (transparent)
+let userDirColors = {};
+
+async function loadDirColors() {
+  userDirColors = await window.api.getDirColors();
+}
+
+function hashString(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+// Get the path used for color hashing.
+// - Worktrees (.claude/worktrees/xxx) → parent project dir
+// - Inside a git repo → git root
+// - Otherwise → exact cwd (each folder gets its own color)
+function getColorKey(session) {
+  const { cwd, gitRoot, home } = session;
+  if (!cwd) return "";
+  // Strip worktree suffix (.claude/worktrees/xxx or .wt/xxx)
+  const wtMatch = cwd.match(/^(.+?)\/(?:\.claude\/worktrees|\.wt)\/.+$/);
+  const resolved = wtMatch ? wtMatch[1] : cwd;
+  // If inside a git repo, use the git root
+  if (gitRoot) {
+    // Also handle worktree: if the worktree-stripped path has a git root,
+    // use the worktree-stripped path (it IS the git root)
+    if (wtMatch) return wtMatch[1];
+    return gitRoot;
+  }
+  return resolved;
+}
+
+function getDirColor(session) {
+  const { cwd, home } = session;
+  if (!cwd) return null;
+  // Home directory exactly → no color
+  if (cwd === home) return null;
+
+  const colorKey = getColorKey(session);
+
+  // Check user config — match longest prefix first
+  const configKeys = Object.keys(userDirColors).sort(
+    (a, b) => b.length - a.length,
+  );
+  for (const key of configKeys) {
+    const expandedKey = home ? key.replace(/^~/, home) : key;
+    if (colorKey === expandedKey || colorKey.startsWith(expandedKey + "/")) {
+      return userDirColors[key]; // null = no color, string = exact color
+    }
+  }
+
+  return DIR_COLORS[hashString(colorKey) % DIR_COLORS.length];
+}
+
+// Build a fingerprint for a session to detect changes
+function sessionFingerprint(s) {
+  return `${s.sessionId}|${s.status}|${s.staleIdle ? "stale" : ""}|${s.intentionHeading || ""}|${s.intentionPreview || ""}|${s.cwd || ""}|${s.origin || ""}`;
+}
+
+// Track previous session fingerprints for diff-based update
+let prevSessionFingerprints = null;
+
+// Play a short bell tone via Web Audio API
+let bellCtx = null;
+function playBell() {
+  try {
+    if (!bellCtx) bellCtx = new AudioContext();
+    if (bellCtx.state === "suspended") bellCtx.resume();
+    const osc = bellCtx.createOscillator();
+    const gain = bellCtx.createGain();
+    osc.connect(gain);
+    gain.connect(bellCtx.destination);
+    osc.type = "sine";
+    osc.frequency.value = 880;
+    gain.gain.setValueAtTime(0.3, bellCtx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.001, bellCtx.currentTime + 0.3);
+    osc.start(bellCtx.currentTime);
+    osc.stop(bellCtx.currentTime + 0.3);
+  } catch (_) {
+    // Audio not available — ignore
+  }
+}
+
+// --- Session list ---
+let archiveExpanded = false;
+
+async function loadSessions() {
+  const sessions = await window.api.getSessions();
+  const oldStatuses = new Map(
+    state.cachedSessions.map((s) => [s.sessionId, s.status]),
+  );
+  state.cachedSessions = sessions;
+
+  // Keep CWD in sync (may change as JSONL records cd commands)
+  if (state.currentSessionId) {
+    const current = sessions.find(
+      (s) => s.sessionId === state.currentSessionId,
+    );
+    if (current?.cwd) state.currentSessionCwd = current.cwd;
+  }
+
+  _actions.cleanupStaleTerminals(sessions);
+  _actions.updatePoolHealthBadge();
+
+  // Split into sections — pool and external mixed together
+  const typing = sessions.filter((s) => s.status === STATUS.TYPING);
+  const recent = sessions.filter(
+    (s) => s.status === STATUS.IDLE || s.status === STATUS.OFFLOADED,
+  );
+  const processing = sessions.filter((s) => s.status === STATUS.PROCESSING);
+  const archived = sessions.filter((s) => s.status === STATUS.ARCHIVED);
+
+  // Build fingerprint to check if anything changed
+  const allItems = [...typing, ...recent, ...processing, ...archived];
+  const fingerprints = allItems.map(sessionFingerprint).join("\n");
+  if (fingerprints === prevSessionFingerprints) {
+    // Only update active class (selected session may have changed)
+    for (const li of dom.sessionList.querySelectorAll(".session-item")) {
+      li.classList.toggle(
+        "active",
+        li.dataset.sessionId === state.currentSessionId,
+      );
+    }
+    return;
+  }
+  prevSessionFingerprints = fingerprints;
+
+  // Bell when a session transitions to idle (finished processing)
+  if (oldStatuses.size > 0) {
+    for (const s of sessions) {
+      if (
+        s.status === STATUS_CLASSES.idle &&
+        oldStatuses.has(s.sessionId) &&
+        oldStatuses.get(s.sessionId) !== STATUS_CLASSES.idle
+      ) {
+        playBell();
+        break;
+      }
+    }
+  }
+
+  // Full rebuild only when sessions actually changed
+  dom.sessionList.innerHTML = "";
+
+  if (
+    typing.length === 0 &&
+    recent.length === 0 &&
+    processing.length === 0 &&
+    archived.length === 0
+  ) {
+    dom.sessionList.innerHTML =
+      '<li style="padding: 12px; color: var(--text-dim); font-size: 13px;">No sessions found</li>';
+    return;
+  }
+
+  function addSection(label, items) {
+    if (items.length === 0) return;
+    const header = document.createElement("li");
+    header.className = "session-section-header";
+    header.textContent = `${label} (${items.length})`;
+    dom.sessionList.appendChild(header);
+    for (const s of items) {
+      dom.sessionList.appendChild(createSessionItem(s));
+    }
+  }
+
+  addSection("Typing", typing);
+  addSection("Recent", recent);
+  addSection("Processing", processing);
+
+  // Archive section: collapsible, shows first 5 by default
+  if (archived.length > 0) {
+    const ARCHIVE_VISIBLE = 5;
+    const header = document.createElement("li");
+    header.className = "session-section-header session-section-collapsible";
+    const collapsed = archived.length > ARCHIVE_VISIBLE && !archiveExpanded;
+    header.innerHTML = `<span class="section-toggle">${archiveExpanded ? "▾" : "▸"}</span> Archive (${archived.length})`;
+    if (archived.length > ARCHIVE_VISIBLE) {
+      header.addEventListener("click", () => {
+        archiveExpanded = !archiveExpanded;
+        loadSessions();
+      });
+    }
+    dom.sessionList.appendChild(header);
+    const visible = collapsed ? archived.slice(0, ARCHIVE_VISIBLE) : archived;
+    for (const s of visible) {
+      dom.sessionList.appendChild(createSessionItem(s));
+    }
+    if (collapsed) {
+      const more = document.createElement("li");
+      more.className = "session-section-more";
+      more.textContent = `+${archived.length - ARCHIVE_VISIBLE} more`;
+      more.addEventListener("click", () => {
+        archiveExpanded = true;
+        loadSessions();
+      });
+      dom.sessionList.appendChild(more);
+    }
+  }
+}
+
+function createSessionItem(s) {
+  const li = document.createElement("li");
+  li.className = `session-item${s.sessionId === state.currentSessionId ? " active" : ""}${s.status === STATUS.OFFLOADED || s.status === STATUS.ARCHIVED ? " offloaded" : ""}`;
+  li.dataset.sessionId = s.sessionId;
+  const heading = s.intentionHeading || s.intentionPreview || null;
+  const isPreview = !s.intentionHeading && !!s.intentionPreview;
+  const dp = displayPath(s);
+  const dirColor = getDirColor(s);
+  const indicatorStyle = dirColor
+    ? `background: ${dirColor}; box-shadow: 0 0 4px ${dirColor}`
+    : "background: transparent";
+  const showOrigin =
+    s.origin && s.status !== STATUS.OFFLOADED && s.status !== STATUS.ARCHIVED;
+  const originTag = showOrigin
+    ? `<span class="session-origin-tag session-origin-${escapeHtml(s.origin)}">${escapeHtml(s.origin)}</span>`
+    : "";
+  const staleTag = s.staleIdle
+    ? `<span class="session-origin-tag session-origin-stale">stale</span>`
+    : "";
+  const pinned = s.pinnedUntil && new Date(s.pinnedUntil) > new Date();
+  const pinnedTag = pinned
+    ? '<span class="session-origin-tag session-origin-pinned" title="Pinned — won\'t be offloaded">📌</span>'
+    : "";
+  li.innerHTML = `
+    <div class="session-dir-indicator" style="${indicatorStyle}"></div>
+    <div class="session-item-content">
+      <div class="session-project">
+        <span class="session-status ${STATUS_CLASSES[s.status] || "dead"}"></span>
+        <span class="session-title${isPreview ? " session-preview" : ""}">${escapeHtml(heading || "No intention yet")}</span>
+        ${originTag}${staleTag}${pinnedTag}
+      </div>
+      <div class="session-cwd">${escapeHtml(dp)}</div>
+    </div>
+  `;
+  li.addEventListener("click", () => _actions.selectSession(s));
+  li.addEventListener("contextmenu", (e) => {
+    e.preventDefault();
+    showSessionContextMenu(e, s);
+  });
+  return li;
+}
+
+// Right-click context menu for sessions
+function showSessionContextMenu(e, session) {
+  const existing = document.getElementById("session-context-menu");
+  if (existing) existing.remove();
+
+  const menu = document.createElement("div");
+  menu.id = "session-context-menu";
+  menu.className = "session-context-menu";
+  menu.style.left = `${e.clientX}px`;
+  menu.style.top = `${e.clientY}px`;
+
+  const isArchived = session.status === STATUS.ARCHIVED;
+  const isOffloaded = session.status === STATUS.OFFLOADED;
+
+  if (isArchived) {
+    menu.innerHTML = `
+      <div class="session-context-item" data-action="restart">Restart</div>
+      <div class="session-context-item" data-action="unarchive">Move to Recent</div>
+    `;
+  } else if (isOffloaded) {
+    menu.innerHTML = `
+      <div class="session-context-item" data-action="resume">Resume</div>
+      <div class="session-context-item" data-action="archive">Archive</div>
+    `;
+  } else {
+    menu.innerHTML = `
+      <div class="session-context-item" data-action="archive">Archive</div>
+    `;
+  }
+
+  document.body.appendChild(menu);
+
+  const close = () => menu.remove();
+  setTimeout(() => document.addEventListener("click", close, { once: true }));
+
+  menu.addEventListener("click", async (ev) => {
+    const action = ev.target.dataset.action;
+    menu.remove();
+    if (action === "archive") {
+      try {
+        await window.api.archiveSession(session.sessionId);
+      } catch (err) {
+        console.error("Failed to archive session:", err);
+      }
+      await loadSessions();
+    } else if (action === "unarchive") {
+      try {
+        await window.api.unarchiveSession(session.sessionId);
+      } catch (err) {
+        console.error("Failed to unarchive session:", err);
+      }
+      await loadSessions();
+    } else if (action === "restart") {
+      try {
+        await window.api.unarchiveSession(session.sessionId);
+      } catch (err) {
+        console.error("Failed to unarchive session for restart:", err);
+      }
+      await _actions.resumeOffloadedSession(session);
+    } else if (action === "resume") {
+      await _actions.resumeOffloadedSession(session);
+    }
+  });
+}
+
+// Show read-only snapshot viewer
+function showSnapshotViewer(session, snapshotText) {
+  const existing = document.getElementById("snapshot-viewer");
+  if (existing) existing.remove();
+
+  const viewer = document.createElement("div");
+  viewer.id = "snapshot-viewer";
+  viewer.className = "offload-menu-overlay";
+  viewer.innerHTML = `
+    <div class="snapshot-dialog">
+      <div class="snapshot-header">
+        <span>${escapeHtml(session.intentionHeading || "Snapshot")}</span>
+        <button class="snapshot-close">\u2715</button>
+      </div>
+      <pre class="snapshot-content">${snapshotText ? escapeHtml(snapshotText) : "(no snapshot available)"}</pre>
+    </div>
+  `;
+
+  document.body.appendChild(viewer);
+
+  function closeViewer() {
+    document.removeEventListener("keydown", escHandler, true);
+    viewer.remove();
+  }
+  function escHandler(e) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      closeViewer();
+    }
+  }
+  document.addEventListener("keydown", escHandler, true);
+
+  viewer.addEventListener("click", (e) => {
+    if (e.target === viewer) closeViewer();
+  });
+  viewer
+    .querySelector(".snapshot-close")
+    .addEventListener("click", closeViewer);
+}
+
+// Show snapshot content inline as a dock tab for offloaded/archived sessions
+async function showInlineSnapshot(session, gen) {
+  const isArchived = session.status === STATUS.ARCHIVED;
+  const btnLabel = isArchived ? "Restart" : "Resume";
+
+  let snapshotText = null;
+  if (session.hasSnapshot) {
+    try {
+      snapshotText = await window.api.readOffloadSnapshot(session.sessionId);
+    } catch (err) {
+      debugLog("snapshot", `failed to read snapshot: ${err.message}`);
+    }
+    if (gen !== state.sessionGeneration) return;
+  }
+
+  // Create snapshot content element
+  const container = document.createElement("div");
+  container.className = "dock-snapshot-content";
+  container.innerHTML = `
+    <div class="inline-snapshot-header">
+      <span class="inline-snapshot-label">${isArchived ? "Archived" : "Offloaded"} Session</span>
+      <button class="inline-snapshot-restart">${btnLabel}</button>
+    </div>
+    <pre class="snapshot-content inline-snapshot-content">${snapshotText ? escapeHtml(snapshotText) : "(no snapshot available)"}</pre>
+  `;
+
+  container
+    .querySelector(".inline-snapshot-restart")
+    .addEventListener("click", async () => {
+      if (isArchived) {
+        try {
+          await window.api.unarchiveSession(session.sessionId);
+        } catch (err) {
+          debugLog("snapshot", `unarchive failed: ${err.message}`);
+        }
+      }
+      await _actions.resumeOffloadedSession(session);
+    });
+
+  // Register snapshot as a dock tab
+  _actions.ensureEditorContainer();
+  _actions.ensureDock();
+  state.dock.registerTab(TAB_SNAPSHOT, {
+    type: TAB_SNAPSHOT,
+    label: isArchived ? "Archived" : "Snapshot",
+    closable: false,
+    contentEl: container,
+  });
+  registerEditorTab(state.dock, state.editorContainer);
+  state.dock.setLayout(createDefaultLayout([TAB_SNAPSHOT], [TAB_EDITOR]));
+}
+
+// Clean up inline snapshot when switching away from an offloaded/archived session
+function removeInlineSnapshot() {
+  if (state.dock) {
+    state.dock.unregisterTab(TAB_SNAPSHOT);
+  }
+}
+
+function displayPath(session) {
+  return session.cwd ? session.cwd.replace(session.home, "~") : "~";
+}
+
+// --- Sidebar invalidation & typing state ---
+let typingRefreshTimeout;
+
+function invalidateSidebar() {
+  prevSessionFingerprints = null;
+  loadSessions();
+}
+
+// After editing a fresh/typing session, refresh sidebar so main re-checks intention file
+function updateTypingState() {
+  if (!state.currentSessionId) return;
+  const session = state.cachedSessions.find(
+    (s) => s.sessionId === state.currentSessionId,
+  );
+  if (
+    !session ||
+    (session.status !== STATUS.FRESH && session.status !== STATUS.TYPING)
+  ) {
+    return;
+  }
+  // Immediately update sidebar preview from local editor content (no round-trip)
+  updateTypingPreview();
+  // Also schedule full refresh so main process picks up the status change
+  clearTimeout(typingRefreshTimeout);
+  typingRefreshTimeout = setTimeout(invalidateSidebar, 600); // after 500ms save debounce
+}
+
+// Update the current session's sidebar preview directly from local editor content
+function updateTypingPreview() {
+  if (!state.currentSessionId || !state.editorView) return;
+  const li = dom.sessionList.querySelector(
+    `[data-session-id="${state.currentSessionId}"]`,
+  );
+  if (!li) return;
+  const titleSpan = li.querySelector(".session-title");
+  if (!titleSpan) return;
+  const session = state.cachedSessions.find(
+    (s) => s.sessionId === state.currentSessionId,
+  );
+  if (!session || session.intentionHeading) return;
+  const raw = state.editorView.state.doc.toString().trim();
+  const preview = raw
+    .replace(/^#\s+.*\n?/, "")
+    .trim()
+    .slice(0, 80);
+  titleSpan.textContent = preview || "No intention yet";
+  titleSpan.classList.toggle("session-preview", !!preview);
+}
+
+export {
+  loadDirColors,
+  getDirColor,
+  displayPath,
+  loadSessions,
+  invalidateSidebar,
+  updateTypingState,
+  updateTypingPreview,
+  showInlineSnapshot,
+  removeInlineSnapshot,
+  showSnapshotViewer,
+  sessionFingerprint,
+};

--- a/src/terminal-manager.js
+++ b/src/terminal-manager.js
@@ -1,0 +1,648 @@
+// Terminal management: creation, attach, switch, close, caching, reconnect, IPC handlers
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import {
+  state,
+  dom,
+  debugLog,
+  sessionTerminals,
+  CLEANUP_AFTER_MS,
+} from "./renderer-state.js";
+import {
+  DockLayout,
+  createDefaultLayout,
+  TAB_EDITOR,
+  createEditorContainer,
+  registerTerminalTab,
+  registerEditorTab,
+  setupTerminalResize,
+  teardownTerminalResize,
+  disposeTerminalEntry,
+} from "./dock-helpers.js";
+
+// --- Cross-module dependencies (set via initTerminals) ---
+let _actions = {};
+
+export function initTerminals(actions) {
+  _actions = actions;
+}
+
+// --- xterm.js theme (minimal — let shell theme handle ANSI colors) ---
+const TERM_THEME = {
+  background: "#0a0a0a",
+};
+
+export function createTerminal(extraOpts = {}) {
+  return new Terminal({
+    theme: TERM_THEME,
+    fontFamily: "'SF Mono', Menlo, monospace",
+    fontSize: 13,
+    cursorBlink: false,
+    ...extraOpts,
+  });
+}
+
+// xterm.js sends \r for both Enter and Shift+Enter (ignores shift modifier).
+// Claude Code expects CSI u encoding (\x1b[13;2u) for Shift+Enter to trigger
+// multi-line input. This handler intercepts modified Enter and sends the correct
+// escape sequence directly to the PTY.
+export function wireTerminalInput(term, termId) {
+  term.attachCustomKeyEventHandler((ev) => {
+    if (ev.key !== "Enter") return true;
+    if (!ev.shiftKey && !ev.ctrlKey) return true; // plain Enter or Alt+Enter: let xterm handle
+    // Must return false for ALL event types (keydown, keypress, keyup) to fully
+    // block xterm.js — otherwise keypress also sends \r alongside the CSI u.
+    if (ev.type === "keydown") {
+      const mod =
+        (ev.shiftKey ? 1 : 0) | (ev.altKey ? 2 : 0) | (ev.ctrlKey ? 4 : 0);
+      window.api.ptyWrite(termId, `\x1b[13;${mod + 1}u`);
+    }
+    return false;
+  });
+  term.onData((data) => window.api.ptyWrite(termId, data));
+}
+
+// Temporary lookup for terminals being reconnected (before they're in sessionTerminals)
+export const pendingTerminals = new Map(); // termId -> entry
+export const popupTerminals = new Map(); // termId -> { term, ... } for slot terminal popups
+
+export function findTerminalEntry(termId) {
+  const active = state.terminals.find((t) => t.termId === termId);
+  if (active) return active;
+  for (const cached of sessionTerminals.values()) {
+    const entry = cached.terminals.find((t) => t.termId === termId);
+    if (entry) return entry;
+  }
+  return pendingTerminals.get(termId) || null;
+}
+
+// Derive active terminal index from dock state (no separate state to desync)
+export function getActiveTermIndex() {
+  if (!state.dock || state.terminals.length === 0) return -1;
+  // Check all leaves for a terminal tab that is active
+  for (let i = 0; i < state.terminals.length; i++) {
+    const tabId = state.terminals[i].dockTabId;
+    if (!tabId) continue;
+    const leafId = state.dock.getTabLeafId(tabId);
+    if (leafId && state.dock.getActiveTabInLeaf(leafId) === tabId) return i;
+  }
+  return -1;
+}
+
+// --- Dock helpers ---
+
+export function ensureEditorContainer() {
+  if (state.editorContainer) return;
+  const result = createEditorContainer();
+  state.editorContainer = result.editorContainer;
+  state.editorMount = result.editorMount;
+  state.editorProject = result.editorProject;
+  state.saveStatus = result.saveStatus;
+}
+
+export function ensureDock() {
+  if (state.dock) state.dock.destroy();
+  state.dock = new DockLayout(dom.dockContainer, {
+    onTabClose: (tabId) => {
+      const entry = state.terminals.find((t) => t.dockTabId === tabId);
+      if (entry) {
+        const idx = state.terminals.indexOf(entry);
+        if (idx !== -1) closeTerminal(idx);
+      }
+    },
+    onTabActivate: (tabId) => {
+      // Focus the activated tab's content — resize is handled by dock-resize event
+      const entry = state.terminals.find((t) => t.dockTabId === tabId);
+      if (entry) {
+        entry.term.focus();
+      }
+      if (tabId === TAB_EDITOR && state.editorView) {
+        state.editorView.focus();
+      }
+    },
+    onNewTerminal: (leafId) => {
+      if (state.currentSessionId)
+        spawnTerminal(state.currentSessionCwd, null, null, leafId);
+    },
+    onLayoutChange: () => {
+      syncSessionCache();
+    },
+  });
+}
+
+export function dockRegisterTerminal(entry) {
+  if (!state.dock) return;
+  const label = entry.isPoolTui ? "Claude" : `Terminal ${++state.shellCounter}`;
+  registerTerminalTab(state.dock, entry, label);
+}
+
+// Initialize dock with optional existing terminals and saved layout.
+// If no terminals/layout provided, caller adds tabs and sets layout after.
+export function initDockLayout(existingTerminals, savedLayout) {
+  ensureEditorContainer();
+  ensureDock();
+  state.shellCounter = 0;
+  if (existingTerminals) {
+    for (const t of existingTerminals) dockRegisterTerminal(t);
+  }
+  registerEditorTab(state.dock, state.editorContainer);
+  if (savedLayout) {
+    state.dock.setLayout(savedLayout);
+  } else if (existingTerminals && existingTerminals.length > 0) {
+    const termTabIds = existingTerminals.map((t) => t.dockTabId);
+    state.dock.setLayout(createDefaultLayout(termTabIds, [TAB_EDITOR]));
+  }
+}
+
+// Sync current terminals into the session cache (renderer + main process)
+export function syncSessionCache() {
+  if (!state.currentSessionId) return;
+  if (state.terminals.length === 0) {
+    sessionTerminals.delete(state.currentSessionId);
+  } else {
+    sessionTerminals.set(state.currentSessionId, {
+      terminals: [...state.terminals],
+      dockLayout: state.dock ? state.dock.getLayout() : null,
+      lastAccessed: Date.now(),
+    });
+    // Keep main process metadata in sync
+    for (const t of state.terminals) {
+      window.api.ptySetSession(t.termId, state.currentSessionId);
+    }
+  }
+}
+
+// --- Terminal lifecycle ---
+
+export async function spawnTerminal(cwd, cmd, args, targetLeafId) {
+  const container = document.createElement("div");
+  container.style.cssText = "width:100%;height:100%;";
+
+  const term = createTerminal();
+
+  const fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.open(container);
+
+  let termId, pid;
+  try {
+    ({ termId, pid } = await window.api.ptySpawn({
+      cwd: cwd || undefined,
+      cmd: cmd || undefined,
+      args: args || undefined,
+      sessionId: state.currentSessionId || undefined,
+    }));
+  } catch (err) {
+    term.dispose();
+    container.remove();
+    throw err;
+  }
+
+  const entry = {
+    termId,
+    pid,
+    term,
+    fitAddon,
+    container,
+    isPoolTui: false,
+    dockTabId: null,
+    _resizeHandler: null,
+  };
+  state.terminals.push(entry);
+
+  // Register before attach so replay/data can find this terminal
+  pendingTerminals.set(termId, entry);
+  try {
+    await window.api.ptyAttach(termId);
+  } catch (err) {
+    debugLog("term", `attach failed termId=${termId}`, err.message);
+    const idx = state.terminals.indexOf(entry);
+    if (idx !== -1) state.terminals.splice(idx, 1);
+    term.dispose();
+    container.remove();
+    pendingTerminals.delete(termId);
+    throw err;
+  }
+  pendingTerminals.delete(termId);
+
+  wireTerminalInput(term, termId);
+  setupTerminalResize(entry);
+
+  // Register with dock
+  dockRegisterTerminal(entry);
+  if (state.dock) {
+    // Add to target leaf or next to Claude tab
+    const tuiTab = state.terminals.find((t) => t.isPoolTui)?.dockTabId;
+    const leaf =
+      targetLeafId ||
+      (tuiTab && state.dock.getTabLeafId(tuiTab)) ||
+      state.dock.getFirstLeafId();
+    state.dock.addTab(entry.dockTabId, leaf);
+  }
+
+  // Focus the new terminal so user can type immediately
+  entry.term.focus();
+
+  syncSessionCache();
+  return entry;
+}
+
+// Attach to an existing pool slot's PTY (no spawn — the Claude TUI is already running)
+export async function attachPoolTerminal(poolTermId) {
+  const container = document.createElement("div");
+  container.style.cssText = "width:100%;height:100%;";
+
+  const term = createTerminal();
+
+  const fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.open(container);
+
+  const entry = {
+    termId: poolTermId,
+    pid: null,
+    term,
+    fitAddon,
+    container,
+    isPoolTui: true,
+    dockTabId: null,
+    _resizeHandler: null,
+  };
+  state.terminals.push(entry);
+
+  // Register before attach so replay/data can find this terminal
+  pendingTerminals.set(poolTermId, entry);
+  try {
+    await window.api.ptyAttach(poolTermId);
+  } catch (err) {
+    debugLog("pool", `attach failed poolTermId=${poolTermId}`, err.message);
+    const idx = state.terminals.indexOf(entry);
+    if (idx !== -1) state.terminals.splice(idx, 1);
+    term.dispose();
+    container.remove();
+    pendingTerminals.delete(poolTermId);
+    throw err;
+  }
+  pendingTerminals.delete(poolTermId);
+
+  wireTerminalInput(term, poolTermId);
+  setupTerminalResize(entry);
+
+  // Register with dock
+  dockRegisterTerminal(entry);
+  if (state.dock) {
+    const leaf = state.dock.getFirstLeafId();
+    state.dock.addTab(entry.dockTabId, leaf);
+  }
+
+  // Focus the new terminal so user can type immediately
+  entry.term.focus();
+
+  syncSessionCache();
+  return entry;
+}
+
+export function switchToTerminal(index) {
+  if (index < 0 || index >= state.terminals.length) return;
+  const entry = state.terminals[index];
+  if (entry.dockTabId && state.dock) {
+    state.dock.activateTab(entry.dockTabId);
+  }
+}
+
+export async function closeTerminal(index) {
+  if (index < 0 || index >= state.terminals.length) return;
+
+  const entry = state.terminals[index];
+  if (entry.isPoolTui) return; // Can't close the main Claude terminal
+  await window.api.ptyDetach(entry.termId).catch(() => {});
+  await window.api.ptyKill(entry.termId);
+  disposeTerminalEntry(entry, state.dock);
+  state.terminals.splice(index, 1);
+
+  if (state.terminals.length === 0) {
+    dom.sessionView.classList.add("hidden");
+    dom.emptyState.classList.remove("hidden");
+  } else {
+    // Focus the remaining active terminal (or first terminal)
+    focusTerminal();
+  }
+
+  syncSessionCache();
+}
+
+// Hide current session's terminals (preserve them in cache)
+export function hideCurrentTerminals() {
+  _actions.removeInlineSnapshot();
+  if (state.currentSessionId && state.terminals.length > 0) {
+    syncSessionCache();
+    for (const entry of state.terminals) teardownTerminalResize(entry);
+  }
+  state.terminals = [];
+  state.shellCounter = 0;
+}
+
+// Restore cached terminals for a session, returns true if restored
+export function restoreSessionTerminals(sessionId) {
+  const cached = sessionTerminals.get(sessionId);
+  if (!cached || cached.terminals.length === 0) return false;
+
+  cached.lastAccessed = Date.now();
+  state.terminals = cached.terminals;
+
+  initDockLayout(state.terminals, cached.dockLayout);
+  for (const entry of state.terminals) setupTerminalResize(entry);
+
+  // initDockLayout dispatches dock-resize before listeners are registered —
+  // fire again so restored terminals adapt to the current container size
+  window.dispatchEvent(new Event("dock-resize"));
+
+  return true;
+}
+
+// Kill and fully dispose terminals for a specific session.
+// keepAlive: if true, extra shell terminals stay alive in the daemon (detach only, no kill).
+// Used during offload so terminals can be re-attached on resume.
+export function destroySessionTerminals(sessionId, { keepAlive = false } = {}) {
+  const cached = sessionTerminals.get(sessionId);
+  if (!cached) return;
+  for (const entry of cached.terminals) {
+    window.api.ptyDetach(entry.termId).catch(() => {});
+    // Don't kill pool TUI terminals — the Claude process must stay alive.
+    // With keepAlive, also skip killing extra shells (they survive in daemon).
+    if (!entry.isPoolTui && !keepAlive) {
+      window.api.ptyKill(entry.termId).catch(() => {});
+    }
+    const activeDock = sessionId === state.currentSessionId ? state.dock : null;
+    disposeTerminalEntry(entry, activeDock);
+  }
+  sessionTerminals.delete(sessionId);
+}
+
+// Kill ALL terminals across all sessions (used on new-session)
+export function killAllTerminals() {
+  for (const [sid] of sessionTerminals) {
+    destroySessionTerminals(sid);
+  }
+  for (const entry of state.terminals) {
+    window.api.ptyDetach(entry.termId).catch(() => {});
+    if (!entry.isPoolTui) {
+      window.api.ptyKill(entry.termId).catch(() => {});
+    }
+    disposeTerminalEntry(entry, state.dock);
+  }
+  state.terminals = [];
+  state.shellCounter = 0;
+}
+
+// Clean up terminals for dead sessions that haven't been accessed recently
+export function cleanupStaleTerminals(liveSessions) {
+  const aliveIds = new Set(
+    liveSessions.filter((s) => s.alive).map((s) => s.sessionId),
+  );
+  const now = Date.now();
+  for (const [sid, cached] of sessionTerminals) {
+    if (sid === state.currentSessionId) continue; // never clean up active session
+    const isDead = !aliveIds.has(sid);
+    const isStale = now - cached.lastAccessed > CLEANUP_AFTER_MS;
+    if (isDead && isStale) {
+      destroySessionTerminals(sid);
+    }
+  }
+}
+
+// --- Focus management ---
+
+export function focusTerminal() {
+  const idx = getActiveTermIndex();
+  const entry = idx >= 0 ? state.terminals[idx] : state.terminals[0];
+  if (entry) {
+    if (entry.dockTabId && state.dock) state.dock.activateTab(entry.dockTabId);
+    entry.term.focus();
+  }
+}
+
+// --- Reconnect ---
+
+// Reconnect a single PTY from daemon (after app restart or reload)
+export async function reconnectTerminal(ptyInfo) {
+  const container = document.createElement("div");
+  container.style.cssText = "width:100%;height:100%;";
+
+  // Match the PTY's current dimensions so replay buffer renders correctly
+  const term = createTerminal({
+    ...(ptyInfo.cols && { cols: ptyInfo.cols }),
+    ...(ptyInfo.rows && { rows: ptyInfo.rows }),
+  });
+
+  const fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.open(container);
+
+  const entry = {
+    termId: ptyInfo.termId,
+    pid: ptyInfo.pid,
+    term,
+    fitAddon,
+    container,
+    isPoolTui: !!ptyInfo.isPoolTui,
+    dockTabId: null,
+    _resizeHandler: null,
+  };
+
+  if (ptyInfo.buffer) {
+    term.write(ptyInfo.buffer);
+    entry.skipReplay = true;
+  }
+
+  pendingTerminals.set(ptyInfo.termId, entry);
+
+  try {
+    await window.api.ptyAttach(ptyInfo.termId);
+  } catch (err) {
+    pendingTerminals.delete(ptyInfo.termId);
+    term.dispose();
+    container.remove();
+    throw err;
+  }
+
+  pendingTerminals.delete(ptyInfo.termId);
+
+  if (ptyInfo.exited) term.write("\r\n[Process exited]\r\n");
+
+  wireTerminalInput(term, ptyInfo.termId);
+  setupTerminalResize(entry);
+
+  return entry;
+}
+
+// On app start: reconnect to any PTYs that survived from previous instance
+export async function reconnectAllPtys() {
+  const ptys = await window.api.ptyList();
+  debugLog("startup", `reconnecting ${ptys.length} PTYs`);
+  if (ptys.length === 0) return;
+
+  // Identify pool slot termIds so we can tag reconnected terminals
+  const pool = await window.api.poolRead();
+  const poolTermIds = new Set();
+  if (pool) {
+    for (const slot of pool.slots) {
+      poolTermIds.add(slot.termId);
+    }
+  }
+
+  // Group by sessionId
+  const bySession = new Map();
+  for (const p of ptys) {
+    p.isPoolTui = poolTermIds.has(p.termId);
+    const sid = p.sessionId || "__none__";
+    if (!bySession.has(sid)) bySession.set(sid, []);
+    bySession.get(sid).push(p);
+  }
+
+  // Reconnect each session's terminals (skip orphaned terminals with no session)
+  for (const [sid, sessionPtys] of bySession) {
+    if (sid === "__none__") {
+      debugLog("startup", `detaching ${sessionPtys.length} orphaned PTYs`);
+      for (const p of sessionPtys) {
+        window.api.ptyDetach(p.termId).catch(() => {});
+      }
+      continue;
+    }
+    const entries = [];
+    for (const p of sessionPtys) {
+      entries.push(await reconnectTerminal(p));
+    }
+    sessionTerminals.set(sid, {
+      terminals: entries,
+      lastAccessed: Date.now(),
+    });
+  }
+
+  // Restore the most recent alive session that has terminals
+  const sessions = await window.api.getSessions();
+  const lastActive = sessions.find(
+    (s) => s.alive && sessionTerminals.has(s.sessionId),
+  );
+  if (lastActive) {
+    state.currentSessionId = lastActive.sessionId;
+    state.currentSessionCwd = lastActive.cwd;
+
+    const cached = sessionTerminals.get(lastActive.sessionId);
+    state.terminals = cached.terminals;
+
+    dom.emptyState.classList.add("hidden");
+    dom.sessionView.classList.remove("hidden");
+
+    ensureEditorContainer();
+    state.editorProject.textContent = lastActive.project
+      ? `${lastActive.project} — ${_actions.displayPath(lastActive)}`
+      : lastActive.sessionId;
+
+    const content = await window.api.readIntention(lastActive.sessionId);
+    _actions.createEditor(content);
+    await window.api.watchIntention(lastActive.sessionId);
+
+    // Set up dock with restored terminals
+    initDockLayout(state.terminals);
+  }
+}
+
+// --- PTY IPC handlers (wired on module load) ---
+
+// Wire PTY output from daemon (via main process)
+window.api.onPtyData((termId, data) => {
+  const entry = findTerminalEntry(termId);
+  if (entry) entry.term.write(data);
+  // Also forward to popup terminal if open (may be same or different entry)
+  const popup = popupTerminals.get(termId);
+  if (popup && popup !== entry) popup.term.write(data);
+});
+
+window.api.onPtyReplay((termId, data) => {
+  const entry = findTerminalEntry(termId);
+  // Skip if buffer was already written directly during reconnect
+  if (entry && !entry.skipReplay) entry.term.write(data);
+  // Popup always receives replay (it never has skipReplay)
+  const popup = popupTerminals.get(termId);
+  if (popup && popup !== entry) popup.term.write(data);
+});
+
+window.api.onPtyExit((termId) => {
+  const entry = findTerminalEntry(termId);
+  if (entry) entry.term.write("\r\n[Process exited]\r\n");
+  const popup = popupTerminals.get(termId);
+  if (popup && popup !== entry) popup.term.write("\r\n[Process exited]\r\n");
+});
+
+// API-spawned terminal: attach to it and show a tab (if it belongs to current session)
+window.api.onApiTermOpened(async (sessionId, termId) => {
+  if (sessionId !== state.currentSessionId) return;
+  if (state.terminals.some((t) => t.termId === termId)) return;
+
+  const container = document.createElement("div");
+  container.style.cssText = "width:100%;height:100%;";
+
+  const term = createTerminal();
+  const fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.open(container);
+
+  const entry = {
+    termId,
+    pid: null,
+    term,
+    fitAddon,
+    container,
+    isPoolTui: false,
+    dockTabId: null,
+    _resizeHandler: null,
+  };
+  state.terminals.push(entry);
+
+  pendingTerminals.set(termId, entry);
+  try {
+    await window.api.ptyAttach(termId);
+  } catch (err) {
+    debugLog("api-term", `attach failed termId=${termId}`, err.message);
+    const idx = state.terminals.indexOf(entry);
+    if (idx !== -1) state.terminals.splice(idx, 1);
+    term.dispose();
+    container.remove();
+    pendingTerminals.delete(termId);
+    return;
+  }
+  pendingTerminals.delete(termId);
+
+  wireTerminalInput(term, termId);
+  setupTerminalResize(entry);
+
+  dockRegisterTerminal(entry);
+  if (state.dock) {
+    const tuiTab = state.terminals.find((t) => t.isPoolTui)?.dockTabId;
+    const leaf =
+      (tuiTab && state.dock.getTabLeafId(tuiTab)) ||
+      state.dock.getFirstLeafId();
+    state.dock.addTab(entry.dockTabId, leaf);
+  }
+  syncSessionCache();
+});
+
+// API-closed terminal: clean up the renderer side
+window.api.onApiTermClosed((sessionId, termId) => {
+  if (sessionId !== state.currentSessionId) return;
+  const idx = state.terminals.findIndex((t) => t.termId === termId);
+  if (idx === -1) return;
+
+  const entry = state.terminals[idx];
+  window.api.ptyDetach(entry.termId).catch(() => {});
+  disposeTerminalEntry(entry, state.dock);
+  state.terminals.splice(idx, 1);
+
+  if (state.terminals.length === 0) {
+    dom.sessionView.classList.add("hidden");
+    dom.emptyState.classList.remove("hidden");
+  }
+
+  syncSessionCache();
+});


### PR DESCRIPTION
## Summary

- Extract the 3214-line `renderer.js` monolith into 6 focused modules + a slim orchestrator
- **renderer-state.js** — shared mutable state, DOM refs, status classes, utilities
- **editor.js** — CodeMirror 6 live preview editor setup
- **session-sidebar.js** — session list rendering, directory colors, context menus, snapshots
- **terminal-manager.js** — terminal creation, attach, switch, close, caching, reconnect, PTY IPC
- **pool-ui.js** — pool settings panel, slot terminal popup, shortcut settings
- **command-palette.js** — COMMANDS registry, pane navigation, palette UI
- **renderer.js** — orchestrator (session lifecycle, auto-save, IPC wiring, module init)
- Pure extraction refactoring — no behavioral changes

## Test plan

- [x] `npm run build` succeeds (esbuild bundles all modules)
- [x] All 255 tests pass (`npm test`)
- [ ] Manual smoke test: session selection, terminal tabs, pool settings, command palette, keyboard shortcuts

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)