### PR TITLE
perf: batch offload target computation in preWarmPool

### DIFF
--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -29,6 +29,7 @@ const {
   findSlotByIndex: findSlotByIndexInPool,
   resolveSlot: resolveSlotInPool,
   findOffloadTarget,
+  findOffloadTargets,
 } = require("./pool");
 const { STATUS, POOL_STATUS, INITIATOR } = require("./session-statuses");
 const {
@@ -1076,24 +1077,34 @@ async function executeOffload(target) {
 
 // Pre-warm the pool by offloading idle sessions to maintain minFreshSlots.
 // Runs after reconcilePool on the same 30s interval.
+// Collects all offload targets in a single locked pass, then executes outside the lock.
 async function preWarmPool() {
+  const { getSessions } = getSessionDiscovery();
   const minFresh = getMinFreshSlots();
   if (minFresh === 0) return;
 
-  // May need to offload multiple sessions to reach minFresh
-  for (let i = 0; i < minFresh; i++) {
-    let target;
-    try {
-      target = await checkOffloadNeeded(minFresh);
-    } catch (err) {
-      // "No fresh or idle slots available" is expected — anything else is a bug
-      if (!err.message?.includes("No fresh or idle")) {
-        _debugLog("main", `Pre-warm check failed: ${err.message}`);
-      }
-      return;
+  // Phase 1: collect all offload targets in a single lock acquisition
+  let targets;
+  try {
+    targets = await withPoolLock(async () => {
+      const pool = readPool();
+      if (!pool) return false;
+      const sessions = await getSessions();
+      enrichSessionsWithGraphData(sessions);
+      const sessionMap = new Map(sessions.map((s) => [s.sessionId, s]));
+      return findOffloadTargets(pool, sessionMap, minFresh);
+    });
+  } catch (err) {
+    if (!err.message?.includes("No fresh or idle")) {
+      _debugLog("main", `Pre-warm check failed: ${err.message}`);
     }
-    if (target === false) return; // Pool not initialized
-    if (!target) return; // Enough fresh slots
+    return;
+  }
+  if (targets === false) return; // Pool not initialized
+  if (targets.length === 0) return; // Enough fresh slots
+
+  // Phase 2: execute offloads outside the lock (each acquires its own lock internally)
+  for (const target of targets) {
     _debugLog(
       "main",
       `Pre-warming pool: offloading session ${target.sessionId}`,

--- a/src/pool.js
+++ b/src/pool.js
@@ -213,19 +213,20 @@ function resolveSlot(pool, msg) {
 }
 
 /**
- * Find an idle slot to offload so a fresh slot becomes available.
- * Returns offload info { sessionId, termId, pid, cwd, gitRoot } or null
- * if enough fresh slots already exist. Throws if no fresh or idle slots.
+ * Find up to N idle slots to offload so fresh slots become available.
+ * Returns array of offload targets (may be empty if enough fresh slots exist).
+ * Throws if offloads are needed but no idle slots are available.
  * @param {number} [minFresh=1] — minimum number of fresh slots to maintain
  */
-function findOffloadTarget(pool, sessionMap, minFresh = 1) {
+function findOffloadTargets(pool, sessionMap, minFresh = 1) {
   const freshCount = pool.slots.filter((s) => {
     // Typing slots don't count as fresh — they're protected
     if (s.status === POOL_STATUS.FRESH) return true;
     const session = s.sessionId ? sessionMap.get(s.sessionId) : null;
     return session && session.status === STATUS.FRESH;
   }).length;
-  if (freshCount >= minFresh) return null;
+  const needed = minFresh - freshCount;
+  if (needed <= 0) return [];
 
   const idleSlots = pool.slots.filter((s) => {
     if (isSlotPinned(s)) return false;
@@ -243,15 +244,27 @@ function findOffloadTarget(pool, sessionMap, minFresh = 1) {
     if (ia !== ib) return ia - ib;
     return (sa?.idleTs || 0) - (sb?.idleTs || 0);
   });
-  const victim = idleSlots[0];
-  const vs = sessionMap.get(victim.sessionId);
-  return {
-    sessionId: victim.sessionId,
-    termId: victim.termId,
-    pid: victim.pid,
-    cwd: vs?.cwd,
-    gitRoot: vs?.gitRoot,
-  };
+  return idleSlots.slice(0, needed).map((slot) => {
+    const vs = sessionMap.get(slot.sessionId);
+    return {
+      sessionId: slot.sessionId,
+      termId: slot.termId,
+      pid: slot.pid,
+      cwd: vs?.cwd,
+      gitRoot: vs?.gitRoot,
+    };
+  });
+}
+
+/**
+ * Find a single idle slot to offload (convenience wrapper around findOffloadTargets).
+ * Returns offload info or null if enough fresh slots exist.
+ * Throws if offloads are needed but no idle slots are available.
+ * @param {number} [minFresh=1] — minimum number of fresh slots to maintain
+ */
+function findOffloadTarget(pool, sessionMap, minFresh = 1) {
+  const targets = findOffloadTargets(pool, sessionMap, minFresh);
+  return targets.length > 0 ? targets[0] : null;
 }
 
 module.exports = {
@@ -267,4 +280,5 @@ module.exports = {
   findSlotByIndex,
   resolveSlot,
   findOffloadTarget,
+  findOffloadTargets,
 };


### PR DESCRIPTION
## Summary

- `preWarmPool()` previously acquired the pool lock N times (once per `checkOffloadNeeded` call per iteration). Now collects all offload targets in a single `withPoolLock` pass via new `findOffloadTargets()`, then executes offloads outside the lock.
- `findOffloadTarget()` refactored to delegate to `findOffloadTargets()`, eliminating duplicated fresh-count/idle-sort/target-mapping logic.
- Offloads still execute sequentially outside the lock (each `executeOffload` acquires its own lock internally for the pool write), so pool state remains consistent.

**Tradeoff**: targets are computed from a single snapshot, so pool state may drift between offloads. This is acceptable because `preWarmPool` runs on a 30s interval and stale targets are handled gracefully by `offloadSession`.

Fixes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)