### PR TITLE
Make Stop hook async to prevent blocking Claude

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -24,7 +24,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/idle-signal.sh write stop"
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/idle-signal.sh write stop",
+            "async": true
           }
         ]
       }


### PR DESCRIPTION
## Summary

- The Stop idle-signal hook was running **synchronously**, blocking Claude from processing re-prompts or new user input until it completed
- The script's `read_input()` does a 1-second blocking read, and the background verifier adds more latency — all while Claude is stuck waiting
- This caused sessions to feel "stuck" especially when combined with the `check-improvements.sh` Stop hook (which blocks and retries)
- The `claude-next-idle` plugin already runs the identical pattern with `async: true` — this aligns open-cockpit to match

## Test plan

- [x] All 255 existing tests pass
- [ ] Verify idle detection still works (signal file written after ~5s delay)
- [ ] Verify sessions transition to idle in the UI correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)