### PR TITLE
Fix scrambled terminal display on Cmd+N

### DIFF
--- a/src/dock-helpers.js
+++ b/src/dock-helpers.js
@@ -68,6 +68,15 @@ export function setupTerminalResize(entry) {
     requestAnimationFrame(() => {
       pending = false;
       if (!entry.container.offsetParent) return;
+      // FitAddon.proposeDimensions() returns undefined when xterm's cell
+      // dimensions are 0 — happens when the terminal was opened in a detached
+      // or zero-sized container and hasn't painted yet. In that case fit() is
+      // a silent no-op, leaving the terminal at wrong cols/rows. Retry after
+      // the next paint so xterm can compute font metrics first.
+      if (!entry.fitAddon.proposeDimensions()) {
+        requestAnimationFrame(() => doFit());
+        return;
+      }
       entry.fitAddon.fit();
       const { cols, rows } = entry.term;
       if (cols !== prevCols || rows !== prevRows) {


### PR DESCRIPTION
## Summary

- Fixes terminals appearing scrambled (wrong width, overlapping elements) when creating new sessions via Cmd+N
- **Root cause**: `term.open(container)` is called on a detached container, so xterm computes cell dimensions as 0. When `FitAddon.fit()` runs in the next rAF, `proposeDimensions()` returns `undefined` (cell dims are 0), making `fit()` a silent no-op. The terminal stays at default 80×24 and no `ptyResize` is sent — the Claude TUI renders at the wrong size
- **Fix**: Check `proposeDimensions()` before calling `fit()`. If it returns `undefined`, schedule a retry after the next paint so xterm can compute font metrics first
- Manual window resize previously fixed it because by then xterm had painted and cell dims were valid

## Test plan

- [ ] Press Cmd+N repeatedly to create new sessions — terminal should display correctly every time
- [ ] Verify existing resize behavior still works (window resize, sidebar toggle, split drag)
- [ ] Verify tab switching still triggers proper terminal refit

🤖 Generated with [Claude Code](https://claude.com/claude-code)