### PR TITLE
Fix settings version display

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -374,11 +374,9 @@ let ownsApiSocket = false;
 app.whenReady().then(async () => {
   debugLog("main", `starting${IS_DEV ? " (dev)" : ""} pid=${process.pid}`);
 
-  // Read app version once from plugin.json
-  const pluginJson = readJsonSync(
-    path.join(__dirname, "..", ".claude-plugin", "plugin.json"),
-  );
-  const cachedAppVersion = pluginJson?.version || PLUGIN_VERSION.UNKNOWN;
+  // App version from package.json (Electron app version)
+  const pkgJson = readJsonSync(path.join(__dirname, "..", "package.json"));
+  const cachedAppVersion = pkgJson?.version || PLUGIN_VERSION.UNKNOWN;
 
   // Start watching installed_plugins.json for version changes
   startPluginVersionWatch();

--- a/src/pool-ui.js
+++ b/src/pool-ui.js
@@ -564,18 +564,14 @@ function renderGeneralTab(version, pluginVersion, updateState) {
   return `
     <div class="settings-tab-panel" data-tab="general">
       <div class="settings-section">
-        <div class="settings-section-title">About</div>
+        <div class="settings-section-title">Open Cockpit</div>
         <div class="settings-info-row">
-          <span class="settings-info-label">App Version</span>
+          <span class="settings-info-label">App</span>
           <span class="settings-info-value">${escapeHtml(version)}</span>
         </div>
         <div class="settings-info-row">
-          <span class="settings-info-label">Plugin Version</span>
+          <span class="settings-info-label">Plugin</span>
           <span class="settings-info-value${pluginMismatch ? " plugin-version-mismatch" : ""}">${escapeHtml(pluginVersion)}${pluginMismatch ? " ⚠" : ""}</span>
-        </div>
-        <div class="settings-info-row">
-          <span class="settings-info-label">App</span>
-          <span class="settings-info-value">Open Cockpit</span>
         </div>
       </div>
       <div class="settings-section">


### PR DESCRIPTION
## Summary

- **App Version was wrong** — was reading from `.claude-plugin/plugin.json` (CI-bumped plugin version like `0.1.125`) instead of `package.json` (Electron app version like `0.3.4`)
- **Clearer labels**: Section header "Open Cockpit", with "App" (Electron version) and "Plugin" (Claude Code plugin version) rows
- Removed redundant "App: Open Cockpit" static row

## Test plan

- [ ] Open Settings → General — verify App shows `0.3.x` (package.json), Plugin shows `0.1.x` (installed_plugins.json)
- [ ] If versions mismatch, amber ⚠ still shows on Plugin row

🤖 Generated with [Claude Code](https://claude.com/claude-code)