### PR TITLE
Offload model-initiated sessions before user-initiated

### DIFF
--- a/src/api-handlers.js
+++ b/src/api-handlers.js
@@ -6,7 +6,7 @@ const {
   findSlotByIndex: findSlotByIndexInPool,
   resolveSlot: resolveSlotInPool,
 } = require("./pool");
-const { STATUS, POOL_STATUS } = require("./session-statuses");
+const { STATUS, POOL_STATUS, INITIATOR } = require("./session-statuses");
 const { IDLE_SIGNALS_DIR } = require("./paths");
 const { secureWriteFileSync } = require("./secure-fs");
 const {
@@ -278,7 +278,7 @@ function buildApiHandlers() {
     recordSessionRelation(
       result.sessionId,
       msg.parentSessionId || null,
-      msg.parentSessionId ? "model" : "user",
+      msg.parentSessionId ? INITIATOR.MODEL : INITIATOR.USER,
     );
     return result;
   };

--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -25,7 +25,7 @@ const {
   resolveSlot: resolveSlotInPool,
   findOffloadTarget,
 } = require("./pool");
-const { STATUS, POOL_STATUS } = require("./session-statuses");
+const { STATUS, POOL_STATUS, INITIATOR } = require("./session-statuses");
 const {
   daemonSend,
   daemonSendSafe,
@@ -261,7 +261,7 @@ function recordSessionRelation(sessionId, parentSessionId, initiator) {
   const graph = readSessionGraph();
   graph[sessionId] = {
     parentSessionId: parentSessionId || null,
-    initiator: initiator || "user",
+    initiator: initiator || INITIATOR.USER,
     createdAt: new Date().toISOString(),
   };
   writeSessionGraph(graph);
@@ -1173,6 +1173,7 @@ async function withFreshSlot(claimFn) {
     const pool = readPool();
     if (!pool) throw new Error("Pool not initialized");
     const sessions = await getSessions();
+    enrichSessionsWithGraphData(sessions);
     const sessionMap = new Map(sessions.map((s) => [s.sessionId, s]));
     return findOffloadTarget(pool, sessionMap);
   });

--- a/src/pool.js
+++ b/src/pool.js
@@ -4,7 +4,7 @@
  */
 const path = require("path");
 const fs = require("fs");
-const { STATUS, POOL_STATUS } = require("./session-statuses");
+const { STATUS, POOL_STATUS, INITIATOR } = require("./session-statuses");
 
 /**
  * Read pool.json from disk. Returns parsed object or null on failure.
@@ -223,6 +223,10 @@ function findOffloadTarget(pool, sessionMap) {
   idleSlots.sort((a, b) => {
     const sa = sessionMap.get(a.sessionId);
     const sb = sessionMap.get(b.sessionId);
+    // Prefer offloading model-initiated sessions before user-initiated
+    const ia = sa?.initiator === INITIATOR.MODEL ? 0 : 1;
+    const ib = sb?.initiator === INITIATOR.MODEL ? 0 : 1;
+    if (ia !== ib) return ia - ib;
     return (sa?.idleTs || 0) - (sb?.idleTs || 0);
   });
   const victim = idleSlots[0];

--- a/src/session-sidebar.js
+++ b/src/session-sidebar.js
@@ -11,7 +11,7 @@ import {
   toggleBellMuted,
   syncBellButton,
 } from "./renderer-state.js";
-import { STATUS } from "./session-statuses.js";
+import { STATUS, INITIATOR } from "./session-statuses.js";
 import {
   createDefaultLayout,
   TAB_EDITOR,
@@ -227,7 +227,7 @@ async function loadSessions() {
   prevSessionFingerprints = fingerprints;
 
   // Bell when a session transitions to idle (finished processing).
-  // Skip child sessions (initiator === "model") — they shouldn't ring.
+  // Skip child sessions (model-initiated) — they shouldn't ring.
   // Suppress for the currently-viewed session if the window is focused
   // and the user has been active in the last 20 seconds.
   if (oldStatuses.size > 0) {
@@ -235,7 +235,7 @@ async function loadSessions() {
     for (const s of sessions) {
       if (
         s.status === STATUS.IDLE &&
-        s.initiator !== "model" &&
+        s.initiator !== INITIATOR.MODEL &&
         oldStatuses.has(s.sessionId) &&
         oldStatuses.get(s.sessionId) !== STATUS.IDLE
       ) {

--- a/src/session-statuses.js
+++ b/src/session-statuses.js
@@ -22,4 +22,9 @@ const POOL_STATUS = {
   ERROR: "error",
 };
 
-module.exports = { STATUS, POOL_STATUS };
+const INITIATOR = {
+  USER: "user",
+  MODEL: "model",
+};
+
+module.exports = { STATUS, POOL_STATUS, INITIATOR };

--- a/test/pool.test.js
+++ b/test/pool.test.js
@@ -853,6 +853,68 @@ describe("findOffloadTarget", () => {
     const target = findOffloadTarget(pool, sessionMap);
     expect(target.sessionId).toBe("s2"); // idleTs defaults to 0 (oldest)
   });
+
+  it("offloads model-initiated sessions before user-initiated", () => {
+    const pool = createPool(3);
+    pool.slots.push(
+      { ...createSlot(0, "t1", 100), status: "idle", sessionId: "s1" },
+      { ...createSlot(1, "t2", 200), status: "idle", sessionId: "s2" },
+      { ...createSlot(2, "t3", 300), status: "idle", sessionId: "s3" },
+    );
+    const sessionMap = new Map([
+      [
+        "s1",
+        { sessionId: "s1", status: "idle", idleTs: 100, initiator: "user" },
+      ],
+      [
+        "s2",
+        { sessionId: "s2", status: "idle", idleTs: 200, initiator: "model" },
+      ],
+      [
+        "s3",
+        { sessionId: "s3", status: "idle", idleTs: 50, initiator: "user" },
+      ],
+    ]);
+    const target = findOffloadTarget(pool, sessionMap);
+    expect(target.sessionId).toBe("s2"); // model-initiated offloaded first
+  });
+
+  it("uses LRU within same initiator group", () => {
+    const pool = createPool(2);
+    pool.slots.push(
+      { ...createSlot(0, "t1", 100), status: "idle", sessionId: "s1" },
+      { ...createSlot(1, "t2", 200), status: "idle", sessionId: "s2" },
+    );
+    const sessionMap = new Map([
+      [
+        "s1",
+        { sessionId: "s1", status: "idle", idleTs: 300, initiator: "model" },
+      ],
+      [
+        "s2",
+        { sessionId: "s2", status: "idle", idleTs: 100, initiator: "model" },
+      ],
+    ]);
+    const target = findOffloadTarget(pool, sessionMap);
+    expect(target.sessionId).toBe("s2"); // s2 has earlier idleTs (LRU)
+  });
+
+  it("treats missing initiator as user-initiated", () => {
+    const pool = createPool(2);
+    pool.slots.push(
+      { ...createSlot(0, "t1", 100), status: "idle", sessionId: "s1" },
+      { ...createSlot(1, "t2", 200), status: "idle", sessionId: "s2" },
+    );
+    const sessionMap = new Map([
+      ["s1", { sessionId: "s1", status: "idle", idleTs: 100 }], // no initiator
+      [
+        "s2",
+        { sessionId: "s2", status: "idle", idleTs: 200, initiator: "model" },
+      ],
+    ]);
+    const target = findOffloadTarget(pool, sessionMap);
+    expect(target.sessionId).toBe("s2"); // model offloaded before implicit user
+  });
 });
 
 describe("readPool / writePool — edge cases", () => {


### PR DESCRIPTION
## Summary
- When the pool is full, prefer offloading agent-spawned (model-initiated) sessions before human-started ones
- Within each initiator group, LRU order is preserved (oldest idle first)
- Extracts `INITIATOR.MODEL`/`INITIATOR.USER` constants to `session-statuses.js`, replacing raw string literals across 4 files

## Test plan
- [x] 3 new unit tests covering model-first offload, LRU within group, missing initiator fallback
- [x] All 258 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)