### PR TITLE
Fix resumed sessions stuck in processing category

### DIFF
--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -1390,6 +1390,24 @@ async function poolResume(sessionId) {
         skipTrustPrompt: true,
         skipFreshSignal: true,
         onResolved: async (newSessionId) => {
+          // Write an idle signal so the resumed session appears as idle/recent
+          // immediately. The Stop hook won't fire after /resume (no assistant
+          // turn), so without this the session stays stuck in "processing".
+          // Trigger "resume" is not in FRESH_TRIGGERS, so session-discovery
+          // will mark it as activated and show it as IDLE.
+          if (newSessionId) {
+            secureMkdirSync(IDLE_SIGNALS_DIR, { recursive: true });
+            secureWriteFileSync(
+              path.join(IDLE_SIGNALS_DIR, String(slot.pid)),
+              JSON.stringify({
+                cwd: os.homedir(),
+                session_id: newSessionId,
+                transcript: "",
+                ts: Math.floor(Date.now() / 1000),
+                trigger: "resume",
+              }),
+            );
+          }
           // Re-tag orphaned extra terminals from old session to new session
           if (newSessionId) {
             try {


### PR DESCRIPTION
## Summary

- After `/resume`, the Stop hook doesn't fire (no assistant turn), so no idle signal was written
- The session stayed in "processing" until the 5-minute stale timeout kicked in
- Typing made it worse — showed as "typing" since the session was never activated
- **Fix:** Write an idle signal with trigger `"resume"` in the `onResolved` callback, so the session immediately appears as idle/recent

## Test plan

- [ ] Resume an archived session
- [ ] Verify it appears in the "recent" category (not processing)
- [ ] Type in the editor — verify it stays in recent (not typing)
- [ ] Send a message — verify normal processing→idle cycle works

🤖 Generated with [Claude Code](https://claude.com/claude-code)