### PR TITLE
Put cockpit-cli on PATH via SessionStart hook

### DIFF
--- a/hooks/ensure-cli-path.sh
+++ b/hooks/ensure-cli-path.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Ensure cockpit-cli is on PATH by symlinking into ~/.local/bin/.
+# Runs on SessionStart — auto-updates the symlink when the plugin version changes.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLI_SRC="$SCRIPT_DIR/../bin/cockpit-cli"
+CLI_DST="$HOME/.local/bin/cockpit-cli"
+
+[ -x "$CLI_SRC" ] || exit 0
+mkdir -p "$HOME/.local/bin"
+ln -sf "$CLI_SRC" "$CLI_DST"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,6 +6,10 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-pid-map.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/ensure-cli-path.sh"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Adds `ensure-cli-path.sh` hook that symlinks `bin/cockpit-cli` → `~/.local/bin/cockpit-cli` on every `SessionStart`
- Automatically updates the symlink when the plugin version changes (new cache dir)
- `~/.local/bin` is already on PATH in Claude sessions

## Context
The skill docs reference `cockpit-cli` as a bare command, but the binary lives in a version-specific plugin cache path that isn't on PATH. Every session had to use the full path or fail with `command not found`.

## Test plan
- [ ] Verify `which cockpit-cli` works in a new Claude session after plugin update
- [ ] Verify symlink updates correctly when plugin version bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)