### PR TITLE
Add Session Info panel (⌘I)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ Electron app + Claude Code plugin for session intention tracking.
 - `src/terminal-manager.js` — Terminal creation, attach, switch, close, caching, reconnect, PTY IPC
 - `src/pool-ui.js` — Pool settings panel, slot terminal popup, shortcut settings
 - `src/command-palette.js` — COMMANDS registry, pane navigation, palette UI
+- `src/session-stats.js` — On-demand JSONL parsing, token/cost stats, sub-agent aggregation
+- `src/stats-ui.js` — Session Info overlay dialog (⌘I)
 - `src/index.html` + `src/styles.css` — Layout, neon red dark theme
 - `bin/cockpit-cli` — CLI for observing and interacting with agents. High-level commands (`ls`, `screen`, `watch`, `log`, `prompt`, `key`, `type`) + session commands (`start`, `followup`, `wait`, `pin`, `stop`) + pool management ([docs/api.md](docs/api.md))
 - `skills/cockpit-sessions/` — Skill docs for Claude Code (SKILL.md + sub-skills)

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -58,6 +58,7 @@ All shortcuts appear in the command palette (`Cmd+/`). The `COMMANDS` array in `
 | `Cmd+Alt+]` / `[` | Focus Next / Previous Pane |
 | `Alt+Right` | Toggle Child Sessions (expand/collapse) |
 | `Alt+Shift+Down` / `Up` | Next / Previous Child Session |
+| `Cmd+I` | Session Info |
 | `Cmd+Shift+B` | Toggle Bell (mute/unmute notifications) |
 | *(unbound)* | Toggle Pane Focus (editor ↔ terminal) |
 | *(unbound)* | Split Right |

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -200,6 +200,12 @@ export function initCommandPalette(actions) {
       shortcutAction: "toggle-bell",
       action: () => toggleBellMuted(),
     },
+    {
+      id: "session-info",
+      label: "Session Info",
+      shortcutAction: "session-info",
+      action: () => _actions.openSessionInfo(),
+    },
   ];
 
   // Also add Tab 1-9 commands

--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,7 @@ const daemonClient = require("./daemon-client");
 const sessionDiscovery = require("./session-discovery");
 const poolManager = require("./pool-manager");
 const apiHandlersModule = require("./api-handlers");
+const sessionStats = require("./session-stats");
 const autoUpdater = require("./auto-updater");
 const { checkFirstRun } = require("./first-run");
 
@@ -286,6 +287,11 @@ function buildMenu() {
           label: "Command Palette",
           accelerator: accel("toggle-command-palette"),
           click: () => send("toggle-command-palette"),
+        },
+        {
+          label: "Session Info",
+          accelerator: accel("session-info"),
+          click: () => send("session-info"),
         },
         {
           label: "Settings",
@@ -628,6 +634,14 @@ app.whenReady().then(async () => {
     cachedAppVersion = "unknown";
   }
   ipcMain.handle("get-app-version", () => cachedAppVersion);
+
+  // Session stats (on-demand only)
+  ipcMain.handle("get-session-stats", (_e, sessionId) =>
+    sessionStats.getSessionStats(sessionId),
+  );
+  ipcMain.handle("get-all-session-stats", () =>
+    sessionStats.getAllSessionStats(),
+  );
 
   // IPC handlers for shortcut settings
   ipcMain.handle("get-shortcuts", () => getAllShortcuts());

--- a/src/preload.js
+++ b/src/preload.js
@@ -35,6 +35,7 @@ const channels = [
   "archive-current-session",
   "open-in-cursor",
   "open-pool-settings",
+  "session-info",
   "toggle-bell",
   "pool-slots-recovered",
 ];
@@ -114,6 +115,13 @@ contextBridge.exposeInMainWorld("api", {
 
   // App info
   getAppVersion: () => ipcRenderer.invoke("get-app-version"),
+
+  // Session stats (on-demand)
+  getSessionStats: (sessionId) =>
+    ipcRenderer.invoke("get-session-stats", sessionId),
+  getAllSessionStats: () => ipcRenderer.invoke("get-all-session-stats"),
+  onOpenSessionInfo: (callback) =>
+    ipcRenderer.on("session-info", () => callback()),
 
   // Dialog state — suppresses global shortcuts while a modal is open
   setDialogOpen: (open) => ipcRenderer.send("dialog-open", open),

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -55,6 +55,7 @@ import {
   cycleTabInFocusedLeaf,
 } from "./terminal-manager.js";
 import { initPoolUi, showSettings, updatePoolHealthBadge } from "./pool-ui.js";
+import { openSessionInfo } from "./stats-ui.js";
 import {
   initCommandPalette,
   toggleCommandPalette,
@@ -755,6 +756,7 @@ initCommandPalette({
   showSettings,
   toggleChildren,
   switchChildSession,
+  openSessionInfo,
 });
 
 // Editor doc change callback
@@ -869,6 +871,7 @@ window.api.onOpenInCursor(() => {
   if (state.currentSessionCwd) window.api.openInCursor(state.currentSessionCwd);
 });
 window.api.onOpenPoolSettings(() => showSettings());
+window.api.onOpenSessionInfo(() => openSessionInfo());
 window.api.onToggleBell(toggleBellMuted);
 
 // Bell toggle button

--- a/src/session-stats.js
+++ b/src/session-stats.js
@@ -1,0 +1,314 @@
+// Session statistics — on-demand JSONL parsing and cost estimation.
+// All computation happens when explicitly requested (no background polling).
+
+const fs = require("fs");
+const readline = require("readline");
+const { execFile } = require("child_process");
+const { promisify } = require("util");
+const { findJsonlPath } = require("./session-discovery");
+const { readSessionGraph } = require("./pool-manager");
+const { CLAUDE_PROJECTS_DIR } = require("./paths");
+
+const execFileAsync = promisify(execFile);
+
+// Pricing per million tokens (USD)
+const PRICING = {
+  "claude-opus-4-6": {
+    input: 15,
+    output: 75,
+    cacheWrite: 18.75,
+    cacheRead: 1.5,
+  },
+  "claude-sonnet-4-6": {
+    input: 3,
+    output: 15,
+    cacheWrite: 3.75,
+    cacheRead: 0.3,
+  },
+  "claude-haiku-4-5": {
+    input: 0.8,
+    output: 4,
+    cacheWrite: 1,
+    cacheRead: 0.08,
+  },
+};
+
+// Fallback pricing for unknown models (use Sonnet pricing as reasonable default)
+const DEFAULT_PRICING = PRICING["claude-sonnet-4-6"];
+
+function getPricing(model) {
+  if (!model) return DEFAULT_PRICING;
+  // Match partial model names (e.g. "claude-sonnet-4-6-20250514")
+  for (const [key, pricing] of Object.entries(PRICING)) {
+    if (model.startsWith(key)) return pricing;
+  }
+  return DEFAULT_PRICING;
+}
+
+function estimateCost(tokens, model) {
+  const p = getPricing(model);
+  const perM = 1_000_000;
+  return (
+    (tokens.input * p.input) / perM +
+    (tokens.output * p.output) / perM +
+    (tokens.cacheCreation * p.cacheWrite) / perM +
+    (tokens.cacheRead * p.cacheRead) / perM
+  );
+}
+
+function emptyTokens() {
+  return { input: 0, output: 0, cacheCreation: 0, cacheRead: 0 };
+}
+
+function addTokens(a, b) {
+  return {
+    input: a.input + b.input,
+    output: a.output + b.output,
+    cacheCreation: a.cacheCreation + b.cacheCreation,
+    cacheRead: a.cacheRead + b.cacheRead,
+  };
+}
+
+// Parse a JSONL file and extract stats. Reads line-by-line to avoid
+// loading the entire file into memory.
+async function parseJsonlStats(jsonlPath) {
+  const tokens = emptyTokens();
+  const modelCounts = new Map();
+  let turns = 0;
+  let assistantMessages = 0;
+  let toolUses = 0;
+  let firstTs = null;
+  let lastTs = null;
+
+  const stream = fs.createReadStream(jsonlPath, { encoding: "utf-8" });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+  for await (const line of rl) {
+    if (!line.trim()) continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    // Track timestamps
+    if (entry.timestamp) {
+      const ts = entry.timestamp;
+      if (!firstTs || ts < firstTs) firstTs = ts;
+      if (!lastTs || ts > lastTs) lastTs = ts;
+    }
+
+    if (entry.type === "user") {
+      turns++;
+    } else if (entry.type === "assistant") {
+      assistantMessages++;
+      const msg = entry.message;
+      if (!msg) continue;
+
+      // Count model usage
+      if (msg.model) {
+        modelCounts.set(msg.model, (modelCounts.get(msg.model) || 0) + 1);
+      }
+
+      // Accumulate tokens
+      const u = msg.usage;
+      if (u) {
+        tokens.input += u.input_tokens || 0;
+        tokens.output += u.output_tokens || 0;
+        tokens.cacheCreation += u.cache_creation_input_tokens || 0;
+        tokens.cacheRead += u.cache_read_input_tokens || 0;
+      }
+
+      // Count tool uses
+      if (Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          if (block.type === "tool_use") toolUses++;
+        }
+      }
+    }
+  }
+
+  // Determine primary model (most frequent)
+  let model = null;
+  let maxCount = 0;
+  for (const [m, count] of modelCounts) {
+    if (count > maxCount) {
+      model = m;
+      maxCount = count;
+    }
+  }
+
+  // Duration in ms
+  let durationMs = 0;
+  if (firstTs && lastTs) {
+    durationMs = new Date(lastTs).getTime() - new Date(firstTs).getTime();
+  }
+
+  return {
+    tokens,
+    model,
+    turns,
+    assistantMessages,
+    toolUses,
+    durationMs,
+    estimatedCostUSD: estimateCost(tokens, model),
+  };
+}
+
+// Get stats for a single session (without sub-agents)
+async function computeSingleSessionStats(sessionId) {
+  const jsonlPath = await findJsonlPath(sessionId);
+  if (!jsonlPath) {
+    return {
+      sessionId,
+      model: null,
+      durationMs: 0,
+      turns: 0,
+      assistantMessages: 0,
+      toolUses: 0,
+      tokens: emptyTokens(),
+      estimatedCostUSD: 0,
+    };
+  }
+
+  const stats = await parseJsonlStats(jsonlPath);
+  return { sessionId, ...stats };
+}
+
+// Find all child session IDs for a given parent (from session graph)
+function findChildSessionIds(sessionId, graph) {
+  const children = [];
+  for (const [childId, entry] of Object.entries(graph)) {
+    if (entry.parentSessionId === sessionId) {
+      children.push(childId);
+    }
+  }
+  return children;
+}
+
+// Recursively find all descendant session IDs
+function findAllDescendants(sessionId, graph) {
+  const descendants = [];
+  const queue = [sessionId];
+  while (queue.length > 0) {
+    const id = queue.shift();
+    const children = findChildSessionIds(id, graph);
+    for (const childId of children) {
+      descendants.push(childId);
+      queue.push(childId);
+    }
+  }
+  return descendants;
+}
+
+// Get full stats for a session including all sub-agents
+async function getSessionStats(sessionId) {
+  const graph = readSessionGraph();
+
+  // Compute stats for the main session
+  const mainStats = await computeSingleSessionStats(sessionId);
+
+  // Find and compute sub-agent stats
+  const descendantIds = findAllDescendants(sessionId, graph);
+  const subAgentStats = await Promise.all(
+    descendantIds.map((id) => computeSingleSessionStats(id)),
+  );
+
+  // Compute totals (main session + all sub-agents)
+  let totalTokens = { ...mainStats.tokens };
+  let totalCost = mainStats.estimatedCostUSD;
+  let totalTurns = mainStats.turns;
+
+  for (const sub of subAgentStats) {
+    totalTokens = addTokens(totalTokens, sub.tokens);
+    totalCost += sub.estimatedCostUSD;
+    totalTurns += sub.turns;
+  }
+
+  return {
+    ...mainStats,
+    subAgents: subAgentStats,
+    totalWithSubAgents: {
+      tokens: totalTokens,
+      estimatedCostUSD: totalCost,
+      turns: totalTurns,
+    },
+  };
+}
+
+// Get aggregate stats across all sessions that have JSONL files
+async function getAllSessionStats() {
+  // Use `find` for fast JSONL discovery (same pattern as session-discovery.js)
+  let jsonlFiles = [];
+  try {
+    const { stdout } = await execFileAsync(
+      "find",
+      [CLAUDE_PROJECTS_DIR, "-name", "*.jsonl", "-maxdepth", "4"],
+      { encoding: "utf-8", timeout: 10000 },
+    );
+    jsonlFiles = stdout.split("\n").filter(Boolean);
+  } catch {
+    // Directory may not exist
+  }
+
+  let totalTokens = emptyTokens();
+  let totalCost = 0;
+  let totalTurns = 0;
+  let totalAssistant = 0;
+  let totalToolUses = 0;
+  let sessionCount = 0;
+  const modelCounts = new Map();
+
+  // Parse all JSONL files in parallel (batched to avoid fd exhaustion)
+  const BATCH_SIZE = 20;
+  for (let i = 0; i < jsonlFiles.length; i += BATCH_SIZE) {
+    const batch = jsonlFiles.slice(i, i + BATCH_SIZE);
+    const results = await Promise.all(
+      batch.map(async (file) => {
+        try {
+          return await parseJsonlStats(file);
+        } catch {
+          return null;
+        }
+      }),
+    );
+
+    for (const stats of results) {
+      if (!stats) continue;
+      sessionCount++;
+      totalTokens = addTokens(totalTokens, stats.tokens);
+      totalCost += stats.estimatedCostUSD;
+      totalTurns += stats.turns;
+      totalAssistant += stats.assistantMessages;
+      totalToolUses += stats.toolUses;
+      if (stats.model) {
+        modelCounts.set(
+          stats.model,
+          (modelCounts.get(stats.model) || 0) + stats.assistantMessages,
+        );
+      }
+    }
+  }
+
+  // Sort models by usage
+  const topModels = [...modelCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([model, count]) => ({ model, count }));
+
+  return {
+    sessionCount,
+    tokens: totalTokens,
+    estimatedCostUSD: totalCost,
+    turns: totalTurns,
+    assistantMessages: totalAssistant,
+    toolUses: totalToolUses,
+    topModels,
+  };
+}
+
+module.exports = {
+  getSessionStats,
+  getAllSessionStats,
+  PRICING,
+};

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -45,6 +45,8 @@ const DEFAULT_SHORTCUTS = {
   "prev-child-session": "Alt+Shift+Up",
   // Bell
   "toggle-bell": "CmdOrCtrl+Shift+B",
+  // Session info
+  "session-info": "CmdOrCtrl+I",
   // These are handled via before-input-event, not menu accelerators
   "next-terminal-tab-alt": "Ctrl+Tab",
   "prev-terminal-tab-alt": "Ctrl+Shift+Tab",

--- a/src/stats-ui.js
+++ b/src/stats-ui.js
@@ -1,0 +1,304 @@
+// Session Info overlay — on-demand stats display for the current session.
+// Triggered by ⌘I or command palette. Uses createOverlayDialog pattern.
+
+import { createOverlayDialog } from "./overlay-dialog.js";
+import { state, escapeHtml } from "./renderer-state.js";
+
+function formatNumber(n) {
+  if (n == null) return "0";
+  return n.toLocaleString("en-US");
+}
+
+function formatCost(usd) {
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
+function formatDuration(ms) {
+  if (!ms || ms <= 0) return "—";
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  if (minutes < 60) return `${minutes}m ${secs}s`;
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  return `${hours}h ${mins}m`;
+}
+
+function shortModel(model) {
+  if (!model) return "unknown";
+  // "claude-opus-4-6-20250514" → "Opus 4.6"
+  const m = model.match(/claude-(\w+)-([\d]+)-([\d]+)/);
+  if (m) return `${m[1][0].toUpperCase()}${m[1].slice(1)} ${m[2]}.${m[3]}`;
+  return escapeHtml(model);
+}
+
+function tokenTotalCount(tokens) {
+  return tokens.input + tokens.output + tokens.cacheCreation + tokens.cacheRead;
+}
+
+function renderTokenGrid(tokens, label = "Tokens") {
+  return `
+    <div class="stats-section">
+      <div class="stats-section-title">${label}</div>
+      <div class="stats-grid">
+        <div class="stats-cell">
+          <span class="stats-label">Input</span>
+          <span class="stats-value">${formatNumber(tokens.input)}</span>
+        </div>
+        <div class="stats-cell">
+          <span class="stats-label">Output</span>
+          <span class="stats-value">${formatNumber(tokens.output)}</span>
+        </div>
+        <div class="stats-cell">
+          <span class="stats-label">Cache Write</span>
+          <span class="stats-value">${formatNumber(tokens.cacheCreation)}</span>
+        </div>
+        <div class="stats-cell">
+          <span class="stats-label">Cache Read</span>
+          <span class="stats-value">${formatNumber(tokens.cacheRead)}</span>
+        </div>
+      </div>
+    </div>`;
+}
+
+function renderSubAgentRow(sub) {
+  const total = tokenTotalCount(sub.tokens);
+  return `
+    <tr>
+      <td class="stats-sub-id" title="${escapeHtml(sub.sessionId)}">${escapeHtml(sub.sessionId.slice(0, 8))}…</td>
+      <td>${shortModel(sub.model)}</td>
+      <td class="stats-num">${sub.turns}</td>
+      <td class="stats-num">${formatNumber(total)}</td>
+      <td class="stats-num">${formatCost(sub.estimatedCostUSD)}</td>
+    </tr>`;
+}
+
+function renderSessionTab(stats) {
+  const hasSubAgents = stats.subAgents && stats.subAgents.length > 0;
+
+  let subAgentsHtml = "";
+  if (hasSubAgents) {
+    subAgentsHtml = `
+      <div class="stats-section">
+        <div class="stats-section-title">Sub-Agents (${stats.subAgents.length})</div>
+        <table class="stats-table">
+          <thead>
+            <tr>
+              <th>Session</th>
+              <th>Model</th>
+              <th>Turns</th>
+              <th>Tokens</th>
+              <th>Cost</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${stats.subAgents.map(renderSubAgentRow).join("")}
+          </tbody>
+        </table>
+      </div>
+
+      <div class="stats-section stats-totals">
+        <div class="stats-section-title">Total (Session + Sub-Agents)</div>
+        <div class="stats-grid">
+          <div class="stats-cell">
+            <span class="stats-label">Turns</span>
+            <span class="stats-value">${formatNumber(stats.totalWithSubAgents.turns)}</span>
+          </div>
+          <div class="stats-cell">
+            <span class="stats-label">Tokens</span>
+            <span class="stats-value">${formatNumber(tokenTotalCount(stats.totalWithSubAgents.tokens))}</span>
+          </div>
+          <div class="stats-cell">
+            <span class="stats-label">Est. Cost</span>
+            <span class="stats-value stats-cost">${formatCost(stats.totalWithSubAgents.estimatedCostUSD)}</span>
+          </div>
+        </div>
+      </div>`;
+  }
+
+  return `
+    <div class="stats-tab-panel active" data-tab="session">
+      <div class="stats-overview">
+        <div class="stats-grid">
+          <div class="stats-cell">
+            <span class="stats-label">Model</span>
+            <span class="stats-value stats-model">${shortModel(stats.model)}</span>
+          </div>
+          <div class="stats-cell">
+            <span class="stats-label">Duration</span>
+            <span class="stats-value">${formatDuration(stats.durationMs)}</span>
+          </div>
+          <div class="stats-cell">
+            <span class="stats-label">Turns</span>
+            <span class="stats-value">${formatNumber(stats.turns)}</span>
+          </div>
+          <div class="stats-cell">
+            <span class="stats-label">Tool Uses</span>
+            <span class="stats-value">${formatNumber(stats.toolUses)}</span>
+          </div>
+          <div class="stats-cell">
+            <span class="stats-label">Est. Cost</span>
+            <span class="stats-value stats-cost">${formatCost(stats.estimatedCostUSD)}</span>
+          </div>
+        </div>
+      </div>
+      ${renderTokenGrid(stats.tokens)}
+      ${subAgentsHtml}
+    </div>`;
+}
+
+function renderAllSessionsTab(allStats) {
+  const topModelsHtml = allStats.topModels
+    .slice(0, 5)
+    .map(
+      (m) => `
+      <div class="stats-model-row">
+        <span class="stats-model">${shortModel(m.model)}</span>
+        <span class="stats-num">${formatNumber(m.count)} responses</span>
+      </div>`,
+    )
+    .join("");
+
+  return `
+    <div class="stats-tab-panel" data-tab="all">
+      <div class="stats-overview">
+        <div class="stats-grid">
+          <div class="stats-cell">
+            <span class="stats-label">Sessions</span>
+            <span class="stats-value">${formatNumber(allStats.sessionCount)}</span>
+          </div>
+          <div class="stats-cell">
+            <span class="stats-label">Turns</span>
+            <span class="stats-value">${formatNumber(allStats.turns)}</span>
+          </div>
+          <div class="stats-cell">
+            <span class="stats-label">Tool Uses</span>
+            <span class="stats-value">${formatNumber(allStats.toolUses)}</span>
+          </div>
+          <div class="stats-cell">
+            <span class="stats-label">Est. Total Cost</span>
+            <span class="stats-value stats-cost">${formatCost(allStats.estimatedCostUSD)}</span>
+          </div>
+        </div>
+      </div>
+      ${renderTokenGrid(allStats.tokens)}
+      ${
+        topModelsHtml
+          ? `
+        <div class="stats-section">
+          <div class="stats-section-title">Top Models</div>
+          ${topModelsHtml}
+        </div>`
+          : ""
+      }
+    </div>`;
+}
+
+function renderLoading() {
+  return `
+    <div class="stats-loading">
+      <span>Computing stats…</span>
+    </div>`;
+}
+
+const TABS = [
+  { id: "session", label: "Session" },
+  { id: "all", label: "All Sessions" },
+];
+
+export async function openSessionInfo() {
+  const sessionId = state.currentSessionId;
+  if (!sessionId) return;
+
+  const { overlay, close } = createOverlayDialog({
+    id: "session-info",
+    closeSelector: ".settings-close-btn",
+    html: `
+      <div class="settings-dialog stats-dialog">
+        <div class="settings-header">
+          <span>Session Info</span>
+          <button class="close-dialog-btn settings-close-btn">✕</button>
+        </div>
+        <div class="settings-layout">
+          <div class="settings-nav">
+            ${TABS.map(
+              (tab) =>
+                `<button class="settings-nav-item${tab.id === "session" ? " active" : ""}" data-tab="${tab.id}">${tab.label}</button>`,
+            ).join("")}
+          </div>
+          <div class="settings-content stats-content">
+            ${renderLoading()}
+          </div>
+        </div>
+      </div>
+    `,
+    onClose: () => window.api.setDialogOpen(false),
+  });
+
+  window.api.setDialogOpen(true);
+
+  const content = overlay.querySelector(".stats-content");
+  const navItems = overlay.querySelectorAll(".settings-nav-item");
+
+  // Tab switching + lazy loading for "All Sessions"
+  let allStatsLoaded = false;
+
+  function switchTab(tabId) {
+    navItems.forEach((btn) =>
+      btn.classList.toggle("active", btn.dataset.tab === tabId),
+    );
+    overlay
+      .querySelectorAll(".stats-tab-panel")
+      .forEach((panel) =>
+        panel.classList.toggle("active", panel.dataset.tab === tabId),
+      );
+    if (tabId === "all" && !allStatsLoaded) {
+      allStatsLoaded = true;
+      loadAllSessionStats();
+    }
+  }
+
+  navItems.forEach((btn) =>
+    btn.addEventListener("click", () => switchTab(btn.dataset.tab)),
+  );
+
+  // Load session stats (fast — single file)
+  try {
+    const stats = await window.api.getSessionStats(sessionId);
+    content.innerHTML =
+      renderSessionTab(stats) +
+      `<div class="stats-tab-panel" data-tab="all">${renderLoading()}</div>`;
+    switchTab("session");
+  } catch {
+    content.innerHTML = `<div class="stats-tab-panel active" data-tab="session">
+      <div class="stats-error">Failed to load session stats</div>
+    </div>`;
+  }
+
+  // Lazy: only loads when user clicks "All Sessions" tab
+  async function loadAllSessionStats() {
+    try {
+      const allStats = await window.api.getAllSessionStats();
+      const allPanel = overlay.querySelector(
+        '.stats-tab-panel[data-tab="all"]',
+      );
+      if (allPanel) {
+        const wasActive = allPanel.classList.contains("active");
+        const newPanel = document.createElement("div");
+        newPanel.innerHTML = renderAllSessionsTab(allStats);
+        const realPanel = newPanel.firstElementChild;
+        if (wasActive) realPanel.classList.add("active");
+        allPanel.replaceWith(realPanel);
+      }
+    } catch {
+      const allPanel = overlay.querySelector(
+        '.stats-tab-panel[data-tab="all"]',
+      );
+      if (allPanel) {
+        allPanel.innerHTML = `<div class="stats-error">Failed to load stats</div>`;
+      }
+    }
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1360,3 +1360,137 @@ body.dock-resizing-v {
     transform: translateY(10px);
   }
 }
+
+/* Session Info overlay */
+.stats-dialog {
+  width: 580px;
+}
+
+.stats-content {
+  padding: 16px;
+}
+
+.stats-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 0;
+  color: var(--text-dim);
+  font-size: 13px;
+}
+
+.stats-error {
+  padding: 20px;
+  color: var(--text-dim);
+  text-align: center;
+}
+
+.stats-tab-panel {
+  display: none;
+}
+
+.stats-tab-panel.active {
+  display: block;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.stats-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.stats-label {
+  font-size: 11px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.stats-value {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.stats-cost {
+  color: #4ec9b0;
+}
+
+.stats-model {
+  color: var(--accent);
+}
+
+.stats-section {
+  margin-top: 20px;
+}
+
+.stats-section-title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
+  margin-bottom: 10px;
+}
+
+.stats-totals {
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+}
+
+/* Sub-agent table */
+.stats-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.stats-table th {
+  text-align: left;
+  padding: 6px 8px;
+  color: var(--text-dim);
+  font-weight: 500;
+  border-bottom: 1px solid var(--border);
+}
+
+.stats-table td {
+  padding: 6px 8px;
+  color: var(--text);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.stats-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.stats-sub-id {
+  font-family: monospace;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+/* Top models in All Sessions tab */
+.stats-model-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  font-size: 13px;
+}
+
+.stats-model-row .stats-model {
+  font-weight: 500;
+}
+
+.stats-model-row .stats-num {
+  color: var(--text-dim);
+  font-size: 12px;
+}


### PR DESCRIPTION
## Summary
- New overlay dialog (⌘I) showing per-session token/cost statistics
- Token breakdown: input, output, cache write, cache read
- Estimated cost from model pricing table, duration, turns, tool uses
- Sub-agent aggregation with per-agent breakdown and totals
- Lazy-loaded "All Sessions" tab with aggregate stats across all JSONL transcripts
- All computation on-demand only — no background polling

## Test plan
- [ ] Press ⌘I on an active session — verify stats display
- [ ] Check sub-agent section appears for sessions with children
- [ ] Click "All Sessions" tab — verify lazy loading + aggregate stats
- [ ] Open command palette → "Session Info" works
- [ ] Verify in Settings > Shortcuts that ⌘I appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)