### PR TITLE
fix: add author email for .deb build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "open-cockpit",
   "version": "0.2.0",
   "description": "Session cockpit for Claude Code",
-  "author": "Elias Schlie",
+  "author": "Elias Schlie <elias@eliasschlie.com>",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Adds author email to `package.json` (`Elias Schlie <elias@eliasschlie.com>`)
- Fixes Linux `.deb` build failure: `electron-builder` requires an email to set the package maintainer

## Test plan
- [x] All 290 tests pass
- [ ] Linux CI build succeeds with `.deb` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)