### PR TITLE
fix: remove racy transcript size check from idle signal hook

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -26,13 +26,13 @@ Resolves the session ID via the PID mapping written by `session-pid-map.sh`.
 
 Detects when sessions become idle (waiting for user input) or start processing. Writes signal files to `~/.open-cockpit/idle-signals/<PID>`.
 
-**No false positives.** Idle signals must only appear when a session is truly waiting for user input. The app may trigger notifications (e.g. a bell) on idle, so a premature signal is worse than a delayed one. The `stop` trigger defers writing for a few seconds and verifies the transcript hasn't changed (which would indicate a re-prompt from another hook).
+**No false positives.** Idle signals must only appear when a session is truly waiting for user input. The app may trigger notifications (e.g. a bell) on idle, so a premature signal is worse than a delayed one. The `stop` trigger defers writing for 5 seconds and verifies via a `.pending` file that no re-prompt occurred (UserPromptSubmit clears it, new Stop hooks overwrite it).
 
 ### Signal lifecycle
 
 | Hook Event | Matcher | Action | Meaning |
 |------------|---------|--------|---------|
-| `Stop` | — | deferred write (stop) | Claude finished responding (verified after 3s) |
+| `Stop` | — | deferred write (stop) | Claude finished responding (verified after 5s) |
 | `PreToolUse` | `AskUserQuestion\|ExitPlanMode` | write (tool) | Claude is asking for input |
 | `PermissionRequest` | — | write (permission) | Waiting for permission approval |
 | `PostToolUse` | — | clear | Processing resumed after tool use |

--- a/hooks/idle-signal.sh
+++ b/hooks/idle-signal.sh
@@ -5,11 +5,10 @@
 #
 # IMPORTANT: Idle signals must have NO FALSE POSITIVES. A session must only
 # be marked idle when it is truly waiting for user input. The "stop" trigger
-# defers writing for IDLE_VERIFY_DELAY seconds and verifies the transcript
-# size hasn't changed (which would indicate a re-prompt from another Stop hook).
-# Uses file SIZE (not mtime) because Claude keeps the JSONL file handle open,
-# causing mtime updates even without new content, and writes system entries
-# (stop_hook_summary, turn_duration) after the Stop hook fires.
+# defers writing and verifies via a .pending file that the session wasn't
+# re-prompted. Re-prompts are caught because:
+#   - UserPromptSubmit clears the .pending file (via idle-signal.sh clear)
+#   - A new Stop hook overwrites .pending with its own PID
 #
 # Usage: idle-signal.sh write [stop|tool|permission]
 #        idle-signal.sh clear
@@ -17,8 +16,7 @@
 set -euo pipefail
 source "$(dirname "$0")/common.sh"
 
-SYSTEM_ENTRY_WAIT=4
-IDLE_VERIFY_DELAY=3
+IDLE_VERIFY_DELAY=5
 mkdir -p "$SIGNAL_DIR"
 
 # $PPID is the Claude process that spawned this hook
@@ -35,11 +33,6 @@ read_input() {
         echo "$line"
         cat 2>/dev/null
     fi
-}
-
-# Cross-platform file size in bytes (macOS uses -f, Linux uses -c)
-file_size() {
-    stat -f %z "$1" 2>/dev/null || stat -c %s "$1" 2>/dev/null || echo 0
 }
 
 case "${1:-}" in
@@ -83,39 +76,20 @@ case "${1:-}" in
             (
                 trap 'rm -f "$pending"' EXIT
 
-                # Wait for system entries (stop_hook_summary, turn_duration)
-                # to finish writing. With async:true, Claude writes these
-                # concurrently (not blocked by the hook), so they can take
-                # up to ~3s to appear. Use SYSTEM_ENTRY_WAIT for margin.
-                sleep "$SYSTEM_ENTRY_WAIT"
-
-                # Abort early if pending was invalidated during system-entry wait
-                [ ! -f "$pending" ] && exit 0
-                [ "$(cat "$pending" 2>/dev/null)" != "$$" ] && exit 0
-
-                # Record file size AFTER system entries are done.
-                # A re-prompt would add new content (tool calls, assistant text).
-                before=""
-                if [ -n "$transcript" ] && [ -f "$transcript" ]; then
-                    before=$(file_size "$transcript")
-                fi
-
+                # Wait before writing the signal. Re-prompts are detected
+                # via .pending invalidation (UserPromptSubmit clears it,
+                # new Stop hooks overwrite with their PID). No transcript
+                # size check needed — it was racy with system entries
+                # (stop_hook_summary, turn_duration) that Claude writes
+                # concurrently, causing missed idle signals (#229).
                 sleep "$IDLE_VERIFY_DELAY"
 
                 # Abort if our pending claim was invalidated (clear or new stop)
                 [ ! -f "$pending" ] && exit 0
                 [ "$(cat "$pending" 2>/dev/null)" != "$$" ] && exit 0
 
-                # Abort if transcript grew (re-prompt or user input added content)
-                if [ -n "$before" ] && [ -f "$transcript" ]; then
-                    after=$(file_size "$transcript")
-                    [ "$before" != "$after" ] && exit 0
-                fi
-
-                # Session is truly idle — write signal (re-check pending to close TOCTOU race)
-                if [ "$(cat "$pending" 2>/dev/null)" = "$$" ]; then
-                    printf '%s\n' "$signal_json" > "$signal_file"
-                fi
+                # Session is truly idle — write signal
+                printf '%s\n' "$signal_json" > "$signal_file"
             ) &
             disown
         else


### PR DESCRIPTION
## Summary

- **Root cause**: The Stop hook's background process used a two-phase approach — wait 4s for system entries, snapshot transcript size, wait 3s, check if size changed. When system entries (stop_hook_summary, turn_duration) took longer than 4s to write, the size check detected growth and aborted, never writing the idle signal. These sessions fell back to the 5-minute stale detection.
- **Key insight**: The `.pending` file mechanism already handles all re-prompt invalidation. `UserPromptSubmit` clears `.pending`, and new Stop hooks overwrite it with their PID. The transcript size check was redundant defense-in-depth that introduced a race condition.
- **Fix**: Remove the transcript size comparison entirely. Consolidate the two sleeps (4s + 3s) into a single 5s delay. Remove the now-unused `file_size` helper. Net -26 lines.

Fixes #229

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — all 311 tests pass
- [ ] Deploy and verify pool sessions get idle signals within ~5s of completion (no more 5-minute stale fallbacks in debug log)
- [ ] Verify re-prompts (e.g., from other hooks) still correctly prevent premature idle signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)