### PR TITLE
Add cross-platform support (Linux + Windows)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,4 +1,4 @@
-name: Build and release macOS .dmg
+name: Build and release
 
 on:
   push:
@@ -9,36 +9,70 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  build-mac:
     runs-on: macos-latest
-
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-
       - run: npm ci
-
       - run: npm run build
-
       - name: Build .dmg with electron-builder (ad-hoc signed)
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
         run: npx electron-builder --mac --publish never
-
-      - name: Upload .dmg artifact
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
-          name: open-cockpit-dmg
+          name: open-cockpit-mac
           path: release-builds/*.dmg
 
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Build AppImage and .deb
+        run: npx electron-builder --linux --publish never
+      - uses: actions/upload-artifact@v4
+        with:
+          name: open-cockpit-linux
+          path: |
+            release-builds/*.AppImage
+            release-builds/*.deb
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Build Windows installer
+        run: npx electron-builder --win --publish never
+      - uses: actions/upload-artifact@v4
+        with:
+          name: open-cockpit-windows
+          path: release-builds/*.exe
+
+  release:
+    needs: [build-mac, build-linux, build-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: |
-            release-builds/*.dmg
-            release-builds/*.blockmap
-            release-builds/latest-mac.yml
+          files: artifacts/**/*

--- a/package.json
+++ b/package.json
@@ -47,6 +47,17 @@
         }
       ]
     },
+    "linux": {
+      "target": [
+        "AppImage",
+        "deb"
+      ]
+    },
+    "win": {
+      "target": [
+        "nsis"
+      ]
+    },
     "dmg": {
       "title": "Open Cockpit"
     },

--- a/src/api-server.js
+++ b/src/api-server.js
@@ -1,5 +1,6 @@
 const net = require("net");
 const fs = require("fs");
+const { chmodSync } = require("./platform");
 
 const MAX_BUFFER_SIZE = 1024 * 1024; // 1MB
 
@@ -77,7 +78,7 @@ function createApiServer(socketPath, handlers, { onListening } = {}) {
   // the socket of a running instance.
   function tryListen() {
     server.listen(socketPath, () => {
-      fs.chmodSync(socketPath, 0o600);
+      chmodSync(socketPath, 0o600);
       if (onListening) onListening();
     });
   }

--- a/src/daemon-client.js
+++ b/src/daemon-client.js
@@ -1,4 +1,5 @@
 const net = require("net");
+const path = require("path");
 const fs = require("fs");
 const os = require("os");
 const { spawn: spawnChild } = require("child_process");
@@ -35,7 +36,7 @@ function isDaemonRunning() {
 
 function getDaemonExecPath() {
   if (process.platform !== "darwin") return process.execPath;
-  const link = os.homedir() + "/.open-cockpit/electron-node";
+  const link = path.join(os.homedir(), ".open-cockpit", "electron-node");
   try {
     const target = fs.readlinkSync(link);
     if (target === process.execPath) return link;

--- a/src/parse-origins.js
+++ b/src/parse-origins.js
@@ -1,3 +1,10 @@
+// Detect origin from an environment string (env vars separated by spaces or null bytes).
+function detectOrigin(envStr) {
+  if (/\bOPEN_COCKPIT_POOL=1\b/.test(envStr)) return "pool";
+  if (/\bSUB_CLAUDE=1\b/.test(envStr)) return "sub-claude";
+  return "ext";
+}
+
 // Parse ps eww output to detect session origins for given PIDs.
 function parseOrigins(psOutput, pids) {
   const results = new Map();
@@ -5,17 +12,9 @@ function parseOrigins(psOutput, pids) {
   for (const pid of pids) {
     // ps right-aligns PIDs with variable whitespace
     const pidLine = lines.find((l) => new RegExp(`^\\s*${pid}\\s`).test(l));
-    let origin = "ext";
-    if (pidLine) {
-      if (/\bOPEN_COCKPIT_POOL=1\b/.test(pidLine)) {
-        origin = "pool";
-      } else if (/\bSUB_CLAUDE=1\b/.test(pidLine)) {
-        origin = "sub-claude";
-      }
-    }
-    results.set(pid, origin);
+    results.set(pid, pidLine ? detectOrigin(pidLine) : "ext");
   }
   return results;
 }
 
-module.exports = { parseOrigins };
+module.exports = { parseOrigins, detectOrigin };

--- a/src/platform.js
+++ b/src/platform.js
@@ -1,0 +1,534 @@
+/**
+ * Platform abstraction layer — centralizes all OS-specific logic.
+ *
+ * macOS: ps eww, lsof, osascript, open -a
+ * Linux: /proc filesystem
+ * Windows: wmic, tasklist (best-effort, limited)
+ */
+
+const path = require("path");
+const os = require("os");
+const fs = require("fs");
+const { execFile } = require("child_process");
+const { promisify } = require("util");
+const execFileAsync = promisify(execFile);
+
+const IS_WINDOWS = process.platform === "win32";
+const IS_LINUX = process.platform === "linux";
+const IS_MAC = process.platform === "darwin";
+
+// --- Shell detection ---
+
+const DEFAULT_SHELLS_MAC = ["/bin/zsh", "/bin/bash", "/bin/sh"];
+const DEFAULT_SHELLS_LINUX = ["/bin/bash", "/bin/sh", "/bin/zsh"];
+const DEFAULT_SHELLS_WINDOWS = [
+  process.env.COMSPEC || "C:\\Windows\\System32\\cmd.exe",
+  "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+];
+
+function getAllowedShells() {
+  if (IS_WINDOWS) return new Set(DEFAULT_SHELLS_WINDOWS);
+  if (IS_LINUX) return new Set(DEFAULT_SHELLS_LINUX);
+  return new Set(DEFAULT_SHELLS_MAC);
+}
+
+function getDefaultShell() {
+  if (IS_WINDOWS) {
+    return process.env.COMSPEC || "C:\\Windows\\System32\\cmd.exe";
+  }
+  return process.env.SHELL || "/bin/zsh";
+}
+
+// --- PATH separator ---
+
+function joinPathEnv(dirs, existingPath) {
+  return [...dirs, existingPath || ""].join(path.delimiter);
+}
+
+// --- Extra PATH directories ---
+
+function getExtraPathDirs() {
+  const home = os.homedir();
+  const dirs = [
+    path.join(home, ".claude", "local", "bin"),
+    path.join(home, ".local", "bin"),
+  ];
+  if (!IS_WINDOWS) {
+    dirs.push("/usr/local/bin");
+  }
+  return dirs;
+}
+
+// --- Claude binary discovery ---
+
+function resolveClaudePath() {
+  const whichCmd = IS_WINDOWS ? "where" : "which";
+  try {
+    const { execFileSync } = require("child_process");
+    return execFileSync(whichCmd, ["claude"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    /* not in PATH — fall through to candidates */
+  }
+  const home = os.homedir();
+  const candidates = [
+    path.join(
+      home,
+      ".claude",
+      "local",
+      "bin",
+      IS_WINDOWS ? "claude.exe" : "claude",
+    ),
+    ...(IS_WINDOWS ? [] : ["/usr/local/bin/claude"]),
+    path.join(home, ".local", "bin", IS_WINDOWS ? "claude.exe" : "claude"),
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) return p;
+  }
+  throw new Error("Claude binary not found");
+}
+
+// --- Process CWD detection ---
+
+async function batchGetCwds(pids) {
+  const cwdMap = new Map();
+  if (pids.length === 0) return cwdMap;
+
+  if (IS_LINUX) {
+    // Use /proc/<pid>/cwd symlinks
+    for (const pid of pids) {
+      try {
+        const cwd = await fs.promises.readlink(`/proc/${pid}/cwd`);
+        cwdMap.set(String(pid), cwd);
+      } catch {
+        /* ENOENT/EACCES — process may have exited or be owned by another user */
+      }
+    }
+    return cwdMap;
+  }
+
+  if (IS_WINDOWS) {
+    // Windows: no reliable way to get CWD of another process without debug APIs.
+    // Return empty — callers fall back to JSONL-based CWD detection.
+    return cwdMap;
+  }
+
+  // macOS: lsof
+  try {
+    const { stdout } = await execFileAsync(
+      "lsof",
+      ["-a", "-p", pids.join(","), "-d", "cwd", "-F", "pn"],
+      { encoding: "utf-8", timeout: 5000 },
+    );
+    let currentPid = null;
+    for (const line of stdout.split("\n")) {
+      if (line.startsWith("p")) {
+        currentPid = line.slice(1);
+      } else if (line.startsWith("n") && currentPid) {
+        cwdMap.set(currentPid, line.slice(1));
+      }
+    }
+  } catch (err) {
+    console.error(
+      "[platform] lsof failed to resolve session cwds:",
+      err.message,
+    );
+  }
+  return cwdMap;
+}
+
+// Synchronous single-PID CWD lookup (used by saveExternalClearOffload)
+function getCwdSync(pid) {
+  if (IS_LINUX) {
+    try {
+      return fs.readlinkSync(`/proc/${pid}/cwd`);
+    } catch {
+      return null;
+    }
+  }
+
+  if (IS_WINDOWS) {
+    return null;
+  }
+
+  // macOS: lsof
+  try {
+    const { execFileSync } = require("child_process");
+    const output = execFileSync(
+      "lsof",
+      ["-a", "-p", String(pid), "-d", "cwd", "-F", "n"],
+      { encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] },
+    );
+    const m = output.match(/^n(.+)$/m);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+// --- Process environment detection (for origin tagging) ---
+
+// Returns { format: "per-pid", byPid: Map<string, string> } on Linux,
+//         { format: "raw-ps", raw: string } on macOS,
+//         { format: "unavailable" } on Windows.
+async function batchGetProcessEnvs(pids) {
+  if (pids.length === 0) return { format: "unavailable" };
+
+  if (IS_LINUX) {
+    const byPid = new Map();
+    // Read /proc/<pid>/environ in parallel
+    await Promise.all(
+      pids.map(async (pid) => {
+        try {
+          const raw = await fs.promises.readFile(
+            `/proc/${pid}/environ`,
+            "utf-8",
+          );
+          // Replace null bytes with spaces so regex matching works
+          byPid.set(String(pid), raw.replace(/\0/g, " "));
+        } catch {
+          /* ENOENT/EACCES — process may have exited */
+        }
+      }),
+    );
+    return { format: "per-pid", byPid };
+  }
+
+  if (IS_WINDOWS) {
+    // Windows: reading another process's environment requires debug APIs.
+    return { format: "unavailable" };
+  }
+
+  // macOS: ps eww — single call returns all PIDs
+  try {
+    const { stdout } = await execFileAsync(
+      "ps",
+      ["eww", "-p", pids.join(",")],
+      { encoding: "utf-8", timeout: 3000 },
+    );
+    return { format: "raw-ps", raw: stdout };
+  } catch {
+    /* ps failed — callers default to "ext" */
+    return { format: "unavailable" };
+  }
+}
+
+// --- Process tree walking (for terminal app detection) ---
+
+function getParentPidSync(pid) {
+  if (IS_LINUX) {
+    try {
+      const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf-8");
+      const match = stat.match(/^\d+\s+\(.+?\)\s+\S+\s+(\d+)/);
+      return match ? match[1] : null;
+    } catch {
+      return null;
+    }
+  }
+  // macOS and Windows
+  const { execFileSync } = require("child_process");
+  if (IS_WINDOWS) {
+    try {
+      const stdout = execFileSync(
+        "wmic",
+        [
+          "process",
+          "where",
+          `ProcessId=${pid}`,
+          "get",
+          "ParentProcessId",
+          "/value",
+        ],
+        { encoding: "utf-8", timeout: 2000 },
+      );
+      const match = stdout.match(/ParentProcessId=(\d+)/);
+      return match ? match[1] : null;
+    } catch {
+      return null;
+    }
+  }
+  try {
+    return (
+      execFileSync("ps", ["-o", "ppid=", "-p", String(pid)], {
+        encoding: "utf-8",
+        timeout: 2000,
+      }).trim() || null
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function getParentPid(pid) {
+  if (IS_LINUX) {
+    try {
+      const stat = await fs.promises.readFile(`/proc/${pid}/stat`, "utf-8");
+      // Format: pid (comm) state ppid ...
+      const match = stat.match(/^\d+\s+\(.+?\)\s+\S+\s+(\d+)/);
+      return match ? match[1] : null;
+    } catch {
+      return null;
+    }
+  }
+
+  if (IS_WINDOWS) {
+    try {
+      const { stdout } = await execFileAsync(
+        "wmic",
+        [
+          "process",
+          "where",
+          `ProcessId=${pid}`,
+          "get",
+          "ParentProcessId",
+          "/value",
+        ],
+        { encoding: "utf-8", timeout: 3000 },
+      );
+      const match = stdout.match(/ParentProcessId=(\d+)/);
+      return match ? match[1] : null;
+    } catch {
+      return null;
+    }
+  }
+
+  // macOS
+  try {
+    const { stdout } = await execFileAsync(
+      "ps",
+      ["-p", String(pid), "-o", "ppid="],
+      { timeout: 3000 },
+    );
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function getProcessName(pid) {
+  if (IS_LINUX) {
+    try {
+      const comm = await fs.promises.readFile(`/proc/${pid}/comm`, "utf-8");
+      return comm.trim();
+    } catch {
+      return null;
+    }
+  }
+
+  if (IS_WINDOWS) {
+    try {
+      const { stdout } = await execFileAsync(
+        "wmic",
+        ["process", "where", `ProcessId=${pid}`, "get", "Name", "/value"],
+        { encoding: "utf-8", timeout: 3000 },
+      );
+      const match = stdout.match(/Name=(.+)/);
+      return match ? match[1].trim() : null;
+    } catch {
+      return null;
+    }
+  }
+
+  // macOS
+  try {
+    const { stdout } = await execFileAsync(
+      "ps",
+      ["-p", String(pid), "-o", "comm="],
+      { timeout: 3000 },
+    );
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+// --- TTY detection (for iTerm integration — macOS only) ---
+
+async function getProcessTty(pid) {
+  if (!IS_MAC) return null;
+  try {
+    const { stdout } = await execFileAsync(
+      "ps",
+      ["-p", String(pid), "-o", "tty="],
+      { timeout: 3000 },
+    );
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+// --- App activation (macOS-only, no-op elsewhere) ---
+
+async function activateApp(appName) {
+  if (!IS_MAC) return false;
+  try {
+    await execFileAsync("osascript", [
+      "-e",
+      `tell application "${appName}" to activate`,
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// --- Open file/folder in editor (cross-platform) ---
+
+async function openInApp(appName, target) {
+  if (IS_MAC) {
+    await execFileAsync("open", ["-a", appName, target]);
+    return;
+  }
+  if (IS_LINUX) {
+    // Try launching the app directly (e.g., "cursor", "code")
+    const cmd = appName.toLowerCase().replace(/\s+/g, "");
+    const { spawn: spawnChild } = require("child_process");
+    spawnChild(cmd, [target], { detached: true, stdio: "ignore" }).unref();
+    return;
+  }
+  // Windows
+  const { spawn: spawnChild } = require("child_process");
+  spawnChild("cmd", ["/c", "start", "", appName, target], {
+    detached: true,
+    stdio: "ignore",
+  }).unref();
+}
+
+// --- iTerm2 AppleScript interaction (macOS-only) ---
+
+async function withITermSessionByTty(tty, action, resultValue) {
+  if (!IS_MAC) return null;
+  if (!tty || tty === "??" || !/^ttys?\d+$/.test(tty)) return null;
+  try {
+    const { stdout } = await execFileAsync(
+      "osascript",
+      [
+        "-e",
+        `tell application "System Events"
+  if not (exists process "iTerm2") then return "not_running"
+end tell
+tell application "iTerm"
+  repeat with w in windows
+    repeat with t in tabs of w
+      repeat with s in sessions of t
+        if tty of s ends with "${tty}" then
+          ${action}
+          return "${resultValue}"
+        end if
+      end repeat
+    end repeat
+  end repeat
+  return "not_found"
+end tell`,
+      ],
+      { timeout: 3000 },
+    );
+    if (stdout.trim() === resultValue) return { app: "iTerm" };
+  } catch (err) {
+    console.error(
+      `[platform] iTerm ${resultValue} via osascript failed:`,
+      err.message,
+    );
+  }
+  return null;
+}
+
+// --- File read with tail (cross-platform) ---
+
+async function readFileTail(filePath, lineCount) {
+  if (IS_WINDOWS) {
+    // Use PowerShell's Get-Content -Tail for efficiency on large files
+    try {
+      const { stdout } = await execFileAsync(
+        "powershell",
+        [
+          "-NoProfile",
+          "-Command",
+          `Get-Content '${filePath}' -Tail ${lineCount}`,
+        ],
+        { encoding: "utf-8", timeout: 5000 },
+      );
+      return stdout;
+    } catch {
+      return "";
+    }
+  }
+  // Unix: use tail for efficiency on large files
+  try {
+    const { stdout } = await execFileAsync(
+      "tail",
+      [`-${lineCount}`, filePath],
+      { encoding: "utf-8", timeout: 3000 },
+    );
+    return stdout;
+  } catch {
+    return "";
+  }
+}
+
+// --- File search (cross-platform replacement for find) ---
+
+async function findFileRecursive(dir, filename) {
+  // Use Node.js recursive readdir instead of shell `find`
+  try {
+    const entries = await fs.promises.readdir(dir, {
+      withFileTypes: true,
+      recursive: true,
+    });
+    for (const entry of entries) {
+      if (entry.name === filename) {
+        // entry.parentPath available in Node 20+
+        const parentPath = entry.parentPath || entry.path;
+        return path.join(parentPath, entry.name);
+      }
+    }
+  } catch {
+    /* ENOENT or permission error — directory may not exist */
+  }
+  return null;
+}
+
+// --- File permissions (no-op on Windows) ---
+
+function chmodSync(filePath, mode) {
+  if (IS_WINDOWS) return; // Windows uses ACLs, chmod is a no-op
+  fs.chmodSync(filePath, mode);
+}
+
+// --- Root path check ---
+
+function isRootPath(p) {
+  if (IS_WINDOWS) {
+    // C:\, D:\, etc.
+    return /^[A-Za-z]:\\?$/.test(p);
+  }
+  return p === "/";
+}
+
+module.exports = {
+  IS_WINDOWS,
+  IS_LINUX,
+  IS_MAC,
+  getAllowedShells,
+  getDefaultShell,
+  joinPathEnv,
+  getExtraPathDirs,
+  resolveClaudePath,
+  batchGetCwds,
+  getCwdSync,
+  batchGetProcessEnvs,
+  getParentPid,
+  getParentPidSync,
+  getProcessName,
+  getProcessTty,
+  activateApp,
+  openInApp,
+  withITermSessionByTty,
+  readFileTail,
+  findFileRecursive,
+  chmodSync,
+  isRootPath,
+};

--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -9,6 +9,7 @@ const {
 } = require("child_process");
 const { promisify } = require("util");
 const execFileAsync = promisify(execFile);
+const platform = require("./platform");
 const { Terminal: HeadlessTerminal } = require("@xterm/headless");
 const { createPoolLock } = require("./pool-lock");
 const { secureMkdirSync, secureWriteFileSync } = require("./secure-fs");
@@ -273,10 +274,7 @@ function detectParentFromPidAncestry(pid) {
   if (!pid) return null;
   let current;
   try {
-    current = execFileSync("ps", ["-o", "ppid=", "-p", String(pid)], {
-      encoding: "utf-8",
-      timeout: 2000,
-    }).trim();
+    current = platform.getParentPidSync(String(pid));
   } catch {
     return null;
   }
@@ -288,10 +286,7 @@ function detectParentFromPidAncestry(pid) {
       // Not a known session — keep walking
     }
     try {
-      current = execFileSync("ps", ["-o", "ppid=", "-p", current], {
-        encoding: "utf-8",
-        timeout: 2000,
-      }).trim();
+      current = platform.getParentPidSync(current);
     } catch {
       break;
     }
@@ -419,21 +414,7 @@ async function saveExternalClearOffload(oldSessionId, pid) {
   // Gather what metadata we can
   let cwd = null;
   if (pid) {
-    try {
-      const lsof = execFileSync(
-        "lsof",
-        ["-a", "-p", String(pid), "-d", "cwd", "-F", "n"],
-        { encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] },
-      );
-      const m = lsof.match(/^n(.+)$/m);
-      if (m) cwd = m[1];
-    } catch (err) {
-      console.error(
-        "[main] lsof failed to resolve cwd for PID",
-        pid,
-        err.message,
-      );
-    }
+    cwd = platform.getCwdSync(pid);
   }
 
   await writeOffloadMeta(oldSessionId, {
@@ -574,23 +555,7 @@ function readOffloadMeta(sessionId) {
 // --- Pool Management ---
 
 function resolveClaudePath() {
-  try {
-    return execFileSync("which", ["claude"], {
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "ignore"],
-    }).trim();
-  } catch {
-    /* `which` fails if claude not in PATH — fall through to candidates */
-  }
-  const candidates = [
-    path.join(os.homedir(), ".claude", "local", "bin", "claude"),
-    "/usr/local/bin/claude",
-    path.join(os.homedir(), ".local", "bin", "claude"),
-  ];
-  for (const p of candidates) {
-    if (fs.existsSync(p)) return p;
-  }
-  throw new Error("Claude binary not found");
+  return platform.resolveClaudePath();
 }
 
 function readPool() {
@@ -1396,7 +1361,7 @@ async function openInCursor(cwd) {
     `${projectName}.code-workspace`,
   );
   if (fs.existsSync(namedWorkspace)) {
-    await execFileAsync("open", ["-a", "Cursor", namedWorkspace]);
+    await platform.openInApp("Cursor", namedWorkspace);
     return;
   }
 
@@ -1405,7 +1370,7 @@ async function openInCursor(cwd) {
     const entries = fs.readdirSync(cwd);
     const localWs = entries.find((e) => e.endsWith(".code-workspace"));
     if (localWs) {
-      await execFileAsync("open", ["-a", "Cursor", path.join(cwd, localWs)]);
+      await platform.openInApp("Cursor", path.join(cwd, localWs));
       return;
     }
   } catch {
@@ -1413,63 +1378,14 @@ async function openInCursor(cwd) {
   }
 
   // Fall back to opening the folder
-  await execFileAsync("open", ["-a", "Cursor", cwd]);
+  await platform.openInApp("Cursor", cwd);
 }
 
 // Run an AppleScript action on the iTerm session matching a PID's TTY.
-// `action` is the AppleScript code to run inside the matched session block (has vars w, t, s).
-// `resultValue` is the string the AppleScript returns on success.
-// Returns { app: "iTerm" } on success, null otherwise.
+// macOS-only — returns null on other platforms.
 async function withITermSessionByPid(pid, action, resultValue) {
-  const EXEC_TIMEOUT = 3000;
-
-  let tty;
-  try {
-    const { stdout } = await execFileAsync(
-      "ps",
-      ["-p", String(pid), "-o", "tty="],
-      {
-        timeout: EXEC_TIMEOUT,
-      },
-    );
-    tty = stdout.trim();
-  } catch {
-    return null;
-  }
-  if (!tty || tty === "??" || !/^ttys?\d+$/.test(tty)) return null;
-
-  try {
-    const { stdout } = await execFileAsync(
-      "osascript",
-      [
-        "-e",
-        `tell application "System Events"
-  if not (exists process "iTerm2") then return "not_running"
-end tell
-tell application "iTerm"
-  repeat with w in windows
-    repeat with t in tabs of w
-      repeat with s in sessions of t
-        if tty of s ends with "${tty}" then
-          ${action}
-          return "${resultValue}"
-        end if
-      end repeat
-    end repeat
-  end repeat
-  return "not_found"
-end tell`,
-      ],
-      { timeout: EXEC_TIMEOUT },
-    );
-    if (stdout.trim() === resultValue) return { app: "iTerm" };
-  } catch (err) {
-    console.error(
-      `[main] iTerm ${resultValue} via osascript failed:`,
-      err.message,
-    );
-  }
-  return null;
+  const tty = await platform.getProcessTty(pid);
+  return platform.withITermSessionByTty(tty, action, resultValue);
 }
 
 // Close the external terminal where a Claude session is running.
@@ -1502,11 +1418,10 @@ async function focusExternalTerminal(pid) {
   if (match) return { focused: true, ...match };
 
   // Try Cursor / VS Code: walk process tree to find terminal app ancestor
-  const EXEC_TIMEOUT = 3000;
   const TERMINAL_APPS = [
-    { match: /\/Cursor(\.app\/|\s|$)/, app: "Cursor", activate: "Cursor" },
+    { match: /\bCursor(\.app)?\b/, app: "Cursor", activate: "Cursor" },
     {
-      match: /\/Code(\.app\/|\s|$)/,
+      match: /\bCode(\.app)?\b/,
       app: "VS Code",
       activate: "Visual Studio Code",
     },
@@ -1514,26 +1429,15 @@ async function focusExternalTerminal(pid) {
   try {
     let checkPid = String(pid);
     for (let i = 0; i < 10; i++) {
-      const { stdout: ppidOut } = await execFileAsync(
-        "ps",
-        ["-p", checkPid, "-o", "ppid="],
-        { timeout: EXEC_TIMEOUT },
-      );
-      const ppid = ppidOut.trim();
+      const ppid = await platform.getParentPid(checkPid);
       if (!ppid || ppid === "0" || ppid === "1") break;
-      const { stdout: pnameOut } = await execFileAsync(
-        "ps",
-        ["-p", ppid, "-o", "comm="],
-        { timeout: EXEC_TIMEOUT },
-      );
-      const pname = pnameOut.trim();
-      for (const { match: m, app, activate } of TERMINAL_APPS) {
-        if (m.test(pname)) {
-          await execFileAsync("osascript", [
-            "-e",
-            `tell application "${activate}" to activate`,
-          ]);
-          return { focused: true, app };
+      const pname = await platform.getProcessName(ppid);
+      if (pname) {
+        for (const { match: m, app, activate } of TERMINAL_APPS) {
+          if (m.test(pname)) {
+            await platform.activateApp(activate);
+            return { focused: true, app };
+          }
         }
       }
       checkPid = ppid;

--- a/src/pool.js
+++ b/src/pool.js
@@ -21,9 +21,17 @@ function readPool(poolFile) {
  * Write pool.json atomically (write to tmp, then rename).
  */
 function writePool(poolFile, pool) {
-  fs.mkdirSync(path.dirname(poolFile), { recursive: true, mode: 0o700 });
+  const { IS_WINDOWS } = require("./platform");
+  fs.mkdirSync(path.dirname(poolFile), {
+    recursive: true,
+    ...(IS_WINDOWS ? {} : { mode: 0o700 }),
+  });
   const tmp = poolFile + ".tmp";
-  fs.writeFileSync(tmp, JSON.stringify(pool, null, 2), { mode: 0o600 });
+  fs.writeFileSync(
+    tmp,
+    JSON.stringify(pool, null, 2),
+    IS_WINDOWS ? {} : { mode: 0o600 },
+  );
   fs.renameSync(tmp, poolFile);
 }
 

--- a/src/pty-daemon.js
+++ b/src/pty-daemon.js
@@ -15,17 +15,20 @@ const fs = require("fs");
 const os = require("os");
 const { secureMkdirSync, secureWriteFileSync } = require("./secure-fs");
 const pty = require("node-pty");
+const {
+  getAllowedShells,
+  getDefaultShell,
+  joinPathEnv,
+  getExtraPathDirs,
+  chmodSync,
+} = require("./platform");
 
 const OPEN_COCKPIT_DIR = path.join(os.homedir(), ".open-cockpit");
 const SOCKET_PATH = path.join(OPEN_COCKPIT_DIR, "pty-daemon.sock");
 const BUFFER_SIZE = 100_000; // bytes of output to buffer per terminal for replay
 const IDLE_TIMEOUT_MS = 30 * 60 * 1000; // exit after 30 min with no terminals and no clients
-const ALLOWED_SHELLS = new Set(["/bin/zsh", "/bin/bash", "/bin/sh"]);
-const EXTRA_PATH_DIRS = [
-  path.join(os.homedir(), ".claude", "local", "bin"),
-  path.join(os.homedir(), ".local", "bin"),
-  "/usr/local/bin",
-];
+const ALLOWED_SHELLS = getAllowedShells();
+const EXTRA_PATH_DIRS = getExtraPathDirs();
 
 function isAllowedCmd(cmd) {
   if (ALLOWED_SHELLS.has(cmd)) return true;
@@ -105,10 +108,7 @@ function cleanup() {
 // --- Command handlers ---
 
 function handleSpawn(socket, msg) {
-  const shell =
-    msg.cmd && isAllowedCmd(msg.cmd)
-      ? msg.cmd
-      : process.env.SHELL || "/bin/zsh";
+  const shell = msg.cmd && isAllowedCmd(msg.cmd) ? msg.cmd : getDefaultShell();
   const args = msg.args || [];
   const cwd = msg.cwd || os.homedir();
   const termId = nextTermId++;
@@ -117,7 +117,7 @@ function handleSpawn(socket, msg) {
   const cleanEnv = { ...process.env, TERM: "xterm-256color" };
   delete cleanEnv.CLAUDECODE;
   delete cleanEnv.CLAUDE_CODE_SESSION_ID;
-  cleanEnv.PATH = [...EXTRA_PATH_DIRS, process.env.PATH || ""].join(":");
+  cleanEnv.PATH = joinPathEnv(EXTRA_PATH_DIRS, process.env.PATH);
 
   // Merge caller-provided env overrides (e.g. OPEN_COCKPIT_POOL for origin tagging)
   if (msg.env && typeof msg.env === "object") {
@@ -435,7 +435,7 @@ function startServer() {
 
   server.listen(SOCKET_PATH, () => {
     // Restrict socket to owner only
-    fs.chmodSync(SOCKET_PATH, 0o600);
+    chmodSync(SOCKET_PATH, 0o600);
     console.log(`[pty-daemon] Listening on ${SOCKET_PATH}`);
     // Write PID file so clients can check if daemon is alive
     secureWriteFileSync(

--- a/src/secure-fs.js
+++ b/src/secure-fs.js
@@ -1,12 +1,17 @@
 // Secure file helpers — restrict to owner-only access (#210)
+// On Windows, mode is ignored (ACLs handle permissions).
 const fs = require("fs");
+const { IS_WINDOWS } = require("./platform");
 
 function secureMkdirSync(dirPath, opts = {}) {
-  fs.mkdirSync(dirPath, { ...opts, mode: 0o700 });
+  fs.mkdirSync(dirPath, { ...opts, ...(IS_WINDOWS ? {} : { mode: 0o700 }) });
 }
 
 function secureWriteFileSync(filePath, data, opts) {
-  fs.writeFileSync(filePath, data, { ...opts, mode: 0o600 });
+  fs.writeFileSync(filePath, data, {
+    ...opts,
+    ...(IS_WINDOWS ? {} : { mode: 0o600 }),
+  });
 }
 
 module.exports = { secureMkdirSync, secureWriteFileSync };

--- a/src/session-discovery.js
+++ b/src/session-discovery.js
@@ -1,11 +1,15 @@
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
-const { execFile } = require("child_process");
-const { promisify } = require("util");
-const execFileAsync = promisify(execFile);
+const {
+  batchGetCwds: platformBatchGetCwds,
+  batchGetProcessEnvs,
+  readFileTail,
+  findFileRecursive,
+  isRootPath,
+} = require("./platform");
 const { sortSessions } = require("./sort-sessions");
-const { parseOrigins } = require("./parse-origins");
+const { parseOrigins, detectOrigin } = require("./parse-origins");
 const {
   parseTerminalHasInput,
   checkTerminalInputs,
@@ -209,8 +213,8 @@ function triggerPollOnWrite(termId) {
   }, TERMINAL_WRITE_DEBOUNCE_MS);
 }
 
-// Detect session origin by reading process environment via ps eww (macOS).
-// Batched: resolves all uncached PIDs in a single subprocess call.
+// Detect session origin by reading process environment.
+// macOS: ps eww, Linux: /proc/<pid>/environ, Windows: best-effort (defaults to "ext").
 async function batchDetectOrigins(pids) {
   const results = new Map();
   const uncached = [];
@@ -224,21 +228,30 @@ async function batchDetectOrigins(pids) {
   }
   if (uncached.length > 0) {
     try {
-      const { stdout } = await execFileAsync(
-        "ps",
-        ["eww", "-p", uncached.join(",")],
-        { encoding: "utf-8", timeout: 3000 },
-      );
-      const parsed = parseOrigins(stdout, uncached);
-      for (const [pid, origin] of parsed) {
-        originCache.set(pid, origin);
-        results.set(pid, origin);
+      const envData = await batchGetProcessEnvs(uncached);
+      if (envData.format === "raw-ps") {
+        // macOS: raw ps eww output for parseOrigins
+        const parsed = parseOrigins(envData.raw, uncached);
+        for (const [pid, origin] of parsed) {
+          originCache.set(pid, origin);
+          results.set(pid, origin);
+        }
+      } else if (envData.format === "per-pid") {
+        // Linux: per-PID environ strings
+        for (const pid of uncached) {
+          const origin = detectOrigin(envData.byPid.get(pid) || "");
+          originCache.set(pid, origin);
+          results.set(pid, origin);
+        }
+      } else {
+        // Windows/unavailable: default to ext
+        for (const pid of uncached) {
+          originCache.set(pid, "ext");
+          results.set(pid, "ext");
+        }
       }
     } catch (err) {
-      console.error(
-        "[main] Failed to detect session origins via ps:",
-        err.message,
-      );
+      console.error("[main] Failed to detect session origins:", err.message);
       for (const pid of uncached) {
         originCache.set(pid, "ext");
         results.set(pid, "ext");
@@ -251,12 +264,10 @@ async function batchDetectOrigins(pids) {
 async function findJsonlPath(sessionId) {
   if (jsonlPathCache.has(sessionId)) return jsonlPathCache.get(sessionId);
   try {
-    const { stdout: findOut } = await execFileAsync(
-      "find",
-      [CLAUDE_PROJECTS_DIR, "-name", `${sessionId}.jsonl`],
-      { encoding: "utf-8", timeout: 5000 },
+    const jsonlPath = await findFileRecursive(
+      CLAUDE_PROJECTS_DIR,
+      `${sessionId}.jsonl`,
     );
-    const jsonlPath = findOut.split("\n")[0].trim();
     if (jsonlPath) jsonlPathCache.set(sessionId, jsonlPath);
     return jsonlPath || null;
   } catch (err) {
@@ -291,10 +302,7 @@ async function getCwdFromJsonl(sessionId) {
     const jsonlPath = await findJsonlPath(sessionId);
     if (!jsonlPath) return null;
 
-    const { stdout: tail } = await execFileAsync("tail", ["-100", jsonlPath], {
-      encoding: "utf-8",
-      timeout: 3000,
-    });
+    const tail = await readFileTail(jsonlPath, 100);
     let cwd = "";
     for (const line of tail.split("\n")) {
       if (!line.trim()) continue;
@@ -517,29 +525,9 @@ async function findGitRoot(cwd) {
   return null;
 }
 
-// Batch lsof: get CWDs for all PIDs in one call (async, non-blocking)
+// Batch CWD detection: lsof on macOS, /proc on Linux, no-op on Windows
 async function batchGetCwds(pids) {
-  const cwdMap = new Map();
-  if (pids.length === 0) return cwdMap;
-  try {
-    const { stdout } = await execFileAsync(
-      "lsof",
-      ["-a", "-p", pids.join(","), "-d", "cwd", "-F", "pn"],
-      { encoding: "utf-8", timeout: 5000 },
-    );
-    // Parse lsof -F pn output: lines starting with 'p' = PID, 'n' = path
-    let currentPid = null;
-    for (const line of stdout.split("\n")) {
-      if (line.startsWith("p")) {
-        currentPid = line.slice(1);
-      } else if (line.startsWith("n") && currentPid) {
-        cwdMap.set(currentPid, line.slice(1));
-      }
-    }
-  } catch (err) {
-    console.error("[main] lsof failed to resolve session cwds:", err.message);
-  }
-  return cwdMap;
+  return platformBatchGetCwds(pids);
 }
 
 // Internal — not exported. Use getSessions() from other modules.
@@ -585,7 +573,7 @@ async function getSessionsUncached() {
     let cwd = alive ? cwdMap.get(String(pid)) || null : null;
 
     // Refine CWD via JSONL when lsof reports a generic directory
-    if (!cwd || cwd === os.homedir() || cwd === "/") {
+    if (!cwd || cwd === os.homedir() || isRootPath(cwd)) {
       const refined = await getCwdFromJsonl(sessionId);
       if (refined && fs.existsSync(refined) && refined !== os.homedir()) {
         cwd = refined;


### PR DESCRIPTION
## Summary

- Adds `src/platform.js` — centralized platform abstraction layer replacing all macOS-specific shell commands (`ps eww`, `lsof`, `osascript`, `open`, `find`, `tail`, `which`)
- Linux support: uses `/proc` filesystem for process introspection, `readlink` for CWD, native `tail`
- Windows support: uses `wmic` for process tree walking, PowerShell for file tail, `where` for binary discovery
- macOS-only features (iTerm AppleScript, app activation) gracefully no-op on other platforms
- Build targets now include Linux (AppImage, deb) and Windows (nsis)
- CI matrix builds on macOS, Ubuntu, and Windows runners

## Files changed

- **New**: `src/platform.js` — all platform-specific logic centralized here
- **Updated**: `src/pty-daemon.js`, `src/session-discovery.js`, `src/pool-manager.js`, `src/daemon-client.js`, `src/api-server.js`, `src/secure-fs.js`, `src/pool.js`, `src/parse-origins.js`
- **Updated**: `package.json` (build targets), `.github/workflows/build-release.yml` (matrix CI)

## Test plan

- [x] All 290 existing tests pass
- [x] Build succeeds
- [ ] Manual test on macOS (production app)
- [ ] Verify Linux AppImage builds in CI
- [ ] Verify Windows installer builds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)