### PR TITLE
fix: prevent scrambled terminal display on new pool sessions

### DIFF
--- a/src/dock-helpers.js
+++ b/src/dock-helpers.js
@@ -83,6 +83,8 @@ export function setupTerminalResize(entry) {
         prevCols = cols;
         prevRows = rows;
         window.api.ptyResize(entry.termId, cols, rows);
+        // Report dims so future pool spawns use actual terminal size
+        window.api.reportTerminalDims(cols, rows);
       } else {
         // Dimensions unchanged — force repaint for DOM reattachment cases
         // where the canvas renderer is stale. Skipped when dimensions changed

--- a/src/main.js
+++ b/src/main.js
@@ -480,6 +480,12 @@ app.whenReady().then(async () => {
     debugLog(tag, ...args);
   });
 
+  // Terminal dimensions: renderer reports actual cols/rows so pool spawns
+  // can use them instead of the 80×24 daemon default.
+  ipcMain.on("report-terminal-dims", (_e, cols, rows) => {
+    poolManager.setTerminalDims(cols, rows);
+  });
+
   // --- Register shared IPC handlers ---
   const { sharedHandlers, ipcArgMap } = apiHandlersModule;
   for (const [name, argMapper] of Object.entries(ipcArgMap)) {

--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -66,6 +66,14 @@ let _cachedClaudePath = null;
 const lastWrittenContent = new Map();
 const fileWatchers = new Map();
 
+// Last-known terminal dimensions from the renderer, used when spawning pool
+// PTYs so they start at the actual window size instead of the 80×24 default.
+let _terminalDims = null;
+
+function setTerminalDims(cols, rows) {
+  _terminalDims = { cols, rows };
+}
+
 const { withPoolLock } = createPoolLock(POOL_FILE);
 
 // Poll a condition until it returns a truthy value, with timeout.
@@ -598,12 +606,16 @@ function getCachedClaudePath() {
 // Spawn a single Claude session via the PTY daemon. Returns a slot object.
 async function spawnPoolSlot(index) {
   const claudePath = getCachedClaudePath();
+  const dims = _terminalDims;
   const resp = await daemonRequest({
     type: "spawn",
     cwd: os.homedir(),
     cmd: claudePath,
     args: ["--dangerously-skip-permissions"],
     env: { OPEN_COCKPIT_POOL: "1" },
+    // Use last-known terminal dimensions so Claude's TUI starts at the
+    // correct size. Falls back to daemon default (80×24) on first launch.
+    ...dims,
   });
   return createSlot(index, resp.termId, resp.pid);
 }
@@ -1508,4 +1520,5 @@ module.exports = {
   openInCursor,
   focusExternalTerminal,
   closeExternalTerminal,
+  setTerminalDims,
 };

--- a/src/preload.js
+++ b/src/preload.js
@@ -108,6 +108,8 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.on("pty-replay", (_e, termId, data) => callback(termId, data)),
   onPtyExit: (callback) =>
     ipcRenderer.on("pty-exit", (_e, termId) => callback(termId)),
+  reportTerminalDims: (cols, rows) =>
+    ipcRenderer.send("report-terminal-dims", cols, rows),
 
   // Setup scripts
   listSetupScripts: () => ipcRenderer.invoke("list-setup-scripts"),

--- a/src/terminal-manager.js
+++ b/src/terminal-manager.js
@@ -262,12 +262,17 @@ export async function attachPoolTerminal(poolTermId) {
     fitAddon,
     container,
     isPoolTui: true,
+    // Skip daemon replay — the buffer was generated at 80×24 (daemon default)
+    // and xterm.js reflow to the actual window size garbles TUI cursor
+    // positioning. Instead, the initial ptyResize triggers SIGWINCH which makes
+    // Claude redraw at the correct dimensions.
+    skipReplay: true,
     dockTabId: null,
     _resizeHandler: null,
   };
   state.terminals.push(entry);
 
-  // Register before attach so replay/data can find this terminal
+  // Register before attach so data events can find this terminal
   pendingTerminals.set(poolTermId, entry);
   try {
     await window.api.ptyAttach(poolTermId);


### PR DESCRIPTION
## Summary

- **Skip replay for pool TUI terminals** — the daemon's replay buffer contains Claude's TUI output generated at 80×24 (daemon default). When xterm.js reflows this to the actual window size (~200 cols), absolute cursor positioning gets garbled. By skipping replay and relying on Claude's SIGWINCH-triggered redraw, the terminal always shows content at the correct dimensions.
- **Pass actual terminal dimensions when spawning pool sessions** — the renderer reports its terminal dimensions to the main process on every resize. Pool spawns use these instead of the 80×24 default, so Claude's TUI starts at the correct size from the beginning.

### Root cause

Pool PTYs spawned at 80×24. When attached, the daemon replayed buffered TUI output (designed for 80 cols) into xterm.js. Then `fitAddon.fit()` resized xterm.js to the window size, causing xterm.js to reflow the 80-col content to ~200 cols. This reflow garbles Ink's absolute cursor positioning. Claude's subsequent SIGWINCH redraw couldn't fully clean up because Ink's internal cursor tracking was confused by the reflowed layout — it moved "up N lines" from the wrong position, leaving garbled text scattered across the screen.

### Why previous fixes didn't work

Previous PRs likely addressed timing (when resize happens relative to replay). But the issue isn't a race — it's fundamental to xterm.js reflowing TUI content across a large dimension change (80→200). No amount of timing adjustment fixes the reflow itself.

### Related issues

- #269 — `spawnTerminal` and `onApiTermOpened` also default to 80×24
- #270 — `reconnectTerminal` can garble on window size change across restarts

## Test plan

- [ ] Destroy pool, re-init, open a fresh session — should show Claude's TUI cleanly (no scattered text)
- [ ] Open multiple new sessions in succession — all should render correctly
- [ ] Resize window after opening a session — should still work (SIGWINCH redraw)
- [ ] Pool popup in settings panel should still work (unaffected by skipReplay)
- [ ] Resume an archived session — should render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)