### PR TITLE
fix: add setDialogOpen to command palette

### DIFF
--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -365,11 +365,13 @@ function openCommandPalette() {
   paletteSelectedIndex = 0;
   renderPaletteList("");
   dom.commandPaletteInput.focus();
+  window.api.setDialogOpen(true);
 }
 
 function closeCommandPalette() {
   dom.commandPalette.classList.remove("visible");
   dom.commandPaletteInput.value = "";
+  window.api.setDialogOpen(false);
   // Return focus to terminal
   _actions.focusTerminal();
 }


### PR DESCRIPTION
## Summary

- Command palette did not call `window.api.setDialogOpen(true/false)`, so global keyboard shortcuts (arrow keys switching sessions, etc.) fired through the open palette
- Added `setDialogOpen(true)` in `openCommandPalette()` and `setDialogOpen(false)` in `closeCommandPalette()`, matching the existing pattern in `session-search.js`

Fixes #281

## Test plan

- [ ] Open command palette — verify arrow keys navigate palette items without switching sessions
- [ ] Close command palette — verify global shortcuts resume working

🤖 Generated with [Claude Code](https://claude.com/claude-code)