### PR TITLE
fix: prevent PostToolUse from deleting pool-init idle signals

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -60,7 +60,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/idle-signal.sh clear"
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/idle-signal.sh clear post-tool"
           }
         ]
       }

--- a/hooks/idle-signal.sh
+++ b/hooks/idle-signal.sh
@@ -12,7 +12,7 @@
 # (stop_hook_summary, turn_duration) after the Stop hook fires.
 #
 # Usage: idle-signal.sh write [stop|tool|permission]
-#        idle-signal.sh clear
+#        idle-signal.sh clear [post-tool]
 
 set -euo pipefail
 source "$(dirname "$0")/common.sh"
@@ -126,6 +126,23 @@ case "${1:-}" in
         fi
         ;;
     clear)
+        caller="${2:-}"
+        # PostToolUse fires during Claude's initial turn (before the user has
+        # interacted), which deletes the pool-init idle signal AND aborts any
+        # pending deferred Stop write — leaving no signal until reconcilePool
+        # recreates it ~30s later.
+        #
+        # Fix: when called from PostToolUse, preserve pool-init/session-clear
+        # signals — they mark genuinely idle sessions that haven't had user
+        # interaction yet. The Stop hook's deferred write will overwrite them
+        # with a real "stop" trigger once Claude's turn finishes.
+        if [ "$caller" = "post-tool" ] && [ -f "$signal_file" ]; then
+            trigger=$(json_get "$(cat "$signal_file")" "trigger") || true
+            if [ "$trigger" = "pool-init" ] || [ "$trigger" = "session-clear" ]; then
+                rm -f "$signal_file.pending"
+                exit 0
+            fi
+        fi
         rm -f "$signal_file" "$signal_file.pending"
         ;;
 esac

--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -161,6 +161,10 @@ function createFreshIdleSignal(pid, sessionId) {
       trigger: "pool-init",
     }),
   );
+  _debugLog(
+    "main",
+    `Created pool-init idle signal for PID ${pid} (session ${sessionId})`,
+  );
 }
 
 // Sort: recent (idle+offloaded, limit 10) → processing → fresh/dead hidden
@@ -895,6 +899,8 @@ function cleanupStaleIdleSignals() {
   const sessionPids = new Set(
     fs.existsSync(SESSION_PIDS_DIR) ? fs.readdirSync(SESSION_PIDS_DIR) : [],
   );
+  let removed = 0;
+  let kept = 0;
   for (const filename of fs.readdirSync(IDLE_SIGNALS_DIR)) {
     const pid = Number(filename);
     if (isNaN(pid)) continue;
@@ -906,11 +912,15 @@ function cleanupStaleIdleSignals() {
           `[main] Removed stale idle signal for PID ${pid}` +
             (!alive ? " (dead)" : " (no session-pids entry)"),
         );
+        removed++;
       } catch {
         // ignore removal errors
       }
+    } else {
+      kept++;
     }
   }
+  _debugLog("main", `cleanupStaleIdleSignals: removed=${removed} kept=${kept}`);
 }
 
 // Reconcile pool.json with reality on startup.

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -209,6 +209,68 @@ describe("idle-signal.sh", () => {
     expect(content.trigger).toBe("permission");
   });
 
+  it("'clear post-tool' preserves pool-init signal", () => {
+    const signalFile = path.join(
+      tmpHome,
+      ".open-cockpit/idle-signals",
+      hookPid(),
+    );
+    fs.writeFileSync(
+      signalFile,
+      '{"trigger":"pool-init","session_id":"abc","ts":1000}',
+    );
+
+    runHook("idle-signal.sh", { args: ["clear", "post-tool"] });
+    expect(fs.existsSync(signalFile)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(signalFile, "utf-8"));
+    expect(content.trigger).toBe("pool-init");
+  });
+
+  it("'clear post-tool' preserves session-clear signal", () => {
+    const signalFile = path.join(
+      tmpHome,
+      ".open-cockpit/idle-signals",
+      hookPid(),
+    );
+    fs.writeFileSync(
+      signalFile,
+      '{"trigger":"session-clear","session_id":"abc","ts":1000}',
+    );
+
+    runHook("idle-signal.sh", { args: ["clear", "post-tool"] });
+    expect(fs.existsSync(signalFile)).toBe(true);
+  });
+
+  it("'clear post-tool' still clears non-fresh signals", () => {
+    const signalFile = path.join(
+      tmpHome,
+      ".open-cockpit/idle-signals",
+      hookPid(),
+    );
+    fs.writeFileSync(
+      signalFile,
+      '{"trigger":"stop","session_id":"abc","ts":1000}',
+    );
+
+    runHook("idle-signal.sh", { args: ["clear", "post-tool"] });
+    expect(fs.existsSync(signalFile)).toBe(false);
+  });
+
+  it("'clear' (UserPromptSubmit) always clears pool-init signal", () => {
+    const signalFile = path.join(
+      tmpHome,
+      ".open-cockpit/idle-signals",
+      hookPid(),
+    );
+    fs.writeFileSync(
+      signalFile,
+      '{"trigger":"pool-init","session_id":"abc","ts":1000}',
+    );
+
+    runHook("idle-signal.sh", { args: ["clear"] });
+    expect(fs.existsSync(signalFile)).toBe(false);
+  });
+
   it("writes signal file on 'write session-clear' (replaces old signal)", () => {
     // Simulate existing idle signal from before /clear
     const signalFile = path.join(


### PR DESCRIPTION
## Summary

- **Root cause**: `PostToolUse` fires `idle-signal.sh clear` during Claude's initial session turn (e.g. loading configs, connecting MCPs). This deletes the `pool-init` idle signal created by `createFreshIdleSignal()` AND removes the `.pending` file, aborting the deferred Stop write. Result: no idle signal until `reconcilePool` recreates it ~30s later.
- **Fix**: Pass `post-tool` caller context from the `PostToolUse` hook. When called with `post-tool`, `idle-signal.sh clear` preserves `pool-init` and `session-clear` signals (these mark genuinely idle sessions pre-user-interaction). `UserPromptSubmit` still clears all signals unconditionally.
- **Debug logging**: Added `_debugLog` calls to `createFreshIdleSignal()` and `cleanupStaleIdleSignals()` for future traceability.

Fixes #228

## Test plan

- [x] All 315 existing tests pass
- [x] 4 new test cases for the `clear post-tool` behavior:
  - Preserves `pool-init` signal
  - Preserves `session-clear` signal
  - Still clears `stop` (non-fresh) signals
  - `clear` without `post-tool` arg still clears everything (UserPromptSubmit path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)