### PR TITLE
Fix terminal rendering corruption after DOM reattachment

### DIFF
--- a/src/dock-helpers.js
+++ b/src/dock-helpers.js
@@ -54,29 +54,50 @@ export function registerEditorTab(dock, editorContainer) {
   });
 }
 
-// Terminal resize via dock-resize + window resize events (replaces per-terminal ResizeObservers)
+// Terminal resize: ResizeObserver catches actual container size changes (sidebar
+// toggle, window resize, split drag); dock-resize event catches DOM reattachment
+// where container size is unchanged (tab switch, session restore).
 export function setupTerminalResize(entry) {
   let pending = false;
-  const handler = () => {
+  let prevCols = entry.term.cols;
+  let prevRows = entry.term.rows;
+
+  const doFit = () => {
     if (pending) return;
     pending = true;
     requestAnimationFrame(() => {
       pending = false;
-      if (entry.container.offsetParent) {
-        entry.fitAddon.fit();
-        window.api.ptyResize(entry.termId, entry.term.cols, entry.term.rows);
+      if (!entry.container.offsetParent) return;
+      entry.fitAddon.fit();
+      const { cols, rows } = entry.term;
+      if (cols !== prevCols || rows !== prevRows) {
+        prevCols = cols;
+        prevRows = rows;
+        window.api.ptyResize(entry.termId, cols, rows);
+      } else {
+        // Dimensions unchanged — force repaint for DOM reattachment cases
+        // where the canvas renderer is stale. Skipped when dimensions changed
+        // because fit() already triggers a full re-render via terminal.resize().
+        entry.term.refresh(0, rows - 1);
       }
     });
   };
-  window.addEventListener("dock-resize", handler);
-  window.addEventListener("resize", handler);
-  entry._resizeHandler = handler;
+
+  const ro = new ResizeObserver(doFit);
+  ro.observe(entry.container);
+  window.addEventListener("dock-resize", doFit);
+
+  entry._resizeObserver = ro;
+  entry._resizeHandler = doFit;
 }
 
 export function teardownTerminalResize(entry) {
+  if (entry._resizeObserver) {
+    entry._resizeObserver.disconnect();
+    entry._resizeObserver = null;
+  }
   if (entry._resizeHandler) {
     window.removeEventListener("dock-resize", entry._resizeHandler);
-    window.removeEventListener("resize", entry._resizeHandler);
     entry._resizeHandler = null;
   }
 }

--- a/src/terminal-manager.js
+++ b/src/terminal-manager.js
@@ -353,10 +353,6 @@ export function restoreSessionTerminals(sessionId) {
   initDockLayout(state.terminals, cached.dockLayout);
   for (const entry of state.terminals) setupTerminalResize(entry);
 
-  // initDockLayout dispatches dock-resize before listeners are registered —
-  // fire again so restored terminals adapt to the current container size
-  window.dispatchEvent(new Event("dock-resize"));
-
   return true;
 }
 


### PR DESCRIPTION
## Summary

- Replace event-based terminal resize detection (`dock-resize` + `window resize`) with `ResizeObserver` per terminal container — catches ALL size changes automatically (sidebar toggle, window resize, split drag)
- Force `term.refresh()` after DOM reattachment when dimensions are unchanged — fixes stale xterm.js canvas after dock layout rebuilds
- Only send `ptyResize` when dimensions actually changed — avoids unnecessary SIGWINCH signals

## Root cause

The dock's `_render()` detaches and reattaches all xterm.js canvases on every layout change. Two things went wrong:

1. **Sidebar toggle** changed the dock container width but never fired a resize event, so terminals stayed at stale dimensions → garbled "layered" TUI output
2. **DOM reattachment** with unchanged dimensions made `fit()` a no-op, and xterm's canvas renderer didn't repaint → terminal "stopped changing"

Manual window resize always fixed it because it triggered `fit()` with correct dimensions.

## Test plan

- [x] `npm run build` succeeds
- [x] All 255 tests pass
- [ ] Toggle sidebar — terminals should refit instantly
- [ ] Switch between sessions rapidly — no frozen/garbled terminals
- [ ] Drag dock split handles — smooth resize without flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)