### PR TITLE
refactor: extract shared sessionToPoolStatus helper

### DIFF
--- a/src/api-handlers.js
+++ b/src/api-handlers.js
@@ -6,7 +6,12 @@ const {
   findSlotByIndex: findSlotByIndexInPool,
   resolveSlot: resolveSlotInPool,
 } = require("./pool");
-const { STATUS, POOL_STATUS, INITIATOR } = require("./session-statuses");
+const {
+  STATUS,
+  POOL_STATUS,
+  INITIATOR,
+  sessionToPoolStatus,
+} = require("./session-statuses");
 const { IDLE_SIGNALS_DIR } = require("./paths");
 const { secureWriteFileSync } = require("./secure-fs");
 const {
@@ -114,11 +119,7 @@ async function getEffectiveSlotStatus(slot) {
   const sessions = await getSessions();
   const session = sessions.find((s) => s.sessionId === slot.sessionId);
   if (!session) return slot.status;
-  if (session.status === STATUS.IDLE) return POOL_STATUS.IDLE;
-  if (session.status === STATUS.PROCESSING) return POOL_STATUS.BUSY;
-  if (session.status === STATUS.FRESH) return POOL_STATUS.FRESH;
-  if (session.status === STATUS.TYPING) return POOL_STATUS.TYPING;
-  return slot.status;
+  return sessionToPoolStatus(session.status) ?? slot.status;
 }
 
 function waitForSessionIdle(sessionId, timeoutMs = 300000) {

--- a/src/pool.js
+++ b/src/pool.js
@@ -4,7 +4,12 @@
  */
 const path = require("path");
 const fs = require("fs");
-const { STATUS, POOL_STATUS, INITIATOR } = require("./session-statuses");
+const {
+  STATUS,
+  POOL_STATUS,
+  INITIATOR,
+  sessionToPoolStatus,
+} = require("./session-statuses");
 const { readJsonSync } = require("./secure-fs");
 
 /**
@@ -157,14 +162,7 @@ function syncStatuses(pool, sessions) {
     // Allow dead slots to recover if their process came back alive
     if (slot.status === POOL_STATUS.DEAD && !session.alive) continue;
 
-    let newStatus = slot.status;
-    if (session.status === STATUS.IDLE) newStatus = POOL_STATUS.IDLE;
-    else if (session.status === STATUS.PROCESSING) newStatus = POOL_STATUS.BUSY;
-    else if (session.status === STATUS.FRESH) {
-      newStatus = POOL_STATUS.FRESH;
-    } else if (session.status === STATUS.TYPING) {
-      newStatus = POOL_STATUS.TYPING;
-    }
+    const newStatus = sessionToPoolStatus(session.status) ?? slot.status;
 
     if (newStatus !== slot.status) {
       slot.status = newStatus;

--- a/src/session-statuses.js
+++ b/src/session-statuses.js
@@ -43,10 +43,30 @@ const PLUGIN_VERSION = {
   UNKNOWN: "unknown",
 };
 
+/**
+ * Map a live session status to the corresponding pool slot status.
+ * Returns null if the session status has no pool equivalent (caller decides fallback).
+ */
+function sessionToPoolStatus(sessionStatus) {
+  switch (sessionStatus) {
+    case STATUS.IDLE:
+      return POOL_STATUS.IDLE;
+    case STATUS.PROCESSING:
+      return POOL_STATUS.BUSY;
+    case STATUS.FRESH:
+      return POOL_STATUS.FRESH;
+    case STATUS.TYPING:
+      return POOL_STATUS.TYPING;
+    default:
+      return null;
+  }
+}
+
 module.exports = {
   STATUS,
   POOL_STATUS,
   INITIATOR,
   UPDATE_STATUS,
   PLUGIN_VERSION,
+  sessionToPoolStatus,
 };


### PR DESCRIPTION
## Summary

- Extract `sessionToPoolStatus()` into `src/session-statuses.js` — maps `STATUS.*` → `POOL_STATUS.*` (returns `null` for unmapped statuses)
- Replace duplicate mapping logic in `getEffectiveSlotStatus()` (api-handlers.js) and `syncStatuses()` (pool.js) with the shared helper
- Both callers use `?? slot.status` as their fallback, preserving existing behavior

Fixes #231

## Test plan

- [x] All 311 existing tests pass
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)