### PR TITLE
Fix terminal disappearing when resuming archived sessions

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -328,9 +328,13 @@ async function resumeOffloadedSession(session) {
     // Clean up any renderer-side cached terminals for the old session
     // (e.g. from startup reconnect). The daemon terminals were re-tagged
     // to the new sessionId by main.js, so we just dispose the stale UI.
+    // Skip terminals currently active in the dock — they were attached
+    // during this resume and will be re-cached under the new session ID.
+    const activeTermIds = new Set(state.terminals.map((t) => t.termId));
     const oldCached = sessionTerminals.get(oldSessionId);
     if (oldCached) {
       for (const entry of oldCached.terminals) {
+        if (activeTermIds.has(entry.termId)) continue;
         window.api.ptyDetach(entry.termId).catch(() => {});
         disposeTerminalEntry(entry, state.dock);
       }


### PR DESCRIPTION
## Summary

- When resuming an archived session, `attachPoolTerminal()` caches the newly attached TUI under the **old** session ID (via `syncSessionCache`)
- When `pollForResumedSession` resolves seconds later, the cleanup loop disposes **all** terminals cached for the old session — destroying the active TUI
- Result: terminal tab vanishes from the dock, only the editor/intention pane remains

Fix: skip terminals that are currently in `state.terminals` during old-session cleanup, since they'll be re-cached under the new session ID.

## Test plan

- [ ] Resume an archived session → terminal should stay visible throughout
- [ ] Resume an offloaded session → same behavior
- [ ] Extra terminal tabs from the old session should still be cleaned up properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)