### PR TITLE
fix: use markers to extract clean term run output

### DIFF
--- a/src/api-handlers.js
+++ b/src/api-handlers.js
@@ -624,6 +624,19 @@ function buildApiHandlers() {
     const startMarker = `START_${marker}`;
     const endMarker = `END_${marker}`;
     const wrapped = `echo ${startMarker}; ${msg.command}; echo ${endMarker}`;
+
+    const extractOutput = (buf) => {
+      const clean = stripAnsi(buf);
+      const startIdx = clean.lastIndexOf(startMarker);
+      if (startIdx < 0) return null;
+      const endIdx = clean.indexOf(endMarker, startIdx);
+      const raw = clean.slice(
+        startIdx + startMarker.length,
+        endIdx >= 0 ? endIdx : undefined,
+      );
+      return { output: raw.trim(), complete: endIdx >= 0 };
+    };
+
     daemonSendSafe({
       type: "write",
       termId: tab.termId,
@@ -633,29 +646,20 @@ function buildApiHandlers() {
     await new Promise((r) => setTimeout(r, 300));
     while (Date.now() < deadline) {
       const buf = await readTerminalBuffer(tab.termId);
-      const clean = stripAnsi(buf);
-      const startIdx = clean.lastIndexOf(startMarker);
-      const endIdx = startIdx >= 0 ? clean.indexOf(endMarker, startIdx) : -1;
-      if (startIdx >= 0 && endIdx >= 0) {
-        const between = clean.slice(startIdx + startMarker.length, endIdx);
-        const output = between.replace(/^\r?\n/, "").replace(/\r?\n$/, "");
+      const result = extractOutput(buf);
+      if (result?.complete) {
         return {
           type: "output",
-          output,
+          output: result.output,
           termId: tab.termId,
         };
       }
       await new Promise((r) => setTimeout(r, 200));
     }
     const finalBuf = await readTerminalBuffer(tab.termId);
-    const clean = stripAnsi(finalBuf);
-    const startIdx = clean.lastIndexOf(startMarker);
-    let partial = "";
-    if (startIdx >= 0) {
-      partial = clean.slice(startIdx + startMarker.length).trim();
-    }
+    const result = extractOutput(finalBuf);
     throw new Error(
-      `Command timed out after ${timeoutMs}ms. Partial output: ${partial}`,
+      `Command timed out after ${timeoutMs}ms. Partial output: ${result?.output || ""}`,
     );
   };
 


### PR DESCRIPTION
## Summary

- **Problem:** `cockpit-cli term run` output included shell artifacts — zsh's `%` PROMPT_EOL_MARK, OSC 7 sequences, and prompt status lines leaked into the returned output
- **Root cause:** The old approach used naive line slicing (first line = command echo, last line = prompt, middle = output), which broke when the shell injected extra lines
- **Fix:** Wrap the command with unique start/end marker echoes (`echo START_marker; cmd; echo END_marker`), then extract only the content between markers from the ANSI-stripped buffer. Uses `crypto.randomBytes` for unique markers to avoid false matches.

Fixes #244

## Test plan

- [ ] `cockpit-cli term run <tab> 'echo hello'` — returns `hello` with no shell artifacts
- [ ] `cockpit-cli term run <tab> 'false'` — returns empty output (failing command still produces end marker)
- [ ] `cockpit-cli term run <tab> 'echo -e "line1\nline2\nline3"'` — preserves multiline output
- [ ] `cockpit-cli term exec 'ls'` — ephemeral tab variant works cleanly
- [ ] `npm test` — all 311 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)