### PR TITLE
refactor: define shared ORIGIN constants

### DIFF
--- a/src/parse-origins.js
+++ b/src/parse-origins.js
@@ -1,9 +1,11 @@
+const { ORIGIN } = require("./session-statuses");
+
 // Detect origin from an environment string (env vars separated by spaces or null bytes).
 function detectOrigin(envStr) {
-  if (/\bOPEN_COCKPIT_POOL=1\b/.test(envStr)) return "pool";
-  if (/\bOPEN_COCKPIT_CUSTOM=1\b/.test(envStr)) return "custom";
-  if (/\bSUB_CLAUDE=1\b/.test(envStr)) return "sub-claude";
-  return "ext";
+  if (/\bOPEN_COCKPIT_POOL=1\b/.test(envStr)) return ORIGIN.POOL;
+  if (/\bOPEN_COCKPIT_CUSTOM=1\b/.test(envStr)) return ORIGIN.CUSTOM;
+  if (/\bSUB_CLAUDE=1\b/.test(envStr)) return ORIGIN.SUB_CLAUDE;
+  return ORIGIN.EXT;
 }
 
 // Parse ps eww output to detect session origins for given PIDs.
@@ -13,7 +15,7 @@ function parseOrigins(psOutput, pids) {
   for (const pid of pids) {
     // ps right-aligns PIDs with variable whitespace
     const pidLine = lines.find((l) => new RegExp(`^\\s*${pid}\\s`).test(l));
-    results.set(pid, pidLine ? detectOrigin(pidLine) : "ext");
+    results.set(pid, pidLine ? detectOrigin(pidLine) : ORIGIN.EXT);
   }
   return results;
 }

--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -31,7 +31,12 @@ const {
   findOffloadTarget,
   findOffloadTargets,
 } = require("./pool");
-const { STATUS, POOL_STATUS, INITIATOR } = require("./session-statuses");
+const {
+  STATUS,
+  POOL_STATUS,
+  INITIATOR,
+  ORIGIN,
+} = require("./session-statuses");
 const {
   daemonSend,
   daemonSendSafe,
@@ -200,7 +205,7 @@ async function offloadSession(
     gitRoot,
     claudeSessionId,
     snapshot,
-    origin: "pool",
+    origin: ORIGIN.POOL,
   });
   // Clean up terminal input cache for the offloaded slot
   const { terminalHasInputCache } = getSessionDiscovery();
@@ -439,7 +444,7 @@ async function saveExternalClearOffload(oldSessionId, pid) {
   await writeOffloadMeta(oldSessionId, {
     cwd,
     externalClear: true,
-    origin: "ext",
+    origin: ORIGIN.EXT,
   });
 }
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -10,7 +10,7 @@ import {
   toggleBellMuted,
   syncBellButton,
 } from "./renderer-state.js";
-import { STATUS } from "./session-statuses.js";
+import { STATUS, ORIGIN } from "./session-statuses.js";
 import { disposeTerminalEntry } from "./dock-helpers.js";
 import { createEditor, setOnDocChange } from "./editor.js";
 import { createOverlayDialog } from "./overlay-dialog.js";
@@ -149,7 +149,7 @@ async function selectSession(session) {
 
     // Resolve the daemon terminal ID for pool/custom sessions
     let daemonTermId = null;
-    if (session.origin === "pool") {
+    if (session.origin === ORIGIN.POOL) {
       const pool = await window.api.poolRead();
       if (gen !== state.sessionGeneration) {
         debugLog("session", `race abort gen=${gen} at poolRead`);
@@ -157,7 +157,7 @@ async function selectSession(session) {
       }
       const slot = pool?.slots.find((s) => s.sessionId === session.sessionId);
       daemonTermId = slot?.termId || null;
-    } else if (session.origin === "custom") {
+    } else if (session.origin === ORIGIN.CUSTOM) {
       const allPtys = await window.api.ptyList();
       if (gen !== state.sessionGeneration) {
         debugLog("session", `race abort gen=${gen} at customPtyList`);
@@ -202,7 +202,10 @@ async function selectSession(session) {
       } catch (err) {
         debugLog("session", `extra terminal discovery failed: ${err.message}`);
       }
-    } else if (session.origin === "pool" || session.origin === "custom") {
+    } else if (
+      session.origin === ORIGIN.POOL ||
+      session.origin === ORIGIN.CUSTOM
+    ) {
       // Daemon session but no terminal found — fallback to shell
       await spawnTerminal(session.cwd);
       if (gen !== state.sessionGeneration) {
@@ -241,7 +244,7 @@ async function selectSession(session) {
 
 function isFreshPoolSlot(s) {
   return (
-    s.origin === "pool" &&
+    s.origin === ORIGIN.POOL &&
     (s.status === STATUS.FRESH || s.poolStatus === STATUS.FRESH)
   );
 }
@@ -256,14 +259,14 @@ async function acquireFreshSlot() {
   if (freshSession) return freshSession;
 
   // No pool sessions at all — nothing to acquire from
-  if (!sessions.some((s) => s.origin === "pool")) return null;
+  if (!sessions.some((s) => s.origin === ORIGIN.POOL)) return null;
 
   // 2. Offload the longest-unused idle session (LRU)
   const idleSessions = sessions
     .filter(
       (s) =>
         s.status === STATUS.IDLE &&
-        s.origin === "pool" &&
+        s.origin === ORIGIN.POOL &&
         s.sessionId !== state.currentSessionId,
     )
     .sort((a, b) => a.idleTs - b.idleTs);
@@ -591,7 +594,7 @@ async function focusCurrentExternalTerminal() {
   const session = state.cachedSessions.find(
     (s) => s.sessionId === state.currentSessionId,
   );
-  if (!session || !session.alive || session.origin === "pool") return;
+  if (!session || !session.alive || session.origin === ORIGIN.POOL) return;
   const result = await window.api.focusExternalTerminal(session.pid);
   if (result.focused) showNotification(`Focused ${result.app}`);
 }
@@ -621,7 +624,7 @@ async function archiveCurrentSession() {
     selectSession(idle);
   }
 
-  if (session.origin === "custom" && session.alive) {
+  if (session.origin === ORIGIN.CUSTOM && session.alive) {
     // Custom session: kill the daemon PTY (fully kill, not offload)
     const allPtys = await window.api.ptyList();
     const pty = allPtys.find(
@@ -629,7 +632,7 @@ async function archiveCurrentSession() {
     );
     if (pty) window.api.ptyKill(pty.termId).catch(() => {});
     destroySessionTerminals(session.sessionId);
-  } else if (session.origin !== "pool" && session.alive && session.pid) {
+  } else if (session.origin !== ORIGIN.POOL && session.alive && session.pid) {
     // External/sub-claude session: close external terminal
     window.api.closeExternalTerminal(session.pid).catch(() => {});
   }

--- a/src/session-discovery.js
+++ b/src/session-discovery.js
@@ -15,7 +15,7 @@ const {
   checkTerminalInputs,
 } = require("./terminal-input");
 const { readPool: readPoolFile, isSlotUncommitted } = require("./pool");
-const { STATUS, POOL_STATUS } = require("./session-statuses");
+const { STATUS, POOL_STATUS, ORIGIN } = require("./session-statuses");
 const {
   secureMkdirSync,
   secureWriteFileSync,
@@ -293,15 +293,15 @@ async function batchDetectOrigins(pids) {
       } else {
         // Windows/unavailable: default to ext
         for (const pid of uncached) {
-          originCache.set(pid, "ext");
-          results.set(pid, "ext");
+          originCache.set(pid, ORIGIN.EXT);
+          results.set(pid, ORIGIN.EXT);
         }
       }
     } catch (err) {
       console.error("[main] Failed to detect session origins:", err.message);
       for (const pid of uncached) {
-        originCache.set(pid, "ext");
-        results.set(pid, "ext");
+        originCache.set(pid, ORIGIN.EXT);
+        results.set(pid, ORIGIN.EXT);
       }
     }
   }
@@ -851,8 +851,8 @@ async function getSessionsUncached() {
       let cwd = s.cwd || (await getCwdFromJsonl(s.sessionId));
       let gitRoot = s.gitRoot || (await findGitRoot(cwd));
       const origin = poolSlotMap.has(s.sessionId)
-        ? "pool"
-        : originCache.get(String(s.pid)) || "ext";
+        ? ORIGIN.POOL
+        : originCache.get(String(s.pid)) || ORIGIN.EXT;
 
       secureMkdirSync(offloadDir, { recursive: true });
       const meta = {
@@ -903,11 +903,11 @@ async function getSessionsUncached() {
   const originMap = await batchDetectOrigins(needOriginPids);
   for (const s of sessions) {
     if (poolSlotMap.has(s.sessionId)) {
-      s.origin = "pool";
+      s.origin = ORIGIN.POOL;
     } else if (s.alive) {
-      s.origin = originMap.get(String(s.pid)) || "ext";
+      s.origin = originMap.get(String(s.pid)) || ORIGIN.EXT;
     } else {
-      s.origin = "ext";
+      s.origin = ORIGIN.EXT;
     }
   }
 
@@ -932,7 +932,7 @@ async function getSessionsUncached() {
   // the same UUID), remove the stale offload data from disk.
   for (const offloaded of await getOffloadedSessions()) {
     if (!liveIds.has(offloaded.sessionId)) {
-      if (!offloaded.origin) offloaded.origin = "pool";
+      if (!offloaded.origin) offloaded.origin = ORIGIN.POOL;
       sessions.push(offloaded);
     } else if (!offloaded.archived) {
       // Live session supersedes non-archived offload data — clean up

--- a/src/session-search.js
+++ b/src/session-search.js
@@ -1,6 +1,6 @@
 // Session search: fuzzy search overlay for quickly jumping to sessions
 import { state, dom, STATUS_CLASSES, escapeHtml } from "./renderer-state.js";
-import { STATUS } from "./session-statuses.js";
+import { STATUS, ORIGIN } from "./session-statuses.js";
 import { createPickerOverlay } from "./picker-overlay.js";
 
 // Hoisted regex for word boundary detection in fuzzy scoring
@@ -159,8 +159,8 @@ function renderResults(query) {
     // Show origin for live sessions, status label for offloaded/archived
     const isOffloadedOrArchived =
       s.status === STATUS.OFFLOADED || s.status === STATUS.ARCHIVED;
-    const tagText = isOffloadedOrArchived ? s.status : s.origin || "ext";
-    const safeOrigin = (s.origin || "ext").replace(/[^a-z0-9-]/gi, "-");
+    const tagText = isOffloadedOrArchived ? s.status : s.origin || ORIGIN.EXT;
+    const safeOrigin = (s.origin || ORIGIN.EXT).replace(/[^a-z0-9-]/gi, "-");
     const tagClass = isOffloadedOrArchived
       ? `status-${statusClass}`
       : `origin-${safeOrigin}`;

--- a/src/session-sidebar.js
+++ b/src/session-sidebar.js
@@ -11,7 +11,7 @@ import {
   toggleBellMuted,
   syncBellButton,
 } from "./renderer-state.js";
-import { STATUS, INITIATOR } from "./session-statuses.js";
+import { STATUS, INITIATOR, ORIGIN } from "./session-statuses.js";
 import {
   createDefaultLayout,
   TAB_EDITOR,
@@ -197,7 +197,7 @@ async function loadSessions() {
   const custom = sessions.filter(
     (s) =>
       isTopLevel(s) &&
-      s.origin === "custom" &&
+      s.origin === ORIGIN.CUSTOM &&
       (s.status === STATUS.FRESH || s.status === STATUS.TYPING),
   );
   const customIds = new Set(custom.map((s) => s.sessionId));

--- a/src/session-statuses.js
+++ b/src/session-statuses.js
@@ -3,6 +3,13 @@
  * Import these instead of using raw string literals to catch typos at reference time.
  */
 
+const ORIGIN = {
+  POOL: "pool",
+  CUSTOM: "custom",
+  SUB_CLAUDE: "sub-claude",
+  EXT: "ext",
+};
+
 const STATUS = {
   FRESH: "fresh",
   TYPING: "typing",
@@ -66,6 +73,7 @@ module.exports = {
   STATUS,
   POOL_STATUS,
   INITIATOR,
+  ORIGIN,
   UPDATE_STATUS,
   PLUGIN_VERSION,
   sessionToPoolStatus,


### PR DESCRIPTION
## Summary

- Add `ORIGIN` enum (`POOL`, `CUSTOM`, `SUB_CLAUDE`, `EXT`) to `src/session-statuses.js`, alongside existing `STATUS` and `POOL_STATUS`
- Replace all raw origin string literals across 6 files with `ORIGIN.*` constants
- No behavioral changes — purely mechanical string-to-constant replacement

Fixes #283

## Test plan

- [x] `npm test` — all 311 tests pass
- [x] `npm run build` — bundles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)