### PR TITLE
Fix Cmd+N reopening same session due to stale poolStatus

### DIFF
--- a/src/api-handlers.js
+++ b/src/api-handlers.js
@@ -111,7 +111,7 @@ async function getEffectiveSlotStatus(slot) {
   if (session.status === STATUS.IDLE) return POOL_STATUS.IDLE;
   if (session.status === STATUS.PROCESSING) return POOL_STATUS.BUSY;
   if (session.status === STATUS.FRESH) return POOL_STATUS.FRESH;
-  if (session.status === STATUS.TYPING) return STATUS.TYPING;
+  if (session.status === STATUS.TYPING) return POOL_STATUS.FRESH;
   return slot.status;
 }
 
@@ -141,15 +141,19 @@ function waitForSessionIdle(sessionId, timeoutMs = 300000) {
 const sharedHandlers = {
   "get-sessions": async () => {
     const sessions = await getSessions();
-    await syncPoolStatuses(sessions);
-    const pool = readPool();
+    // syncPoolStatuses returns the pool with up-to-date slot statuses.
+    // We annotate poolStatus here (not in getSessions) to avoid stale reads.
+    const pool = await syncPoolStatuses(sessions);
     if (pool) {
       const slotMap = new Map(
         pool.slots.filter((s) => s.sessionId).map((s) => [s.sessionId, s]),
       );
       for (const s of sessions) {
         const slot = slotMap.get(s.sessionId);
-        if (slot?.pinnedUntil) s.pinnedUntil = slot.pinnedUntil;
+        if (slot) {
+          s.poolStatus = slot.status;
+          if (slot.pinnedUntil) s.pinnedUntil = slot.pinnedUntil;
+        }
       }
     }
     enrichSessionsWithGraphData(sessions);
@@ -384,7 +388,7 @@ function buildApiHandlers() {
   handlers["pool-result"] = async (msg) => {
     const { slot } = resolveSlot(msg);
     const status = await getEffectiveSlotStatus(slot);
-    if (status === POOL_STATUS.BUSY || status === STATUS.PROCESSING) {
+    if (status === POOL_STATUS.BUSY) {
       throw new Error("Session is still running");
     }
     const buffer = await getTerminalBuffer(slot.termId);

--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -1037,12 +1037,14 @@ function pruneSessionGraph(pool) {
 }
 
 // Sync pool.json slot statuses with live session state.
+// Returns the (possibly updated) pool object, or null if no pool.
 async function syncPoolStatuses(sessions) {
-  await withPoolLock(() => {
+  return withPoolLock(() => {
     const pool = readPool();
-    if (!pool) return;
+    if (!pool) return null;
     const updated = syncStatuses(pool, sessions);
     if (updated) writePool(updated);
+    return updated || pool;
   });
 }
 

--- a/src/pool.js
+++ b/src/pool.js
@@ -147,7 +147,12 @@ function syncStatuses(pool, sessions) {
     let newStatus = slot.status;
     if (session.status === STATUS.IDLE) newStatus = POOL_STATUS.IDLE;
     else if (session.status === STATUS.PROCESSING) newStatus = POOL_STATUS.BUSY;
-    else if (session.status === STATUS.FRESH) newStatus = POOL_STATUS.FRESH;
+    else if (
+      session.status === STATUS.FRESH ||
+      session.status === STATUS.TYPING
+    ) {
+      newStatus = POOL_STATUS.FRESH;
+    }
 
     if (newStatus !== slot.status) {
       slot.status = newStatus;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -650,47 +650,54 @@ dom.refreshBtn.addEventListener("click", async () => {
   loadSessions();
 });
 
+let newSessionInProgress = false;
 dom.newSessionBtn.addEventListener("click", async () => {
-  // Check pool is initialized
-  const pool = await window.api.poolRead();
-  if (!pool) {
-    showNotification("Pool not initialized — open pool settings");
-    return;
-  }
+  if (newSessionInProgress) return;
+  newSessionInProgress = true;
+  try {
+    // Check pool is initialized
+    const pool = await window.api.poolRead();
+    if (!pool) {
+      showNotification("Pool not initialized — open pool settings");
+      return;
+    }
 
-  // Check for setup scripts before acquiring a slot
-  let selectedScript = null;
-  const scripts = await window.api.listSetupScripts();
-  if (scripts.length > 0) {
-    selectedScript = await showSetupScriptPicker(scripts);
-    // null means "None" or Escape — proceed without script
-  }
+    // Check for setup scripts before acquiring a slot
+    let selectedScript = null;
+    const scripts = await window.api.listSetupScripts();
+    if (scripts.length > 0) {
+      selectedScript = await showSetupScriptPicker(scripts);
+      // null means "None" or Escape — proceed without script
+    }
 
-  const freshSlot = await acquireFreshSlot();
-  if (!freshSlot) {
-    showNotification(
-      "All pool slots are busy — wait for a session to finish or resize pool",
-    );
-    return;
-  }
-
-  await selectSession(freshSlot);
-
-  // Type setup script into the session's terminal
-  if (selectedScript) {
-    const content = await window.api.readSetupScript(selectedScript);
-    if (content) {
-      const poolData = await window.api.poolRead();
-      const slot = poolData?.slots.find(
-        (s) => s.sessionId === freshSlot.sessionId,
+    const freshSlot = await acquireFreshSlot();
+    if (!freshSlot) {
+      showNotification(
+        "All pool slots are busy — wait for a session to finish or resize pool",
       );
-      if (slot) {
-        await typeSetupScript(slot.termId, content);
+      return;
+    }
+
+    await selectSession(freshSlot);
+
+    // Type setup script into the session's terminal
+    if (selectedScript) {
+      const content = await window.api.readSetupScript(selectedScript);
+      if (content) {
+        const poolData = await window.api.poolRead();
+        const slot = poolData?.slots.find(
+          (s) => s.sessionId === freshSlot.sessionId,
+        );
+        if (slot) {
+          await typeSetupScript(slot.termId, content);
+        }
       }
     }
-  }
 
-  await loadSessions();
+    await loadSessions();
+  } finally {
+    newSessionInProgress = false;
+  }
 });
 
 // --- IPC event handlers ---

--- a/src/session-discovery.js
+++ b/src/session-discovery.js
@@ -840,17 +840,8 @@ async function getSessionsUncached() {
     }
   }
 
-  // Annotate pool sessions with their pool slot status so the renderer
-  // can detect fresh slots without a separate poolRead() call.
-  if (pool) {
-    const slotMap = new Map(
-      pool.slots.filter((s) => s.sessionId).map((s) => [s.sessionId, s.status]),
-    );
-    for (const s of sessions) {
-      const slotStatus = slotMap.get(s.sessionId);
-      if (slotStatus) s.poolStatus = slotStatus;
-    }
-  }
+  // poolStatus is annotated by the get-sessions handler after syncPoolStatuses,
+  // so it reflects the synced (not stale) pool state.
 
   // Prune stale tracker entries for sessions that no longer exist
   const liveIds = new Set(sessions.map((s) => s.sessionId));


### PR DESCRIPTION
## Summary

- **Root cause**: `get-sessions` annotated `poolStatus` from pool.json *before* `syncPoolStatuses` ran, so sessions that transitioned from fresh → processing still had `poolStatus: "fresh"`. `isFreshPoolSlot` matched the current session, `selectSession` no-op'd (same ID).
- `syncPoolStatuses` now returns the synced pool object; handler annotates `poolStatus` from it
- Removed dead `poolStatus` annotation from `getSessionsUncached` (was always overwritten)
- `syncStatuses` now maps `STATUS.TYPING` → `POOL_STATUS.FRESH` (was unmapped)
- Fixed `getEffectiveSlotStatus` returning `STATUS.TYPING` instead of `POOL_STATUS.FRESH` (wrong status domain)
- Fixed `pool-result` handler comparing against `STATUS.PROCESSING` instead of `POOL_STATUS.BUSY`
- Added concurrency guard on Cmd+N handler to prevent piling up async invocations

## Test plan

- [x] All 255 tests pass
- [ ] Press Cmd+N → send a message → press Cmd+N again → should open a different fresh session
- [ ] Rapid Cmd+N presses should not stack up or cause errors

Related: #231, #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)