### PR TITLE
Update docs for split module structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,11 @@ Electron app + Claude Code plugin for session intention tracking.
 - `src/preload.js` — Context bridge (`api` object)
 - `src/shortcuts.js` — Configurable keyboard shortcuts (defaults, overrides, accelerator matching)
 - `src/pool.js` — Pure pool data structures (readPool, writePool, computePoolHealth)
+- `src/pool-lock.js` — Async mutex for pool.json read-modify-write cycles (`withPoolLock`)
+- `src/session-statuses.js` — Shared status string constants (STATUS enum)
+- `src/parse-origins.js` — Session origin detection from `ps eww` output (pool/sub-claude/ext)
+- `src/secure-fs.js` — Owner-only file helpers (mode 0o600/0o700)
+- `src/terminal-input.js` — Headless terminal emulator for detecting text in Claude's TUI input box
 - `src/sort-sessions.js` — Session display ordering (used by main.js)
 - `src/dock-layout.js` — **Dock system**: recursive split tree, drag-and-drop tabs, resize handles
 - `src/dock-helpers.js` — Dock integration utilities (editor container factory, terminal resize, tab registration)
@@ -72,20 +77,34 @@ New sessions will have the latest hooks.
 - `~/.open-cockpit/pty-daemon.sock` — PTY daemon Unix socket
 - `~/.open-cockpit/pty-daemon.pid` — PTY daemon PID file
 
-## Dev
+## Launching the app
 
-```bash
-npm run build   # Bundle renderer only (esbuild)
-```
+Use the exact commands below. Do not try alternatives like `open -a Electron.app`, direct `electron .`, or `npx electron .` — these skip the esbuild build step (`npm run build`), so the renderer bundle is stale or missing and the window appears blank. Additionally, Open Cockpit terminals set `ELECTRON_RUN_AS_NODE=1`, which makes Electron run as plain Node.js instead of a GUI app — the commands below unset it.
 
-> ⚠️ All launch commands include `unset ELECTRON_RUN_AS_NODE` — required when launching from an app-managed terminal, where the env var makes Electron run as plain Node.js.
+### Restart production
 
-### Opening the production instance
-
-`npm start` launches the production instance. It exits immediately while Electron runs in the background — **running it twice stacks instances**. Always use this kill-before-launch command:
+`npm start` exits immediately while Electron runs in the background — running it twice stacks instances. Always use this kill-before-launch command:
 
 ```bash
 cd ~/Documents/Projects/open-cockpit && DAEMON_PID=$(cat ~/.open-cockpit/pty-daemon.pid 2>/dev/null || echo NONE); lsof -c Electron 2>/dev/null | awk -v dir="$(pwd)" '/cwd/ && $NF == dir {print $2}' | grep -v "^${DAEMON_PID}$" | sort -u | xargs kill 2>/dev/null; sleep 0.5; unset ELECTRON_RUN_AS_NODE && nohup npm start > /dev/null 2>&1 &
+```
+
+Confirm with the user before restarting production — it disrupts all active sessions.
+
+### Launch dev instance
+
+`cd` into your worktree first, then use this kill-before-launch command (safe even on first launch):
+
+```bash
+DAEMON_PID=$(cat ~/.open-cockpit/pty-daemon.pid 2>/dev/null || echo NONE); lsof -c Electron 2>/dev/null | awk -v dir="$(pwd)" '/cwd/ && $NF == dir {print $2}' | grep -v "^${DAEMON_PID}$" | sort -u | xargs kill 2>/dev/null; sleep 0.5; unset ELECTRON_RUN_AS_NODE && nohup npm run dev > /dev/null 2>&1 &
+```
+
+`npm run dev` exits immediately while Electron stays in the background — it will *look* like it died, but it didn't. The daemon PID is excluded so terminals survive restarts.
+
+### Build renderer only
+
+```bash
+npm run build   # esbuild bundle — needed before Cmd+R reload
 ```
 
 ## Releasing
@@ -139,25 +158,14 @@ git pull
 
 ## Managing dev instances (multi-session safe)
 
-Multiple Claude sessions may work on different worktrees simultaneously. Electron processes inherit the `cwd` of the worktree — use `lsof` to identify and kill only yours.
+Multiple Claude sessions may work on different worktrees simultaneously. The launch command in "Launch dev instance" above uses `$(pwd)` to scope which Electron process to kill — always `cd` into your worktree first, or it could kill the production instance.
 
-> ⚠️ **CRITICAL: You MUST `cd` into your worktree/project directory before running the kill/launch command.** The command uses `$(pwd)` to scope which Electron process to kill. Running it from `~` or any other directory risks killing the **production instance** if it was launched from that directory.
-
-**Always use this command to launch** (kills any existing instance first — safe even on first launch):
-```bash
-DAEMON_PID=$(cat ~/.open-cockpit/pty-daemon.pid 2>/dev/null || echo NONE); lsof -c Electron 2>/dev/null | awk -v dir="$(pwd)" '/cwd/ && $NF == dir {print $2}' | grep -v "^${DAEMON_PID}$" | sort -u | xargs kill 2>/dev/null; sleep 0.5; unset ELECTRON_RUN_AS_NODE && nohup npm run dev > /dev/null 2>&1 &
-```
-
-> ⚠️ `npm run dev` exits immediately while Electron stays running in the background.
-> It will *look* like it died — it didn't. Always kill-before-launch to avoid stacking instances.
-> The daemon PID is excluded so terminals survive restarts.
-
-**Kill only YOUR worktree's instance:**
+**Kill only YOUR worktree's instance** (without relaunching):
 ```bash
 DAEMON_PID=$(cat ~/.open-cockpit/pty-daemon.pid 2>/dev/null || echo NONE); lsof -c Electron 2>/dev/null | awk -v dir="$(pwd)" '/cwd/ && $NF == dir {print $2}' | grep -v "^${DAEMON_PID}$" | sort -u | xargs kill 2>/dev/null
 ```
 
-**NEVER** use `pkill -f electron`, `killall Electron`, or `grep "cwd.*$(pwd)"` (substring match) — these can kill other sessions' instances or the production app. Always use exact `$NF == dir` matching as shown above.
+Do not use `pkill -f electron`, `killall Electron`, or `grep "cwd.*$(pwd)"` (substring match) — these can kill other sessions' instances or the production app. Use exact `$NF == dir` matching.
 
 ## Reloading after changes
 
@@ -165,7 +173,7 @@ DAEMON_PID=$(cat ~/.open-cockpit/pty-daemon.pid 2>/dev/null || echo NONE); lsof 
 - **Main process changes** (`main.js`, `preload.js`): kill and restart your dev instance (see commands above). Terminals survive (daemon keeps them alive).
 - **Daemon changes** (`pty-daemon.js`): kill daemon (`kill $(cat ~/.open-cockpit/pty-daemon.pid)`), then restart app. This kills all terminals.
 
-> ⚠️ **Avoid restarting the production instance** (`npm start`) unless the user explicitly asks. Restarting disrupts all active sessions. For testing, use `npm run dev` instead. If you must restart production, confirm with the user first.
+> For testing, use `npm run dev` instead of restarting production.
 
 ## Further docs
 

--- a/docs/debug-logging.md
+++ b/docs/debug-logging.md
@@ -68,7 +68,7 @@ grep "renderer:pool" ~/.open-cockpit/debug.log
 
 ## Adding new log points
 
-1. **Renderer**: Call `debugLog("tag", "message", ...args)` — the helper is available globally in `renderer.js`
+1. **Renderer**: Call `debugLog("tag", "message", ...args)` — the helper is defined in `renderer-state.js` and available to all renderer modules
 2. **Main**: Call `debugLog("tag", "message", ...args)` — the function is defined at the top of `main.js`
 3. Use descriptive tags: `session`, `pool`, `term`, `editor`, `startup`, `api`, etc.
 4. Include identifiers (session IDs, term IDs, generation counters) for traceability

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -15,11 +15,9 @@ Shortcuts flow through three layers:
 1. **`src/shortcuts.js`**: Add the action ID and default accelerator to `DEFAULT_SHORTCUTS`. If the shortcut needs `before-input-event` handling (arrow keys, Tab, etc.), add its ID to `INPUT_EVENT_ACTIONS`.
 2. **`src/preload.js`**: Add the channel name to the `channels` array (for stale listener cleanup) and expose an `on<Action>` listener in the `contextBridge`.
 3. **`src/main.js`**: Add a menu entry with `accelerator: accel("action-id")` and `click: () => send("channel-name")`. If it's an input-event action, add a mapping in `inputEventChannels`.
-4. **`src/renderer.js`**:
-   - Implement the action function
-   - Add a `COMMANDS` entry with `shortcutAction` (for dynamic display) and `action`
-   - Add the `SHORTCUT_LABELS` entry (for settings UI)
-   - Wire up `window.api.on<Action>(handler)` at the bottom with other listeners
+4. **`src/command-palette.js`**: Add a `COMMANDS` entry with `shortcutAction` (for dynamic display) and `action`.
+5. **`src/pool-ui.js`**: Add the `SHORTCUT_LABELS` entry (for settings UI).
+6. **`src/renderer.js`**: Wire up `window.api.on<Action>(handler)` at the bottom with other listeners.
 
 ### Shortcut configuration
 
@@ -33,7 +31,7 @@ Overrides are stored in `~/.open-cockpit/shortcuts.json`. Only overridden values
 
 ### Command palette
 
-All shortcuts appear in the command palette (`Cmd+/`). The `COMMANDS` array in `renderer.js` defines entries with `id`, `label`, `shortcutAction` (action ID for dynamic shortcut lookup), and `action` (function). Display strings are generated dynamically from the shortcut config.
+All shortcuts appear in the command palette (`Cmd+/`). The `COMMANDS` array in `command-palette.js` defines entries with `id`, `label`, `shortcutAction` (action ID for dynamic shortcut lookup), and `action` (function). Display strings are generated dynamically from the shortcut config.
 
 ## Default shortcuts
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -5,7 +5,7 @@
 Dark black (`#0a0a0a`) background with neon red (`#ff1a1a`) accents.
 
 - CSS vars: `:root` in `src/styles.css`
-- CodeMirror colors: hardcoded in `src/renderer.js` theme objects (`livePreviewTheme`, `darkTheme`)
+- CodeMirror colors: hardcoded in `src/editor.js` theme objects (`livePreviewTheme`, `darkTheme`)
 - xterm theme: minimal (background + cursor only) — shell's own ANSI colors are preserved
 
 ## Session color coding
@@ -19,8 +19,8 @@ Each session gets a colored sidebar indicator and editor header bar based on its
 - Home directory (`~`) gets no color (transparent)
 
 **Implementation:**
-- `main.js` — `getSessions()` walks up from `cwd` looking for `.git` *directory* (not file — worktrees have `.git` files). Returns `gitRoot` per session.
-- `renderer.js` — `getColorKey(session)` normalizes path (strip worktree suffix, use gitRoot if available), then `getDirColor(session)` checks user config, falls back to hash.
+- `session-discovery.js` — `getSessions()` walks up from `cwd` looking for `.git` *directory* (not file — worktrees have `.git` files). Returns `gitRoot` per session.
+- `session-sidebar.js` — `getColorKey(session)` normalizes path (strip worktree suffix, use gitRoot if available), then `getDirColor(session)` checks user config, falls back to hash.
 
 ## User color overrides
 
@@ -36,4 +36,4 @@ Config file: `~/.open-cockpit/colors.json`
 - Keys are tilde-prefixed paths, matched by longest prefix
 - `null` = no color (transparent), string = exact hex color
 - Reloads on sidebar refresh (↻ button), no app restart needed
-- Served via `get-dir-colors` IPC handler in `main.js`
+- Served via `get-dir-colors` IPC handler in `api-handlers.js`


### PR DESCRIPTION
## Summary

- Add 5 missing modules to CLAUDE.md Architecture: `pool-lock.js`, `session-statuses.js`, `parse-origins.js`, `secure-fs.js`, `terminal-input.js`
- Update `docs/shortcuts.md`: COMMANDS → `command-palette.js`, SHORTCUT_LABELS → `pool-ui.js`
- Update `docs/theme.md`: CodeMirror themes → `editor.js`, getSessions → `session-discovery.js`, color functions → `session-sidebar.js`, IPC handler → `api-handlers.js`
- Update `docs/debug-logging.md`: renderer debugLog → `renderer-state.js`
- Consolidate CLAUDE.md launch commands section

## Test plan

- [x] All 255 tests pass
- [ ] Verify docs references match actual source locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)