### PR TITLE
chore: bump package.json to 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-cockpit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-cockpit",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-cockpit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Session cockpit for Claude Code",
   "author": "Elias Schlie <elias@eliasschlie.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps `package.json` version from `0.2.0` → `0.2.1` to match the release tag
- Ensures electron-builder produces correctly versioned binary filenames (e.g. `Open.Cockpit-0.2.1.dmg` instead of `0.2.0`)

## Test plan
- [x] All 290 tests pass
- [ ] Next tag push produces binaries with `0.2.1` in filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)