### PR TITLE
Fix dead shortcutConfig, DOM monkey-patch, stuck dialogOpen

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -122,6 +122,11 @@ function createWindow() {
     }
   });
 
+  // Reset dialog state if renderer reloads (prevents stuck dialogOpen)
+  mainWindow.webContents.on("did-finish-load", () => {
+    dialogOpen = false;
+  });
+
   mainWindow.webContents.on("console-message", (_e, level, message) => {
     console.log(`[renderer] ${message}`);
   });

--- a/src/pool-ui.js
+++ b/src/pool-ui.js
@@ -226,6 +226,7 @@ async function showSettings(initialTab = "general") {
   ]);
 
   let keyHandler = null;
+  let cleanupRecordingFn = null;
 
   const { overlay, close } = createOverlayDialog({
     id: "unified-settings",
@@ -258,7 +259,7 @@ async function showSettings(initialTab = "general") {
       if (keyHandler) {
         document.removeEventListener("keydown", keyHandler, true);
       }
-      if (overlay._cleanupRecording) overlay._cleanupRecording();
+      if (cleanupRecordingFn) cleanupRecordingFn();
     },
   });
 
@@ -605,7 +606,7 @@ function wireShortcutsTab(overlay, shortcuts, defaults) {
   }
 
   // Store cleanup for dialog close
-  overlay._cleanupRecording = cleanupRecording;
+  cleanupRecordingFn = cleanupRecording;
 
   function showConflictWarning(row, conflicts) {
     row.querySelector(".shortcut-conflict")?.remove();
@@ -714,7 +715,6 @@ function wireShortcutsTab(overlay, shortcuts, defaults) {
       const actionId = row.dataset.action;
       await window.api.setShortcut(actionId, "");
       shortcuts[actionId] = "";
-      shortcutConfig = { ...shortcuts };
       btn.textContent = "—";
       row.querySelector(".shortcut-conflict")?.remove();
       updateResetBtn(row, actionId, "");
@@ -728,7 +728,6 @@ function wireShortcutsTab(overlay, shortcuts, defaults) {
       await window.api.resetShortcut(actionId);
       const defaultVal = await window.api.getDefaultShortcut(actionId);
       shortcuts[actionId] = defaultVal;
-      shortcutConfig = { ...shortcuts };
       const keyBtn = row.querySelector(".shortcut-key-btn");
       keyBtn.textContent = formatShortcutDisplay(defaultVal) || "—";
       // Update conflict warning and reset button


### PR DESCRIPTION
## Summary

Cleanup fixes from simplify review of #247:

- **Remove dead `shortcutConfig` writes** in pool-ui.js — `shortcutConfig` is only declared in command-palette.js, so these writes would throw `ReferenceError` in ES module strict mode
- **Replace `overlay._cleanupRecording` DOM monkey-patch** with a closure variable — avoids fragile property attachment on DOM elements
- **Reset `dialogOpen` on renderer reload** via `did-finish-load` — prevents shortcuts getting permanently swallowed if renderer reloads while a dialog is open

## Test plan

- [x] All 255 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)