### PR TITLE
Nest child sessions under parents in sidebar

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -56,6 +56,8 @@ All shortcuts appear in the command palette (`Cmd+/`). The `COMMANDS` array in `
 | `Cmd+/` | Command Palette |
 | `Cmd+,` | Pool Settings |
 | `Cmd+Alt+]` / `[` | Focus Next / Previous Pane |
+| `Alt+Right` | Toggle Child Sessions (expand/collapse) |
+| `Alt+Shift+Down` / `Up` | Next / Previous Child Session |
 | *(unbound)* | Toggle Pane Focus (editor ↔ terminal) |
 | *(unbound)* | Split Right |
 | *(unbound)* | Split Down |

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -30,6 +30,24 @@ export function initCommandPalette(actions) {
       action: () => _actions.switchSession(-1),
     },
     {
+      id: "toggle-children",
+      label: "Toggle Child Sessions",
+      shortcutAction: "toggle-children",
+      action: () => _actions.toggleChildren(),
+    },
+    {
+      id: "next-child-session",
+      label: "Next Child Session",
+      shortcutAction: "next-child-session",
+      action: () => _actions.switchChildSession(1),
+    },
+    {
+      id: "prev-child-session",
+      label: "Previous Child Session",
+      shortcutAction: "prev-child-session",
+      action: () => _actions.switchChildSession(-1),
+    },
+    {
       id: "new-session",
       label: "New Claude Session",
       shortcutAction: "new-session",

--- a/src/main.js
+++ b/src/main.js
@@ -99,6 +99,9 @@ function createWindow() {
     "next-session": "next-session",
     "prev-session": "prev-session",
     "cycle-pane": "cycle-pane",
+    "toggle-children": "toggle-children",
+    "next-child-session": "next-child-session",
+    "prev-child-session": "prev-child-session",
   };
 
   mainWindow.webContents.on("before-input-event", (event, input) => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -17,6 +17,9 @@ const channels = [
   "new-session",
   "next-session",
   "prev-session",
+  "toggle-children",
+  "next-child-session",
+  "prev-child-session",
   "toggle-sidebar",
   "focus-editor",
   "focus-terminal",
@@ -140,6 +143,12 @@ contextBridge.exposeInMainWorld("api", {
   onNewSession: (callback) => ipcRenderer.on("new-session", () => callback()),
   onNextSession: (callback) => ipcRenderer.on("next-session", () => callback()),
   onPrevSession: (callback) => ipcRenderer.on("prev-session", () => callback()),
+  onToggleChildren: (callback) =>
+    ipcRenderer.on("toggle-children", () => callback()),
+  onNextChildSession: (callback) =>
+    ipcRenderer.on("next-child-session", () => callback()),
+  onPrevChildSession: (callback) =>
+    ipcRenderer.on("prev-child-session", () => callback()),
   onToggleSidebar: (callback) =>
     ipcRenderer.on("toggle-sidebar", () => callback()),
   onFocusEditor: (callback) => ipcRenderer.on("focus-editor", () => callback()),

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -25,6 +25,9 @@ import {
   updateTypingState,
   showInlineSnapshot,
   removeInlineSnapshot,
+  toggleChildrenExpanded,
+  isChildrenExpanded,
+  hasSessionChildren,
 } from "./session-sidebar.js";
 import {
   initTerminals,
@@ -444,6 +447,65 @@ function switchSession(direction) {
   selectSession(navigable[nextIndex]);
 }
 
+// --- Child session navigation ---
+
+function toggleChildren() {
+  if (!state.currentSessionId) return;
+  const current = state.cachedSessions.find(
+    (s) => s.sessionId === state.currentSessionId,
+  );
+  if (!current) return;
+
+  // If current session has children, toggle its expand/collapse
+  if (hasSessionChildren(current.sessionId)) {
+    toggleChildrenExpanded(current.sessionId);
+    return;
+  }
+
+  // If current session is a child, toggle its parent's children
+  if (current.parentSessionId && hasSessionChildren(current.parentSessionId)) {
+    toggleChildrenExpanded(current.parentSessionId);
+  }
+}
+
+function switchChildSession(direction) {
+  if (!state.currentSessionId) return;
+  const current = state.cachedSessions.find(
+    (s) => s.sessionId === state.currentSessionId,
+  );
+  if (!current) return;
+
+  // Determine parent and siblings
+  const parentId = current.parentSessionId || current.sessionId;
+  const siblings = state.cachedSessions.filter(
+    (s) => s.parentSessionId === parentId,
+  );
+  if (siblings.length === 0) return;
+
+  // Ensure parent is expanded so children are visible
+  if (!isChildrenExpanded(parentId)) {
+    toggleChildrenExpanded(parentId);
+  }
+
+  if (!current.parentSessionId) {
+    // On parent: go to first (down) or last (up) child
+    selectSession(direction > 0 ? siblings[0] : siblings[siblings.length - 1]);
+    return;
+  }
+
+  const idx = siblings.findIndex((s) => s.sessionId === current.sessionId);
+  if (idx === -1) return;
+
+  const nextIdx = idx + direction;
+  if (nextIdx < 0 || nextIdx >= siblings.length) {
+    // Navigate back to parent
+    const parent = state.cachedSessions.find((s) => s.sessionId === parentId);
+    if (parent) selectSession(parent);
+  } else {
+    selectSession(siblings[nextIdx]);
+  }
+}
+
 // --- Jump to most recent idle session ---
 
 function jumpToRecentIdle() {
@@ -643,6 +705,8 @@ initCommandPalette({
   loadSessions,
   showPoolSettings,
   showShortcutSettings,
+  toggleChildren,
+  switchChildSession,
 });
 
 // Editor doc change callback
@@ -745,6 +809,9 @@ window.api.onSwitchTerminalTab((index) => {
 window.api.onNewSession(() => dom.newSessionBtn.click());
 window.api.onNextSession(() => switchSession(1));
 window.api.onPrevSession(() => switchSession(-1));
+window.api.onToggleChildren(toggleChildren);
+window.api.onNextChildSession(() => switchChildSession(1));
+window.api.onPrevChildSession(() => switchChildSession(-1));
 window.api.onToggleSidebar(toggleSidebar);
 window.api.onFocusEditor(focusEditor);
 window.api.onFocusTerminal(() => {

--- a/src/session-sidebar.js
+++ b/src/session-sidebar.js
@@ -96,7 +96,7 @@ function getDirColor(session) {
 
 // Build a fingerprint for a session to detect changes
 function sessionFingerprint(s) {
-  return `${s.sessionId}|${s.status}|${s.staleIdle ? "stale" : ""}|${s.intentionHeading || ""}|${s.intentionPreview || ""}|${s.cwd || ""}|${s.origin || ""}`;
+  return `${s.sessionId}|${s.status}|${s.staleIdle ? "stale" : ""}|${s.intentionHeading || ""}|${s.intentionPreview || ""}|${s.cwd || ""}|${s.origin || ""}|${s.parentSessionId || ""}`;
 }
 
 // Track previous session fingerprints for diff-based update
@@ -126,6 +126,32 @@ function playBell() {
 // --- Session list ---
 let archiveExpanded = false;
 
+// Track which parent sessions have their children expanded
+const childrenExpanded = new Set();
+
+// Current parent→children map (rebuilt on each loadSessions)
+let childrenMap = new Map();
+
+// Build a map of parentSessionId -> [child sessions] (recursive tree)
+// Returns { childrenMap, topLevel set of sessionIds that have no visible parent }
+function buildSessionTree(sessions) {
+  const byId = new Map(sessions.map((s) => [s.sessionId, s]));
+  const cMap = new Map(); // parentId -> [child sessions]
+  const childIds = new Set();
+
+  for (const s of sessions) {
+    if (s.parentSessionId && byId.has(s.parentSessionId)) {
+      childIds.add(s.sessionId);
+      if (!cMap.has(s.parentSessionId)) {
+        cMap.set(s.parentSessionId, []);
+      }
+      cMap.get(s.parentSessionId).push(s);
+    }
+  }
+
+  return { childrenMap: cMap, childIds };
+}
+
 async function loadSessions() {
   const sessions = await window.api.getSessions();
   const oldStatuses = new Map(
@@ -144,13 +170,27 @@ async function loadSessions() {
   _actions.cleanupStaleTerminals(sessions);
   _actions.updatePoolHealthBadge();
 
-  // Split into sections — pool and external mixed together
-  const typing = sessions.filter((s) => s.status === STATUS.TYPING);
-  const recent = sessions.filter(
-    (s) => s.status === STATUS.IDLE || s.status === STATUS.OFFLOADED,
+  // Build parent-child tree and filter children out of top-level sections
+  const tree = buildSessionTree(sessions);
+  childrenMap = tree.childrenMap;
+  const { childIds } = tree;
+  const isTopLevel = (s) => !childIds.has(s.sessionId);
+
+  // Split into sections — pool and external mixed together (top-level only)
+  const typing = sessions.filter(
+    (s) => isTopLevel(s) && s.status === STATUS.TYPING,
   );
-  const processing = sessions.filter((s) => s.status === STATUS.PROCESSING);
-  const archived = sessions.filter((s) => s.status === STATUS.ARCHIVED);
+  const recent = sessions.filter(
+    (s) =>
+      isTopLevel(s) &&
+      (s.status === STATUS.IDLE || s.status === STATUS.OFFLOADED),
+  );
+  const processing = sessions.filter(
+    (s) => isTopLevel(s) && s.status === STATUS.PROCESSING,
+  );
+  const archived = sessions.filter(
+    (s) => isTopLevel(s) && s.status === STATUS.ARCHIVED,
+  );
 
   // Build fingerprint to check if anything changed
   const allItems = [...typing, ...recent, ...processing, ...archived];
@@ -168,10 +208,12 @@ async function loadSessions() {
   prevSessionFingerprints = fingerprints;
 
   // Bell when a session transitions to idle (finished processing)
+  // Skip child sessions (initiator === "model") — they shouldn't bing
   if (oldStatuses.size > 0) {
     for (const s of sessions) {
       if (
         s.status === STATUS.IDLE &&
+        s.initiator !== "model" &&
         oldStatuses.has(s.sessionId) &&
         oldStatuses.get(s.sessionId) !== STATUS.IDLE
       ) {
@@ -195,14 +237,41 @@ async function loadSessions() {
     return;
   }
 
+  // Recursively count a session plus all its descendants
+  function countWithChildren(s) {
+    let count = 1;
+    const children = childrenMap.get(s.sessionId);
+    if (children) {
+      for (const c of children) count += countWithChildren(c);
+    }
+    return count;
+  }
+
+  // Render a session item and its nested children (recursive)
+  function appendSessionWithChildren(parent, s, depth) {
+    parent.appendChild(createSessionItem(s, depth));
+    const children = childrenMap.get(s.sessionId);
+    if (!children || children.length === 0) return;
+
+    const isExpanded = childrenExpanded.has(s.sessionId);
+    if (!isExpanded) return;
+
+    for (const child of children) {
+      appendSessionWithChildren(parent, child, depth + 1);
+    }
+  }
+
   function addSection(label, items) {
     if (items.length === 0) return;
+    // Count includes nested children
+    let total = 0;
+    for (const s of items) total += countWithChildren(s);
     const header = document.createElement("li");
     header.className = "session-section-header";
-    header.textContent = `${label} (${items.length})`;
+    header.textContent = `${label} (${total})`;
     dom.sessionList.appendChild(header);
     for (const s of items) {
-      dom.sessionList.appendChild(createSessionItem(s));
+      appendSessionWithChildren(dom.sessionList, s, 0);
     }
   }
 
@@ -226,7 +295,7 @@ async function loadSessions() {
     dom.sessionList.appendChild(header);
     const visible = collapsed ? archived.slice(0, ARCHIVE_VISIBLE) : archived;
     for (const s of visible) {
-      dom.sessionList.appendChild(createSessionItem(s));
+      appendSessionWithChildren(dom.sessionList, s, 0);
     }
     if (collapsed) {
       const more = document.createElement("li");
@@ -241,10 +310,12 @@ async function loadSessions() {
   }
 }
 
-function createSessionItem(s) {
+function createSessionItem(s, depth = 0) {
   const li = document.createElement("li");
-  li.className = `session-item${s.sessionId === state.currentSessionId ? " active" : ""}${s.status === STATUS.OFFLOADED || s.status === STATUS.ARCHIVED ? " offloaded" : ""}`;
+  const isChild = depth > 0;
+  li.className = `session-item${s.sessionId === state.currentSessionId ? " active" : ""}${s.status === STATUS.OFFLOADED || s.status === STATUS.ARCHIVED ? " offloaded" : ""}${isChild ? " session-child" : ""}`;
   li.dataset.sessionId = s.sessionId;
+  if (isChild) li.style.paddingLeft = `${12 + depth * 18}px`;
   const heading = s.intentionHeading || s.intentionPreview || null;
   const isPreview = !s.intentionHeading && !!s.intentionPreview;
   const dp = displayPath(s);
@@ -264,10 +335,19 @@ function createSessionItem(s) {
   const pinnedTag = pinned
     ? '<span class="session-origin-tag session-origin-pinned" title="Pinned — won\'t be offloaded">📌</span>'
     : "";
+
+  // Children toggle for sessions that have children
+  const hasChildren = childrenMap.has(s.sessionId);
+  const isExpanded = childrenExpanded.has(s.sessionId);
+  const toggleHtml = hasChildren
+    ? `<span class="session-children-toggle">${isExpanded ? "▾" : "▸"}</span>`
+    : "";
+
   li.innerHTML = `
     <div class="session-dir-indicator" style="${indicatorStyle}"></div>
     <div class="session-item-content">
       <div class="session-project">
+        ${toggleHtml}
         <span class="session-status ${STATUS_CLASSES[s.status] || "dead"}"></span>
         <span class="session-title${isPreview ? " session-preview" : ""}">${escapeHtml(heading || "No intention yet")}</span>
         ${originTag}${staleTag}${pinnedTag}
@@ -275,6 +355,16 @@ function createSessionItem(s) {
       <div class="session-cwd">${escapeHtml(dp)}</div>
     </div>
   `;
+
+  // Toggle children expand/collapse on arrow click
+  if (hasChildren) {
+    const toggle = li.querySelector(".session-children-toggle");
+    toggle.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleChildrenExpanded(s.sessionId);
+    });
+  }
+
   li.addEventListener("click", () => _actions.selectSession(s));
   li.addEventListener("contextmenu", (e) => {
     e.preventDefault();
@@ -501,6 +591,25 @@ function updateTypingPreview() {
   titleSpan.classList.toggle("session-preview", !!preview);
 }
 
+// --- Children expand/collapse API ---
+
+function toggleChildrenExpanded(sessionId) {
+  if (childrenExpanded.has(sessionId)) {
+    childrenExpanded.delete(sessionId);
+  } else {
+    childrenExpanded.add(sessionId);
+  }
+  invalidateSidebar();
+}
+
+function isChildrenExpanded(sessionId) {
+  return childrenExpanded.has(sessionId);
+}
+
+function hasSessionChildren(sessionId) {
+  return childrenMap.has(sessionId);
+}
+
 export {
   loadDirColors,
   getDirColor,
@@ -513,4 +622,7 @@ export {
   removeInlineSnapshot,
   showSnapshotViewer,
   sessionFingerprint,
+  toggleChildrenExpanded,
+  isChildrenExpanded,
+  hasSessionChildren,
 };

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -39,6 +39,10 @@ const DEFAULT_SHORTCUTS = {
   "focus-prev-pane": "CmdOrCtrl+Alt+[",
   "split-right": "",
   "split-down": "",
+  // Child session navigation
+  "toggle-children": "Alt+Right",
+  "next-child-session": "Alt+Shift+Down",
+  "prev-child-session": "Alt+Shift+Up",
   // These are handled via before-input-event, not menu accelerators
   "next-terminal-tab-alt": "Ctrl+Tab",
   "prev-terminal-tab-alt": "Ctrl+Shift+Tab",
@@ -51,6 +55,9 @@ const INPUT_EVENT_ACTIONS = new Set([
   "next-session",
   "prev-session",
   "cycle-pane",
+  "toggle-children",
+  "next-child-session",
+  "prev-child-session",
 ]);
 
 let userOverrides = {};

--- a/src/styles.css
+++ b/src/styles.css
@@ -289,6 +289,27 @@ body {
   background: rgba(255, 255, 0, 0.1);
 }
 
+/* Child session nesting */
+.session-child {
+  opacity: 0.8;
+}
+
+.session-child:hover {
+  opacity: 1;
+}
+
+.session-children-toggle {
+  font-size: 10px;
+  cursor: pointer;
+  flex-shrink: 0;
+  color: var(--text-dim);
+  padding: 2px;
+}
+
+.session-children-toggle:hover {
+  color: var(--text);
+}
+
 .session-cwd {
   font-size: 11px;
   color: var(--text-dim);


### PR DESCRIPTION
## Summary

- Child sessions (spawned by Claude via `cockpit-cli`) are grouped under their parent in the sidebar with a collapsible ▸/▾ toggle
- Children are filtered out of top-level sections — they only appear nested under their parent
- Bell sound suppressed for model-initiated child sessions
- Keyboard shortcuts: `Alt+Right` (toggle), `Alt+Shift+Down/Up` (navigate children)

## Test plan

- [ ] Spawn child sessions via `cockpit-cli start` from a parent Claude session
- [ ] Verify children appear nested under the parent, not in top-level sections
- [ ] Toggle expand/collapse via click and `Alt+Right`
- [ ] Navigate between children with `Alt+Shift+Down/Up`
- [ ] Verify no bell sounds when child sessions finish
- [ ] Verify orphaned children (parent removed) appear as top-level
- [ ] Check command palette shows new shortcuts

🤖 Generated with [Claude Code](https://claude.com/claude-code)