### PR TITLE
Fix session nav order to match visual sidebar tree

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -424,29 +424,51 @@ function scheduleSave() {
   }, 500);
 }
 
+// --- Session tree helpers (shared by navigation functions) ---
+
+function buildSessionMaps() {
+  const byId = new Map(state.cachedSessions.map((s) => [s.sessionId, s]));
+  const cMap = new Map();
+  const childIds = new Set();
+  for (const s of state.cachedSessions) {
+    if (s.parentSessionId && byId.has(s.parentSessionId)) {
+      childIds.add(s.sessionId);
+      if (!cMap.has(s.parentSessionId)) cMap.set(s.parentSessionId, []);
+      cMap.get(s.parentSessionId).push(s);
+    }
+  }
+  return { byId, cMap, childIds };
+}
+
+// Build flat list matching visual sidebar order (parents with children grouped)
+function buildVisualOrder({ cMap, childIds }) {
+  const result = [];
+  function addWithChildren(s) {
+    result.push(s);
+    const children = cMap.get(s.sessionId);
+    if (children && isChildrenExpanded(s.sessionId)) {
+      for (const child of children) addWithChildren(child);
+    }
+  }
+  for (const s of state.cachedSessions) {
+    if (!childIds.has(s.sessionId)) addWithChildren(s);
+  }
+  return result;
+}
+
 // --- Session switching ---
 
 function switchSession(direction) {
-  // Navigate between active sessions (idle + processing + typing) + archived
-  // Skip child sessions whose parent (or any ancestor) is collapsed
-  const byId = new Map(state.cachedSessions.map((s) => [s.sessionId, s]));
-  const isVisible = (s) => {
-    let cur = s;
-    while (cur.parentSessionId) {
-      if (!isChildrenExpanded(cur.parentSessionId)) return false;
-      cur = byId.get(cur.parentSessionId);
-      if (!cur) break;
-    }
-    return true;
-  };
-  const navigable = state.cachedSessions.filter(
+  // Navigate between visible sessions in visual (tree) order
+  const maps = buildSessionMaps();
+  const ordered = buildVisualOrder(maps);
+  const navigable = ordered.filter(
     (s) =>
-      ((s.alive &&
+      (s.alive &&
         (s.status === STATUS.IDLE ||
           s.status === STATUS.PROCESSING ||
           s.status === STATUS.TYPING)) ||
-        s.status === STATUS.ARCHIVED) &&
-      isVisible(s),
+      s.status === STATUS.ARCHIVED,
   );
   if (navigable.length === 0) return;
   const currentIndex = navigable.findIndex(
@@ -485,14 +507,7 @@ function toggleChildren() {
 
 function switchChildSession(direction) {
   if (!state.currentSessionId) return;
-  const byId = new Map(state.cachedSessions.map((s) => [s.sessionId, s]));
-  const cMap = new Map();
-  for (const s of state.cachedSessions) {
-    if (s.parentSessionId && byId.has(s.parentSessionId)) {
-      if (!cMap.has(s.parentSessionId)) cMap.set(s.parentSessionId, []);
-      cMap.get(s.parentSessionId).push(s);
-    }
-  }
+  const { byId, cMap } = buildSessionMaps();
   const current = byId.get(state.currentSessionId);
   if (!current) return;
 


### PR DESCRIPTION
## Summary
- `switchSession` (Alt+Down/Up) traversed `cachedSessions` directly, where children are interleaved by `idleTs` — not grouped under parents
- This caused navigation to skip nested sessions then jump back to them
- Fix: build flat visual-order list (parent → expanded children → next parent) matching sidebar rendering
- Extract shared `buildSessionMaps`/`buildVisualOrder` helpers for both `switchSession` and `switchChildSession`

## Test plan
- [ ] Alt+Down/Up with expanded nested sub-agents — should follow visual order exactly
- [ ] Alt+Down/Up with collapsed children — should skip them
- [ ] Multiple nesting levels — order stays consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)