### PR TITLE
Archive live sessions before pool destroy

### DIFF
--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -1237,13 +1237,46 @@ async function killSlotProcess(slot) {
   }
 }
 
-// Destroy pool: kill all slots and remove pool.json
+// Destroy pool: archive live sessions, kill all slots, and remove pool.json
 async function poolDestroy() {
   return withPoolLock(async () => {
     const pool = readPool();
     if (!pool) return;
-    const { terminalHasInputCache, getOffloadedSessions } =
+    const { terminalHasInputCache, getOffloadedSessions, getSessions } =
       getSessionDiscovery();
+
+    // Archive all live pool sessions before killing processes.
+    // We snapshot + write archive meta directly instead of using offloadSession()
+    // because offload sends /clear and tracks new slots — pointless during destroy.
+    const sessions = await getSessions();
+    const sessionMap = new Map(sessions.map((s) => [s.sessionId, s]));
+    for (const slot of pool.slots) {
+      if (!slot.sessionId) continue;
+      // Skip if already offloaded/archived
+      if (readOffloadMeta(slot.sessionId)) continue;
+      let snapshot = null;
+      try {
+        const resp = await daemonRequest({ type: "list" });
+        const pty = resp.ptys.find((p) => p.termId === slot.termId);
+        if (pty && pty.buffer) snapshot = await renderBufferToText(pty.buffer);
+      } catch (err) {
+        _debugLog(
+          "main",
+          `poolDestroy: failed to snapshot session ${slot.sessionId}:`,
+          err.message,
+        );
+      }
+      const session = sessionMap.get(slot.sessionId);
+      await writeOffloadMeta(slot.sessionId, {
+        cwd: session?.cwd,
+        gitRoot: session?.gitRoot,
+        claudeSessionId: slot.sessionId,
+        snapshot,
+        origin: "pool",
+        archived: true,
+      });
+    }
+
     for (const slot of pool.slots) {
       await killSlotProcess(slot);
       // Clean up idle-signal and session-pid files so destroyed slots


### PR DESCRIPTION
## Summary

- Pool destroy now snapshots and archives all live sessions before killing slot processes
- Prevents session data loss when reinitializing the pool
- Already-offloaded sessions are skipped (no duplicate work)

## Test plan

- [ ] Start pool with multiple sessions (some idle, some processing)
- [ ] Destroy pool → verify all sessions appear in archive
- [ ] Reinit pool → verify archived sessions are browsable
- [ ] Destroy empty pool (no sessions) → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)