### PR TITLE
refactor: replace _wrappedHandler with WeakMap listener registry

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -1,6 +1,9 @@
 const { contextBridge, ipcRenderer } = require("electron");
 const { PLUGIN_VERSION } = require("./session-statuses");
 
+// Maps original callbacks to their wrapped IPC handlers for proper removal
+const listenerRegistry = new WeakMap();
+
 // Remove stale listeners from previous renderer loads (Cmd+R)
 const channels = [
   "intention-changed",
@@ -153,16 +156,13 @@ contextBridge.exposeInMainWorld("api", {
   onUpdateStatusChanged: (callback) => {
     const wrapped = (_e, state) => callback(state);
     ipcRenderer.on("update-status-changed", wrapped);
-    // Store wrapped ref on the callback for removal
-    callback._wrappedUpdateHandler = wrapped;
+    listenerRegistry.set(callback, wrapped);
   },
   offUpdateStatusChanged: (callback) => {
-    if (callback._wrappedUpdateHandler) {
-      ipcRenderer.removeListener(
-        "update-status-changed",
-        callback._wrappedUpdateHandler,
-      );
-      delete callback._wrappedUpdateHandler;
+    const wrapped = listenerRegistry.get(callback);
+    if (wrapped) {
+      ipcRenderer.removeListener("update-status-changed", wrapped);
+      listenerRegistry.delete(callback);
     }
   },
 


### PR DESCRIPTION
## Summary

- Replaced ad-hoc `callback._wrappedUpdateHandler` property with a module-level `WeakMap` (`listenerRegistry`) to track callback-to-wrapped-handler mappings in `preload.js`
- Property mutation on callback functions is brittle (conflicts with frozen objects, pollutes caller's namespace); WeakMap is the idiomatic solution and allows GC when callbacks are dereferenced

Fixes #268

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — all 311 tests pass (including 4 preload-specific tests)
- [ ] Manual: open pool settings → auto-updater status changes still render and unsubscribe cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)