### PR TITLE
Fix fresh pool sessions incorrectly marked as stale

### DIFF
--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -884,8 +884,19 @@ async function reconcilePool() {
           }
           slot.sessionId = sessionId;
           slot.status = POOL_STATUS.FRESH;
+          createFreshIdleSignal(slot.pid, sessionId);
           changed = true;
         }
+      }
+
+      // Recreate missing pool-init idle signals for fresh slots.
+      // Signals can be lost on app restart or hook race conditions.
+      if (
+        slot.status === POOL_STATUS.FRESH &&
+        slot.sessionId &&
+        !fs.existsSync(path.join(IDLE_SIGNALS_DIR, String(slot.pid)))
+      ) {
+        createFreshIdleSignal(slot.pid, slot.sessionId);
       }
     }
 

--- a/src/session-discovery.js
+++ b/src/session-discovery.js
@@ -624,7 +624,21 @@ async function getSessionsUncached() {
         }
       }
 
-      if (size != null && now - unchangedSince > STALE_PROCESSING_MS) {
+      const staleTimeout =
+        size != null && now - unchangedSince > STALE_PROCESSING_MS;
+
+      // Pool sessions that were never used (no "user" entries) shouldn't be
+      // marked stale — they're genuinely fresh, just missing their pool-init
+      // idle signal (lost on app restart or hook race). Only mark stale if
+      // the session has real user interaction or isn't a pool session.
+      if (
+        staleTimeout &&
+        (!poolSlot ||
+          (await transcriptContains(
+            jsonlPathCache.get(sessionId),
+            '"type":"user"',
+          )))
+      ) {
         // Always log — stale sessions indicate a hook failure and should never happen
         console.error(
           `[main] Stale processing detected for session ${sessionId} (transcript size unchanged for ${Math.round((now - unchangedSince) / 1000)}s) — treating as idle. Idle signal hook may have failed.`,


### PR DESCRIPTION
## Summary

- Fresh pool sessions lose their `pool-init` idle signals (app restarts, hook races) and fall through to the JSONL-size-tracking fallback, which marks them `staleIdle` after 5 minutes of unchanged transcript — even though they're genuinely waiting for their first prompt
- **session-discovery**: Skip stale marking for pool sessions with no user interaction (`"type":"user"` not in transcript)
- **pool-manager**: `reconcilePool()` now recreates missing `pool-init` idle signals for fresh slots every 30s, preventing the fallback path entirely

## Test plan

- [x] All 255 existing tests pass
- [ ] Init pool, wait >5 minutes — fresh sessions should stay `fresh`, not `stale`
- [ ] Restart app with fresh pool sessions — signals should be recreated by reconcilePool
- [ ] Used sessions that finish should still correctly go through stale detection if Stop hook fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)