### PR TITLE
fix: make typing detection resilient to transient parse failures

### DIFF
--- a/src/session-discovery.js
+++ b/src/session-discovery.js
@@ -108,6 +108,32 @@ const terminalHasInputCache = new Map(); // termId -> input text string
 const TERMINAL_POLL_MS = 10_000;
 const TERMINAL_WRITE_DEBOUNCE_MS = 500;
 
+// Track consecutive empty-parse results per termId. A cached "has input" entry
+// is only cleared after MISS_THRESHOLD consecutive polls return empty. This
+// prevents transient parse failures (truncated buffer, mid-redraw, alt-screen
+// loss) from dropping typing status.
+const consecutiveMisses = new Map(); // termId -> miss count
+const MISS_THRESHOLD = 3;
+
+// Wrapper so external callers (pool-manager) keep consecutiveMisses in sync.
+// Exposes Map-like interface used by pool-manager: .get(), .delete(), .clear(), .has()
+const terminalInputApi = {
+  get: (termId) => terminalHasInputCache.get(termId),
+  has: (termId) => terminalHasInputCache.has(termId),
+  set: (termId, val) => {
+    consecutiveMisses.delete(termId);
+    terminalHasInputCache.set(termId, val);
+  },
+  delete: (termId) => {
+    consecutiveMisses.delete(termId);
+    return terminalHasInputCache.delete(termId);
+  },
+  clear: () => {
+    consecutiveMisses.clear();
+    terminalHasInputCache.clear();
+  },
+};
+
 // Cache transcriptContains results (key -> true, once true stays true)
 const transcriptCache = new Map();
 
@@ -169,13 +195,28 @@ async function pollTerminalInput() {
     let changed = false;
     for (const [termId, inputText] of results) {
       const prev = terminalHasInputCache.get(termId) || "";
-      if (inputText !== prev) {
-        if (inputText) {
+      if (inputText) {
+        // Input detected — update cache and reset miss counter
+        consecutiveMisses.delete(termId);
+        if (inputText !== prev) {
           terminalHasInputCache.set(termId, inputText);
-        } else {
-          terminalHasInputCache.delete(termId);
+          changed = true;
         }
-        changed = true;
+      } else if (prev) {
+        // Previously had input, now empty — require consecutive misses before
+        // clearing to handle transient parse failures (alt-screen loss,
+        // mid-redraw captures, buffer truncation)
+        const misses = (consecutiveMisses.get(termId) || 0) + 1;
+        consecutiveMisses.set(termId, misses);
+        if (misses >= MISS_THRESHOLD) {
+          terminalHasInputCache.delete(termId);
+          consecutiveMisses.delete(termId);
+          changed = true;
+          _debugLog(
+            "main",
+            `Terminal input cleared for termId=${termId} after ${MISS_THRESHOLD} consecutive misses`,
+          );
+        }
       }
     }
 
@@ -183,6 +224,7 @@ async function pollTerminalInput() {
     for (const termId of freshTermIds) {
       if (!ptyTermIds.has(termId) && terminalHasInputCache.has(termId)) {
         terminalHasInputCache.delete(termId);
+        consecutiveMisses.delete(termId);
         changed = true;
       }
     }
@@ -1016,6 +1058,6 @@ module.exports = {
   findGitRoot,
   pollTerminalInput,
   triggerPollOnWrite,
-  terminalHasInputCache,
+  terminalHasInputCache: terminalInputApi,
   getJsonlSize,
 };

--- a/src/terminal-input.js
+++ b/src/terminal-input.js
@@ -10,51 +10,88 @@
 const { Terminal } = require("@xterm/headless");
 
 const PROMPT_CHAR = "❯";
+// Claude Code's TUI renders in the alternate screen buffer. If the daemon's
+// 100KB buffer was truncated and lost the original \x1b[?1049h switch,
+// we prepend it as a fallback so xterm renders into the correct buffer.
+const ALT_SCREEN_ON = "\x1b[?1049h";
+
+/**
+ * Scan terminal buffer lines in [start, end) range (bottom-up) for the prompt.
+ * Returns text after the prompt character, or null if not found.
+ */
+function findPromptInRange(buf, start, end) {
+  for (let i = end - 1; i >= start; i--) {
+    const line = buf.getLine(i);
+    if (!line) continue;
+    const text = line.translateToString(true);
+    if (text.includes(PROMPT_CHAR)) {
+      return text.split(PROMPT_CHAR).slice(1).join(PROMPT_CHAR).trim();
+    }
+  }
+  return null;
+}
+
+/**
+ * Scan a terminal for the prompt character and return text after it.
+ * Checks active viewport first, then scrollback.
+ */
+function extractPromptText(term) {
+  const buf = term.buffer.active;
+
+  // Active viewport (most common case)
+  const result = findPromptInRange(buf, 0, term.rows);
+  if (result != null) return result;
+
+  // Scrollback (prompt scrolled up due to long input or rendering artifacts)
+  const scrollResult = findPromptInRange(buf, 0, buf.viewportY);
+  return scrollResult ?? "";
+}
 
 /**
  * Parse a terminal buffer to extract text from Claude's input box.
  * @param {string} buffer - Raw PTY output buffer
- * @param {number} cols - Terminal column width
+ * @param {number} cols - Terminal column width (should match actual PTY)
+ * @param {number} rows - Terminal row count (should match actual PTY)
  * @returns {Promise<string>} trimmed text after the prompt, or "" if none
  */
-async function parseTerminalHasInput(buffer, cols = 200) {
+async function parseTerminalHasInput(buffer, cols = 200, rows = 50) {
   if (!buffer) return "";
 
-  const term = new Terminal({ cols, rows: 50, allowProposedApi: true });
+  // Try with the buffer as-is first (handles both main and alt screen)
+  let result = await tryParse(buffer, cols, rows);
+  if (result) return result;
 
-  // Write buffer and wait for it to be processed
+  // If not found, the buffer may have been truncated and lost the alternate
+  // screen switch. Prepend it and retry — Claude's TUI renders in alt screen.
+  if (!buffer.includes(ALT_SCREEN_ON)) {
+    result = await tryParse(ALT_SCREEN_ON + buffer, cols, rows);
+    if (result) return result;
+  }
+
+  return "";
+}
+
+async function tryParse(buffer, cols, rows) {
+  const term = new Terminal({
+    cols,
+    rows,
+    scrollback: 0,
+    allowProposedApi: true,
+  });
+
   await new Promise((resolve) => {
     term.write(buffer, resolve);
   });
 
-  // Scan screen bottom-up for the last line containing the prompt char
-  let lastPromptText = null;
-  for (let i = term.rows - 1; i >= 0; i--) {
-    const line = term.buffer.active.getLine(i);
-    if (!line) continue;
-    const text = line.translateToString(true);
-    if (text.includes(PROMPT_CHAR)) {
-      lastPromptText = text;
-      break;
-    }
-  }
-
+  const result = extractPromptText(term);
   term.dispose();
-
-  if (!lastPromptText) return "";
-
-  // Extract text after the prompt character
-  const afterPrompt = lastPromptText
-    .split(PROMPT_CHAR)
-    .slice(1)
-    .join(PROMPT_CHAR);
-  return afterPrompt.trim();
+  return result;
 }
 
 /**
  * Check which fresh terminals have input, given a daemon `list` response.
  * Pure function — no daemon calls, no side effects.
- * @param {Array<{termId: number, buffer: string}>} ptys - PTY list from daemon
+ * @param {Array<{termId: number, buffer: string, cols?: number, rows?: number}>} ptys
  * @param {Set<number>} freshTermIds - termIds of fresh pool slots
  * @returns {Promise<Map<number, string>>} termId → input text (empty string if none)
  */
@@ -63,7 +100,11 @@ async function checkTerminalInputs(ptys, freshTermIds) {
   const results = await Promise.all(
     freshPtys.map(async (pty) => ({
       termId: pty.termId,
-      inputText: await parseTerminalHasInput(pty.buffer || ""),
+      inputText: await parseTerminalHasInput(
+        pty.buffer || "",
+        pty.cols || 200,
+        pty.rows || 50,
+      ),
     })),
   );
   const map = new Map();

--- a/test/terminal-input.test.js
+++ b/test/terminal-input.test.js
@@ -140,12 +140,47 @@ describe("parseTerminalHasInput", () => {
     expect(await parseTerminalHasInput("just some text\r\n", 80)).toBe("");
   });
 
-  // Regression: pollTerminalInput previously used per-slot `read-buffer` daemon
-  // requests that silently failed (returning "") when the daemon didn't support
-  // that command. This caused parseTerminalHasInput to always return "",
-  // hiding typed text. The fix uses `list` (which returns all buffers) instead.
-  // This test verifies the core invariant: a buffer with visible text after the
-  // prompt MUST return the text, never be silently swallowed by empty-string fallback.
+  // Test: buffer missing alternate screen switch (truncated at 100KB)
+  // When the daemon buffer exceeds BUFFER_SIZE, the leading alt-screen switch
+  // is lost. parseTerminalHasInput should prepend it as a fallback.
+  it("detects input when alternate screen switch is truncated", async () => {
+    // Buffer WITHOUT the alt-screen switch — simulates truncation
+    const truncatedBuffer = [
+      // No \x1b[?1049h here — it was before the truncation point
+      "\x1b[2J\x1b[H",
+      " ▐▛███▜▌   Claude Code v2.1.69\r\n",
+      "▝▜█████▛▘  Opus 4.6 · Claude Max\r\n",
+      "  ▘▘ ▝▝    /Users/test\r\n",
+      "\r\n",
+      "────────────────────────────────────────────────────────────────────────────────\r\n",
+      "❯ truncated alt screen test\r\n",
+      "────────────────────────────────────────────────────────────────────────────────\r\n",
+    ].join("");
+
+    expect(await parseTerminalHasInput(truncatedBuffer, 80)).toBe(
+      "truncated alt screen test",
+    );
+  });
+
+  // Test: buffer with explicit alternate screen mode
+  it("detects input with alternate screen enabled", async () => {
+    const altScreenBuffer = [
+      "\x1b[?1049h", // switch to alt screen
+      "\x1b[2J\x1b[H",
+      " ▐▛███▜▌   Claude Code v2.1.69\r\n",
+      "▝▜█████▛▘  Opus 4.6 · Claude Max\r\n",
+      "  ▘▘ ▝▝    /Users/test\r\n",
+      "\r\n",
+      "────────────────────────────────────────────────────────────────────────────────\r\n",
+      "❯ alt screen prompt\r\n",
+      "────────────────────────────────────────────────────────────────────────────────\r\n",
+    ].join("");
+
+    expect(await parseTerminalHasInput(altScreenBuffer, 80)).toBe(
+      "alt screen prompt",
+    );
+  });
+
   it("never misses input when given the actual buffer (regression: silent empty fallback)", async () => {
     const bufferWithText = [
       "\x1b[2J\x1b[H",
@@ -217,6 +252,21 @@ describe("checkTerminalInputs", () => {
 
     expect(results.get(1)).toBe("");
     expect(results.get(2)).toBe("");
+  });
+
+  it("uses PTY cols and rows from daemon response", async () => {
+    const ptys = [
+      {
+        termId: 1,
+        buffer: makeBuffer(" with dimensions"),
+        cols: 100,
+        rows: 30,
+      },
+    ];
+    const freshTermIds = new Set([1]);
+
+    const results = await checkTerminalInputs(ptys, freshTermIds);
+    expect(results.get(1)).toBe("with dimensions");
   });
 
   it("returns empty map when no fresh PTYs in list", async () => {


### PR DESCRIPTION
## Summary

- **Alt-screen fallback**: When the daemon's 100KB buffer is truncated and loses the `\x1b[?1049h` switch, the headless xterm renders TUI content in the wrong buffer. Now retries with the switch prepended.
- **Consecutive miss threshold**: Require 3 consecutive empty parses before clearing a previously-detected typing session. Prevents transient failures (mid-redraw, buffer truncation) from dropping typing status.
- **Actual PTY dimensions**: Use `cols`/`rows` from daemon `list` response instead of hardcoded 200×50, ensuring ANSI rendering matches the real terminal.
- **Deduplicated prompt scanning**: Extract `findPromptInRange()` to share logic between viewport and scrollback scanning.
- **Cache API wrapper**: `terminalInputApi` keeps `consecutiveMisses` in sync when pool-manager clears entries externally.
- **Reduced allocation**: `scrollback: 0` saves ~80KB per Terminal instance on each poll cycle.

## Test plan

- [x] All 304 existing tests pass
- [x] New tests for alt-screen truncation, explicit alt-screen mode, and PTY dimension passthrough
- [ ] Manual: type text in a pool session, verify it shows as "typing" in sidebar
- [ ] Manual: leave a typing session idle for 10+ minutes, verify typing status persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)