### PR TITLE
fix: clear TUI terminal buffer before resize to prevent reflow artifacts

### DIFF
--- a/src/dock-helpers.js
+++ b/src/dock-helpers.js
@@ -73,9 +73,24 @@ export function setupTerminalResize(entry) {
       // or zero-sized container and hasn't painted yet. In that case fit() is
       // a silent no-op, leaving the terminal at wrong cols/rows. Retry after
       // the next paint so xterm can compute font metrics first.
-      if (!entry.fitAddon.proposeDimensions()) {
+      const proposed = entry.fitAddon.proposeDimensions();
+      if (!proposed) {
         requestAnimationFrame(() => doFit());
         return;
+      }
+      // Pool TUI terminals (Claude's Ink-based TUI) use absolute cursor
+      // positioning. xterm.js reflow on resize treats content as reflowable
+      // text and re-wraps lines, garbling cursor-positioned UI elements
+      // (e.g. the input bar shifts to the middle of the screen). Clear the
+      // buffer before resizing so there's nothing to reflow. The subsequent
+      // ptyResize sends SIGWINCH, which triggers Claude's full redraw at the
+      // correct dimensions.
+      if (
+        entry.isPoolTui &&
+        (proposed.cols !== prevCols || proposed.rows !== prevRows)
+      ) {
+        entry.term.clear();
+        entry.term.write("\x1b[2J\x1b[H");
       }
       entry.fitAddon.fit();
       const { cols, rows } = entry.term;


### PR DESCRIPTION
## Summary

- **Root cause**: xterm.js reflow on resize treats all content as reflowable text and re-wraps lines at the new column width. Claude's Ink-based TUI uses absolute cursor positioning (ANSI CSI sequences), which reflow garbles — the input bar shifts to the middle, UI elements overlay each other, and content appears at wrong positions. This happens on session switches (cached terminal restored at different window size), sidebar toggles, split resizes, etc.
- **Why resize fixes it**: A manual resize triggers another `doFit` cycle, but this time the terminal has correct content (from the previous SIGWINCH redraw) at matching dimensions, so no reflow occurs.
- **Fix**: Before `fitAddon.fit()` resizes a pool TUI terminal, check if dimensions will actually change. If so, clear the xterm buffer (scrollback + visible screen) so there's nothing to reflow. The subsequent `ptyResize` sends SIGWINCH, triggering Claude's full redraw at the correct dimensions. Shell terminals are unaffected — reflow is acceptable for normal text output.

Complements #274 (which fixed the initial attach case). This fix handles the **ongoing** case where cached terminals are restored or the window is resized while a TUI terminal is active.

## Test plan

- [ ] Switch between sessions after resizing the window — no garbled content or overlaid input bars
- [ ] Toggle sidebar while viewing a Claude terminal — clean redraw
- [ ] Drag-resize a split pane with a Claude terminal — clean redraw  
- [ ] Shell terminal tabs still preserve scrollback on resize (reflow still works for them)
- [ ] Fresh Cmd+N session still shows Claude's prompt correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)