### PR TITLE
Fix idle signal race with async Stop hook

### DIFF
--- a/hooks/idle-signal.sh
+++ b/hooks/idle-signal.sh
@@ -17,6 +17,7 @@
 set -euo pipefail
 source "$(dirname "$0")/common.sh"
 
+SYSTEM_ENTRY_WAIT=4
 IDLE_VERIFY_DELAY=3
 mkdir -p "$SIGNAL_DIR"
 
@@ -83,8 +84,10 @@ case "${1:-}" in
                 trap 'rm -f "$pending"' EXIT
 
                 # Wait for system entries (stop_hook_summary, turn_duration)
-                # to finish writing — they're appended within ~1s of Stop.
-                sleep 2
+                # to finish writing. With async:true, Claude writes these
+                # concurrently (not blocked by the hook), so they can take
+                # up to ~3s to appear. Use SYSTEM_ENTRY_WAIT for margin.
+                sleep "$SYSTEM_ENTRY_WAIT"
 
                 # Abort early if pending was invalidated during system-entry wait
                 [ ! -f "$pending" ] && exit 0


### PR DESCRIPTION
## Summary

- The Stop hook was made `async: true` in v0.1.60 to prevent blocking Claude
- With async, Claude writes system entries (stop_hook_summary, turn_duration) **concurrently** with the hook's background verifier
- The 2-second sleep meant to wait for system entries was too short — they take ~2.5s when running in parallel
- The transcript size check saw the late-arriving system entries as "growth" and aborted, never writing the idle signal
- **Fix:** increase system entry wait from 2s to 4s (total delay 7s, fine since hook is async)

## Test plan

- [x] Reproduced: sent prompt to pool session, confirmed idle signal never written (transcript grew 243584→244945 during verify)
- [x] Applied fix, re-tested: idle signal correctly written after ~12s, session shows "idle"
- [ ] Verify pool reinit picks up fix (destroy + init after CI release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)