### PR TITLE
fix: write replay buffer at PTY dimensions instead of skipping it

### DIFF
--- a/src/terminal-manager.js
+++ b/src/terminal-manager.js
@@ -246,27 +246,39 @@ export async function spawnTerminal(cwd, cmd, args, targetLeafId) {
 
 // Attach to an existing pool slot's PTY (no spawn — the Claude TUI is already running)
 export async function attachPoolTerminal(poolTermId) {
+  // Fetch the PTY's current dimensions so we can create xterm at the same size.
+  // This prevents xterm.js reflow garbling when the replay buffer is written:
+  // the buffer was rendered at these dimensions, so writing to a matching-size
+  // terminal produces correct output. FitAddon later resizes to window dims.
+  const allPtys = await window.api.ptyList();
+  const ptyInfo = allPtys.find((p) => p.termId === poolTermId);
+
   const container = document.createElement("div");
   container.style.cssText = "width:100%;height:100%;";
 
-  const term = createTerminal();
+  const term = createTerminal({
+    ...(ptyInfo?.cols && { cols: ptyInfo.cols }),
+    ...(ptyInfo?.rows && { rows: ptyInfo.rows }),
+  });
 
   const fitAddon = new FitAddon();
   term.loadAddon(fitAddon);
   term.open(container);
 
+  // Write the buffer directly at matching dimensions (no reflow).
+  // Then skip the daemon's replay event to avoid writing it twice.
+  if (ptyInfo?.buffer) {
+    term.write(ptyInfo.buffer);
+  }
+
   const entry = {
     termId: poolTermId,
-    pid: null,
+    pid: ptyInfo?.pid || null,
     term,
     fitAddon,
     container,
     isPoolTui: true,
-    // Skip daemon replay — the buffer was generated at 80×24 (daemon default)
-    // and xterm.js reflow to the actual window size garbles TUI cursor
-    // positioning. Instead, the initial ptyResize triggers SIGWINCH which makes
-    // Claude redraw at the correct dimensions.
-    skipReplay: true,
+    skipReplay: !!ptyInfo?.buffer,
     dockTabId: null,
     _resizeHandler: null,
   };


### PR DESCRIPTION
## Summary

- **Root cause**: macOS's XNU kernel skips SIGWINCH when `ioctl(TIOCSWINSZ)` sets dimensions identical to the current ones (`bcmp` check in `tty_ioctl`). After the first session reports its terminal dims via `reportTerminalDims`, all subsequent pool slots spawn at those exact dimensions. When `attachPoolTerminal` calls `ptyResize` with the same values, SIGWINCH is suppressed, and Claude never redraws — leaving the terminal completely empty.
- **Fix**: Instead of skipping the replay buffer and relying on SIGWINCH, fetch the PTY's actual dimensions and buffer before creating the xterm instance. Create xterm at the PTY's size (no reflow garbling since dimensions match), write the buffer directly, then let FitAddon resize to window dims. This is the same approach `reconnectTerminal` already uses successfully.
- **Also fixes**: The intermittent visual artifacts (overlaid input bars) that occurred when dimensions *did* differ, since the buffer is now always written at the correct dimensions rather than being reflowed.

Fixes the regression from #271 (a565478).

## Test plan

- [ ] Open Cmd+N multiple times — terminal should show Claude's prompt immediately
- [ ] Resize the window, then Cmd+N — still shows prompt correctly
- [ ] Switch between sessions — no visual artifacts or overlaid elements
- [ ] Restart the app — reconnected terminals display correctly (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)