### PR TITLE
Extract readJsonSync helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Electron app + Claude Code plugin for session intention tracking.
 - `src/session-statuses.js` — Shared status string constants (STATUS enum)
 - `src/platform.js` — Cross-platform abstraction (process introspection, CWD detection, shell config, macOS-only features no-op elsewhere)
 - `src/parse-origins.js` — Session origin detection from `ps eww` output (pool/sub-claude/ext)
-- `src/secure-fs.js` — Owner-only file helpers (mode 0o600/0o700)
+- `src/secure-fs.js` — File helpers: owner-only write (mode 0o600/0o700), `readJsonSync(path, fallback)`
 - `src/terminal-input.js` — Headless terminal emulator for detecting text in Claude's TUI input box
 - `src/sort-sessions.js` — Session display ordering (used by main.js)
 - `src/dock-layout.js` — **Dock system**: recursive split tree, drag-and-drop tabs, resize handles

--- a/src/first-run.js
+++ b/src/first-run.js
@@ -3,7 +3,7 @@ const path = require("path");
 const os = require("os");
 const { execFileSync } = require("child_process");
 const { dialog, shell } = require("electron");
-const { secureMkdirSync } = require("./secure-fs");
+const { secureMkdirSync, readJsonSync } = require("./secure-fs");
 const { OPEN_COCKPIT_DIR } = require("./paths");
 const { resolveClaudePath } = require("./pool-manager");
 const { PLUGIN_VERSION } = require("./session-statuses");
@@ -27,21 +27,17 @@ let cachedPluginVersion = null;
 let watchStarted = false;
 
 function refreshPluginVersion() {
-  try {
-    const data = JSON.parse(fs.readFileSync(INSTALLED_PLUGINS_FILE, "utf-8"));
-    const entries = data?.plugins?.[PLUGIN_KEY];
-    if (!Array.isArray(entries) || entries.length === 0) {
-      cachedPluginVersion = null;
-      return;
-    }
-    let best = entries[0];
-    for (const e of entries) {
-      if (e.lastUpdated > best.lastUpdated) best = e;
-    }
-    cachedPluginVersion = best.version || null;
-  } catch {
+  const data = readJsonSync(INSTALLED_PLUGINS_FILE);
+  const entries = data?.plugins?.[PLUGIN_KEY];
+  if (!Array.isArray(entries) || entries.length === 0) {
     cachedPluginVersion = null;
+    return;
   }
+  let best = entries[0];
+  for (const e of entries) {
+    if (e.lastUpdated > best.lastUpdated) best = e;
+  }
+  cachedPluginVersion = best.version || null;
 }
 
 function startPluginVersionWatch() {

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,11 @@ const {
   INPUT_EVENT_ACTIONS,
 } = require("./shortcuts");
 const { createApiServer } = require("./api-server");
-const { secureMkdirSync, secureWriteFileSync } = require("./secure-fs");
+const {
+  secureMkdirSync,
+  secureWriteFileSync,
+  readJsonSync,
+} = require("./secure-fs");
 const {
   IS_DEV,
   OWN_POOL,
@@ -371,18 +375,10 @@ app.whenReady().then(async () => {
   debugLog("main", `starting${IS_DEV ? " (dev)" : ""} pid=${process.pid}`);
 
   // Read app version once from plugin.json
-  let cachedAppVersion;
-  try {
-    const pluginJson = JSON.parse(
-      fs.readFileSync(
-        path.join(__dirname, "..", ".claude-plugin", "plugin.json"),
-        "utf-8",
-      ),
-    );
-    cachedAppVersion = pluginJson.version || PLUGIN_VERSION.UNKNOWN;
-  } catch {
-    cachedAppVersion = PLUGIN_VERSION.UNKNOWN;
-  }
+  const pluginJson = readJsonSync(
+    path.join(__dirname, "..", ".claude-plugin", "plugin.json"),
+  );
+  const cachedAppVersion = pluginJson?.version || PLUGIN_VERSION.UNKNOWN;
 
   // Start watching installed_plugins.json for version changes
   startPluginVersionWatch();
@@ -580,14 +576,7 @@ app.whenReady().then(async () => {
   }
 
   // --- IPC-only handlers (no API equivalent) ---
-  ipcMain.handle("get-dir-colors", () => {
-    try {
-      return JSON.parse(fs.readFileSync(COLORS_FILE, "utf-8"));
-    } catch {
-      /* ENOENT expected — colors.json is optional */
-      return {};
-    }
-  });
+  ipcMain.handle("get-dir-colors", () => readJsonSync(COLORS_FILE, {}));
   ipcMain.handle("watch-intention", (_e, sessionId) => {
     poolManager.validateSessionId(sessionId);
     return poolManager.watchIntention(sessionId);
@@ -670,14 +659,9 @@ app.whenReady().then(async () => {
       /* best-effort — layout save failure is non-fatal */
     }
   });
-  ipcMain.handle("load-layout", (_e, sessionId) => {
-    try {
-      const filePath = path.join(LAYOUTS_DIR, `${sessionId}.json`);
-      return JSON.parse(fs.readFileSync(filePath, "utf-8"));
-    } catch {
-      return null;
-    }
-  });
+  ipcMain.handle("load-layout", (_e, sessionId) =>
+    readJsonSync(path.join(LAYOUTS_DIR, `${sessionId}.json`)),
+  );
   ipcMain.handle("delete-layout", (_e, sessionId) => {
     try {
       fs.unlinkSync(path.join(LAYOUTS_DIR, `${sessionId}.json`));

--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -12,7 +12,11 @@ const execFileAsync = promisify(execFile);
 const platform = require("./platform");
 const { Terminal: HeadlessTerminal } = require("@xterm/headless");
 const { createPoolLock } = require("./pool-lock");
-const { secureMkdirSync, secureWriteFileSync } = require("./secure-fs");
+const {
+  secureMkdirSync,
+  secureWriteFileSync,
+  readJsonSync,
+} = require("./secure-fs");
 const {
   readPool: readPoolFile,
   writePool: writePoolFile,
@@ -254,11 +258,7 @@ function validateSessionId(sessionId) {
 // --- Session graph (parent-child tracking) ---
 
 function readSessionGraph() {
-  try {
-    return JSON.parse(fs.readFileSync(SESSION_GRAPH_FILE, "utf-8"));
-  } catch {
-    return {};
-  }
+  return readJsonSync(SESSION_GRAPH_FILE, {});
 }
 
 function writeSessionGraph(graph) {
@@ -553,13 +553,7 @@ async function readOffloadSnapshot(sessionId) {
 // Read offload meta
 function readOffloadMeta(sessionId) {
   validateSessionId(sessionId);
-  const metaFile = path.join(OFFLOADED_DIR, sessionId, "meta.json");
-  try {
-    return JSON.parse(fs.readFileSync(metaFile, "utf-8"));
-  } catch {
-    /* ENOENT expected — meta may not exist, or JSON may be corrupted */
-    return null;
-  }
+  return readJsonSync(path.join(OFFLOADED_DIR, sessionId, "meta.json"));
 }
 
 // --- Pool Management ---
@@ -610,11 +604,7 @@ function getCachedClaudePath() {
 const DEFAULT_POOL_FLAGS = "--dangerously-skip-permissions";
 
 function readPoolSettings() {
-  try {
-    return JSON.parse(fs.readFileSync(POOL_SETTINGS_FILE, "utf-8"));
-  } catch {
-    return {};
-  }
+  return readJsonSync(POOL_SETTINGS_FILE, {});
 }
 
 function writePoolSettings(settings) {

--- a/src/pool.js
+++ b/src/pool.js
@@ -5,16 +5,13 @@
 const path = require("path");
 const fs = require("fs");
 const { STATUS, POOL_STATUS, INITIATOR } = require("./session-statuses");
+const { readJsonSync } = require("./secure-fs");
 
 /**
  * Read pool.json from disk. Returns parsed object or null on failure.
  */
 function readPool(poolFile) {
-  try {
-    return JSON.parse(fs.readFileSync(poolFile, "utf-8"));
-  } catch {
-    return null;
-  }
+  return readJsonSync(poolFile);
 }
 
 /**

--- a/src/secure-fs.js
+++ b/src/secure-fs.js
@@ -14,4 +14,15 @@ function secureWriteFileSync(filePath, data, opts) {
   });
 }
 
-module.exports = { secureMkdirSync, secureWriteFileSync };
+/**
+ * Read and parse a JSON file, returning `fallback` on any error (ENOENT, parse failure).
+ */
+function readJsonSync(filePath, fallback = null) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+  } catch {
+    return fallback;
+  }
+}
+
+module.exports = { secureMkdirSync, secureWriteFileSync, readJsonSync };

--- a/src/session-discovery.js
+++ b/src/session-discovery.js
@@ -16,7 +16,11 @@ const {
 } = require("./terminal-input");
 const { readPool: readPoolFile, isSlotUncommitted } = require("./pool");
 const { STATUS, POOL_STATUS } = require("./session-statuses");
-const { secureMkdirSync, secureWriteFileSync } = require("./secure-fs");
+const {
+  secureMkdirSync,
+  secureWriteFileSync,
+  readJsonSync,
+} = require("./secure-fs");
 const { daemonRequest } = require("./daemon-client");
 const {
   SESSION_PIDS_DIR,
@@ -473,12 +477,7 @@ async function getOffloadedSessions() {
         .map((s) => s.sessionId),
     );
     if (archivedIds.size > 0) {
-      let sessionGraph;
-      try {
-        sessionGraph = JSON.parse(fs.readFileSync(SESSION_GRAPH_FILE, "utf-8"));
-      } catch {
-        sessionGraph = {};
-      }
+      const sessionGraph = readJsonSync(SESSION_GRAPH_FILE, {});
       for (const s of sessions) {
         if (s.status !== STATUS.OFFLOADED) continue;
         const entry = sessionGraph[s.sessionId];
@@ -770,12 +769,7 @@ async function getSessionsUncached() {
       if (slot.sessionId) poolSessionIdsForArchive.add(slot.sessionId);
     }
   }
-  let sessionGraph;
-  try {
-    sessionGraph = JSON.parse(fs.readFileSync(SESSION_GRAPH_FILE, "utf-8"));
-  } catch {
-    sessionGraph = {};
-  }
+  const sessionGraph = readJsonSync(SESSION_GRAPH_FILE, {});
   const sessionIdSet = new Set(sessions.map((s) => s.sessionId));
   for (let i = sessions.length - 1; i >= 0; i--) {
     const s = sessions[i];


### PR DESCRIPTION
## Summary

- Add `readJsonSync(path, fallback)` to `secure-fs.js` — reads + parses JSON, returns `fallback` on any error
- Replace 9 inline `JSON.parse(fs.readFileSync(...))` try/catch blocks across `pool.js`, `pool-manager.js`, `session-discovery.js`, `first-run.js`, and `main.js`
- Net -28 lines (53 added, 81 removed)

## Test plan

- [x] All 308 tests pass
- [ ] Launch app — verify pool, settings, session graph, layouts all still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)