### PR TITLE
Auto-detect parent session from PID ancestry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,11 +207,13 @@ Do not use `pkill -f electron`, `killall Electron`, or `grep "cwd.*$(pwd)"` (sub
 ## Session graph (parent-child tracking)
 
 Sessions track who started them and parent-child relationships in `~/.open-cockpit/session-graph.json`:
-- **initiator**: `"user"` (human via UI/terminal) or `"model"` (Claude via `cockpit-cli start`)
+- **initiator**: `"user"` (human via UI/terminal) or `"model"` (Claude via `cockpit-cli start` or Agent tool)
 - **parentSessionId**: the session that spawned this one (null for top-level)
-- CLI auto-detects parent by walking PPID chain → `~/.open-cockpit/session-pids/`
+- **Auto-detection**: `enrichSessionsWithGraphData()` walks PPID chain for sessions without graph entries, auto-detects parent from `session-pids/` mappings, and persists the relationship. Works for all sub-agent types (Agent tool, cockpit-cli, external).
+- CLI also detects parent by walking PPID chain → `~/.open-cockpit/session-pids/`
 - API: `pool-start` accepts optional `parentSessionId`; `get-session-graph` returns the full graph
 - `get-sessions` response enriched with `parentSessionId` and `initiator` fields
+- **Child session archiving**: Dead child sessions are NOT independently auto-archived — they stay under their parent and only get archived when the parent is archived (depth-first cascade)
 
 ## Session pinning
 

--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -267,15 +267,67 @@ function recordSessionRelation(sessionId, parentSessionId, initiator) {
   writeSessionGraph(graph);
 }
 
+// Walk PPID chain for a process, checking each ancestor against session-pids/.
+// Returns the parent session ID if found, null otherwise.
+function detectParentFromPidAncestry(pid) {
+  if (!pid) return null;
+  let current;
+  try {
+    current = execFileSync("ps", ["-o", "ppid=", "-p", String(pid)], {
+      encoding: "utf-8",
+      timeout: 2000,
+    }).trim();
+  } catch {
+    return null;
+  }
+  while (current && current !== "0" && current !== "1") {
+    const pidFile = path.join(SESSION_PIDS_DIR, current);
+    try {
+      return fs.readFileSync(pidFile, "utf-8").trim();
+    } catch {
+      // Not a known session — keep walking
+    }
+    try {
+      current = execFileSync("ps", ["-o", "ppid=", "-p", current], {
+        encoding: "utf-8",
+        timeout: 2000,
+      }).trim();
+    } catch {
+      break;
+    }
+  }
+  return null;
+}
+
 function enrichSessionsWithGraphData(sessions) {
   const graph = readSessionGraph();
+  let graphChanged = false;
   for (const s of sessions) {
     const rel = graph[s.sessionId];
     if (rel) {
       s.parentSessionId = rel.parentSessionId;
       s.initiator = rel.initiator;
+    } else if (s.alive && s.pid) {
+      // Session not in graph — auto-detect parent from PID ancestry.
+      // Only for alive sessions (dead PIDs can't be walked).
+      const parentId = detectParentFromPidAncestry(s.pid);
+      if (parentId && parentId !== s.sessionId) {
+        graph[s.sessionId] = {
+          parentSessionId: parentId,
+          initiator: INITIATOR.MODEL,
+          createdAt: new Date().toISOString(),
+        };
+        s.parentSessionId = parentId;
+        s.initiator = INITIATOR.MODEL;
+        graphChanged = true;
+        _debugLog(
+          "main",
+          `auto-detected parent for ${s.sessionId}: ${parentId}`,
+        );
+      }
     }
   }
+  if (graphChanged) writeSessionGraph(graph);
 }
 
 // Render raw PTY buffer into readable screen text using a headless terminal.


### PR DESCRIPTION
## Summary

- Sessions spawned by Claude's Agent tool had no graph entry — they appeared as orphans instead of nesting under their parent
- `enrichSessionsWithGraphData()` now walks the PPID chain for sessions missing from the graph
- If an ancestor PID maps to another session via `session-pids/`, the relationship is auto-detected and persisted to `session-graph.json`
- Works for all sub-agent types: Agent tool, cockpit-cli, external processes

## Root cause

Parent-child relationships were only recorded via the `pool-start` API handler. Claude Code's Agent tool spawns sub-processes directly — they get PID-mapped by the SessionStart hook, but the parent relationship was never recorded.

## Test plan

- [ ] Spawn sub-agents via Agent tool → they nest under parent in sidebar
- [ ] Spawn sub-agents via cockpit-cli start → still works (explicit recording takes precedence)
- [ ] Dead sub-agents stay under parent (not independently archived)
- [ ] Verify `session-graph.json` gets auto-populated for Agent tool sub-agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)