### PR TITLE
fix: add sessionId validation to layout IPC handlers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -649,6 +649,7 @@ app.whenReady().then(async () => {
   });
   // --- Layout persistence ---
   ipcMain.handle("save-layout", (_e, sessionId, layout) => {
+    poolManager.validateSessionId(sessionId);
     try {
       secureMkdirSync(LAYOUTS_DIR);
       const filePath = path.join(LAYOUTS_DIR, `${sessionId}.json`);
@@ -657,10 +658,12 @@ app.whenReady().then(async () => {
       /* best-effort — layout save failure is non-fatal */
     }
   });
-  ipcMain.handle("load-layout", (_e, sessionId) =>
-    readJsonSync(path.join(LAYOUTS_DIR, `${sessionId}.json`)),
-  );
+  ipcMain.handle("load-layout", (_e, sessionId) => {
+    poolManager.validateSessionId(sessionId);
+    return readJsonSync(path.join(LAYOUTS_DIR, `${sessionId}.json`));
+  });
   ipcMain.handle("delete-layout", (_e, sessionId) => {
+    poolManager.validateSessionId(sessionId);
     try {
       fs.unlinkSync(path.join(LAYOUTS_DIR, `${sessionId}.json`));
     } catch {


### PR DESCRIPTION
## Summary
- Added `validateSessionId()` calls to `load-layout`, `save-layout`, and `delete-layout` IPC handlers
- Matches the validation pattern used by all other session-based handlers

Fixes #289

## Test plan
- [ ] Verify layout save/load/delete still works for valid session IDs
- [ ] Verify invalid session IDs are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)