### PR TITLE
Skip collapsed children in session nav, enlarge fold indicator

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -433,13 +433,25 @@ function scheduleSave() {
 
 function switchSession(direction) {
   // Navigate between active sessions (idle + processing + typing) + archived
+  // Skip child sessions whose parent (or any ancestor) is collapsed
+  const byId = new Map(state.cachedSessions.map((s) => [s.sessionId, s]));
+  const isVisible = (s) => {
+    let cur = s;
+    while (cur.parentSessionId) {
+      if (!isChildrenExpanded(cur.parentSessionId)) return false;
+      cur = byId.get(cur.parentSessionId);
+      if (!cur) break;
+    }
+    return true;
+  };
   const navigable = state.cachedSessions.filter(
     (s) =>
-      (s.alive &&
+      ((s.alive &&
         (s.status === STATUS.IDLE ||
           s.status === STATUS.PROCESSING ||
           s.status === STATUS.TYPING)) ||
-      s.status === STATUS.ARCHIVED,
+        s.status === STATUS.ARCHIVED) &&
+      isVisible(s),
   );
   if (navigable.length === 0) return;
   const currentIndex = navigable.findIndex(

--- a/src/styles.css
+++ b/src/styles.css
@@ -303,11 +303,11 @@ body {
 }
 
 .session-children-toggle {
-  font-size: 10px;
+  font-size: 14px;
   cursor: pointer;
   flex-shrink: 0;
   color: var(--text-dim);
-  padding: 2px;
+  padding: 2px 4px;
 }
 
 .session-children-toggle:hover {


### PR DESCRIPTION
## Summary
- **Session navigation** (Alt+Up/Down) now respects the expand/collapse state — collapsed child sessions are skipped, matching what's visible in the sidebar. Walks the full ancestor chain so deeply nested sessions are handled correctly.
- **Fold indicator** (▸/▾) enlarged from 10px → 14px with extra padding for easier clicking.

## Test plan
- [ ] With child sessions collapsed, Alt+Up/Down skips them
- [ ] Expand children → they become navigable again
- [ ] Deeply nested children (grandchildren) are also skipped when any ancestor is collapsed
- [ ] Fold indicator is visually larger and easier to click

🤖 Generated with [Claude Code](https://claude.com/claude-code)