### PR TITLE
fix: prevent resume from caching terminal under wrong session ID

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -335,6 +335,9 @@ async function resumeOffloadedSession(session) {
 
   // Transition: cache previous session's terminals, set up fresh dock, attach terminal
   hideCurrentTerminals();
+  // Clear currentSessionId so attachPoolTerminal → syncSessionCache() doesn't
+  // cache the resumed terminal under the previously-viewed session's ID.
+  state.currentSessionId = null;
   initDockLayout();
 
   try {


### PR DESCRIPTION
## Summary

- When resuming an offloaded session, `attachPoolTerminal()` → `syncSessionCache()` cached the resumed terminal under `state.currentSessionId`, which still held the **previously-viewed** session's ID
- Both sessions then restored the same xterm terminal when clicked in the sidebar
- Fix: clear `currentSessionId` after `hideCurrentTerminals()` so `syncSessionCache()` no-ops until the correct ID is set after polling

## Test plan

- [ ] Resume an offloaded session while viewing a different session
- [ ] Click both sessions in sidebar — each should show its own terminal
- [ ] Verify resumed session's terminal content matches the original conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)