### PR TITLE
refactor: extract wireSettingsInput helper in pool-ui

### DIFF
--- a/src/pool-ui.js
+++ b/src/pool-ui.js
@@ -1002,7 +1002,11 @@ function wireSettingsInput(
 ) {
   const input = overlay.querySelector(selector);
   if (!input) return;
-  const save = () => saveFn(input);
+  let timer;
+  const save = () => {
+    clearTimeout(timer);
+    saveFn(input);
+  };
   input.addEventListener("blur", save);
   input.addEventListener("keydown", (e) => {
     if (e.key === "Enter") {
@@ -1013,7 +1017,6 @@ function wireSettingsInput(
     e.stopPropagation();
   });
   if (debounceMs) {
-    let timer;
     input.addEventListener("input", () => {
       clearTimeout(timer);
       timer = setTimeout(save, debounceMs);


### PR DESCRIPTION
## Summary

- Extract `wireSettingsInput()` helper to deduplicate the save-on-blur / save+notify-on-Enter / stopPropagation / optional-debounce pattern used by `pool-flags-input` and `pool-min-fresh-input`
- Helper passes the input element to the save callback, eliminating redundant DOM queries
- Net reduction of ~40 lines replaced by ~47 (helper + cleaner call sites)

Fixes #284

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — all 311 tests pass
- [ ] Manual: open Settings → Pool tab, verify flags input saves on blur/Enter/debounce, min-fresh input saves on blur/Enter

🤖 Generated with [Claude Code](https://claude.com/claude-code)