### PR TITLE
fix: read app version from package.json instead of plugin.json

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -374,11 +374,9 @@ let ownsApiSocket = false;
 app.whenReady().then(async () => {
   debugLog("main", `starting${IS_DEV ? " (dev)" : ""} pid=${process.pid}`);
 
-  // Read app version once from plugin.json
-  const pluginJson = readJsonSync(
-    path.join(__dirname, "..", ".claude-plugin", "plugin.json"),
-  );
-  const cachedAppVersion = pluginJson?.version || PLUGIN_VERSION.UNKNOWN;
+  // Read app version from package.json (plugin.json has the plugin version)
+  const packageJson = readJsonSync(path.join(__dirname, "..", "package.json"));
+  const cachedAppVersion = packageJson?.version || PLUGIN_VERSION.UNKNOWN;
 
   // Start watching installed_plugins.json for version changes
   startPluginVersionWatch();


### PR DESCRIPTION
## Summary

- App version in Settings was showing the plugin version (`0.1.x`) instead of the actual app version (`0.3.5`)
- Root cause: `main.js` read version from `.claude-plugin/plugin.json` instead of `package.json`

## Test plan

- [x] All 311 tests pass
- [ ] Open Settings → General → About — App Version should show `0.3.5`, not `0.1.136`

🤖 Generated with [Claude Code](https://claude.com/claude-code)