### PR TITLE
refactor: migrate showSetupScriptPicker to shared picker overlay

### DIFF
--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -356,11 +356,6 @@ function renderPaletteList(query) {
     item.className = `overlay-picker-item command-palette-item${i === clamped ? " selected" : ""}`;
     const shortcut = getCommandShortcut(cmd);
     item.innerHTML = `<span class="command-palette-label">${cmd.label}</span><span class="command-palette-shortcut">${shortcut}</span>`;
-    item.addEventListener("click", () => {
-      picker.close();
-      cmd.action();
-    });
-
     item.addEventListener("mouseenter", () => picker.updateSelection(i));
     dom.commandPaletteList.appendChild(item);
   });

--- a/src/index.html
+++ b/src/index.html
@@ -31,6 +31,14 @@
       </div>
     </main>
   </div>
+  <div id="setup-script-picker" class="overlay-picker">
+    <div class="overlay-picker-dialog">
+      <div class="setup-script-title">Setup Script</div>
+      <div class="setup-script-subtitle">Run a script in the new session</div>
+      <input id="setup-script-input" class="overlay-picker-input" type="text" placeholder="Filter scripts..." autocomplete="off" spellcheck="false">
+      <div id="setup-script-list" class="overlay-picker-list"></div>
+    </div>
+  </div>
   <div id="session-search" class="overlay-picker">
     <div id="session-search-dialog" class="overlay-picker-dialog">
       <input id="session-search-input" class="overlay-picker-input" type="text" placeholder="Search sessions..." autocomplete="off" spellcheck="false">

--- a/src/picker-overlay.js
+++ b/src/picker-overlay.js
@@ -113,6 +113,18 @@ export function createPickerOverlay({
     if (e.target === overlayEl) close();
   });
 
+  // Click on list item to select
+  listEl.addEventListener("click", (e) => {
+    const item = e.target.closest(`.${itemClass}`);
+    if (!item) return;
+    const items = listEl.querySelectorAll(`.${itemClass}`);
+    const index = Array.from(items).indexOf(item);
+    if (index !== -1) {
+      close();
+      onSelect(index);
+    }
+  });
+
   return {
     open,
     close,

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -65,6 +65,7 @@ import {
   splitFocusedTab,
 } from "./command-palette.js";
 import { initSessionSearch, toggleSessionSearch } from "./session-search.js";
+import { createPickerOverlay } from "./picker-overlay.js";
 
 // --- Populate DOM refs ---
 dom.sessionList = document.getElementById("session-list");
@@ -80,6 +81,9 @@ dom.commandPaletteList = document.getElementById("command-palette-list");
 dom.sessionSearch = document.getElementById("session-search");
 dom.sessionSearchInput = document.getElementById("session-search-input");
 dom.sessionSearchList = document.getElementById("session-search-list");
+dom.setupScriptPicker = document.getElementById("setup-script-picker");
+dom.setupScriptInput = document.getElementById("setup-script-input");
+dom.setupScriptList = document.getElementById("setup-script-list");
 
 // --- Focus management ---
 
@@ -644,90 +648,61 @@ async function archiveCurrentSession() {
 
 // --- Setup script picker ---
 
+let setupScriptResolve = null;
+let setupScriptOptions = [];
+
+const setupScriptPicker = createPickerOverlay({
+  overlayEl: dom.setupScriptPicker,
+  inputEl: dom.setupScriptInput,
+  listEl: dom.setupScriptList,
+  itemClass: "overlay-picker-item",
+  onInput(query) {
+    renderSetupScriptItems(query);
+  },
+  onSelect(index) {
+    if (!setupScriptResolve) return;
+    const filtered = filterSetupScriptOptions(dom.setupScriptInput.value);
+    const option = filtered[index];
+    setupScriptResolve(option === "None" ? null : option);
+    setupScriptResolve = null;
+  },
+  onOpen() {},
+  onClose() {
+    if (setupScriptResolve) {
+      setupScriptResolve(null);
+      setupScriptResolve = null;
+    }
+  },
+  getItemCount() {
+    return dom.setupScriptList.querySelectorAll(".overlay-picker-item").length;
+  },
+});
+
+function filterSetupScriptOptions(query) {
+  if (!query) return setupScriptOptions;
+  const q = query.toLowerCase();
+  return setupScriptOptions.filter((o) => o.toLowerCase().includes(q));
+}
+
+function renderSetupScriptItems(query) {
+  const filtered = filterSetupScriptOptions(query);
+  dom.setupScriptList.innerHTML = "";
+  for (let i = 0; i < filtered.length; i++) {
+    const item = document.createElement("div");
+    item.className = "overlay-picker-item";
+    if (i === 0) item.classList.add("selected");
+    item.textContent = filtered[i];
+    dom.setupScriptList.appendChild(item);
+  }
+  setupScriptPicker.clampSelection();
+}
+
 function showSetupScriptPicker(scripts) {
   return new Promise((resolve) => {
-    const overlay = document.createElement("div");
-    overlay.className = "setup-script-overlay";
-
-    const dialog = document.createElement("div");
-    dialog.className = "setup-script-dialog";
-
-    const title = document.createElement("div");
-    title.className = "setup-script-title";
-    title.textContent = "Setup Script";
-    dialog.appendChild(title);
-
-    const subtitle = document.createElement("div");
-    subtitle.className = "setup-script-subtitle";
-    subtitle.textContent = "Run a script in the new session";
-    dialog.appendChild(subtitle);
-
-    const list = document.createElement("div");
-    list.className = "setup-script-list";
-
-    let selectedIndex = 0;
-    const items = [];
-
-    // "None" option first
-    const allOptions = ["None", ...scripts];
-
-    for (let i = 0; i < allOptions.length; i++) {
-      const item = document.createElement("div");
-      item.className = "setup-script-item";
-      if (i === 0) item.classList.add("selected");
-      item.textContent = allOptions[i];
-      item.addEventListener("click", () => {
-        cleanup();
-        resolve(i === 0 ? null : allOptions[i]);
-      });
-      list.appendChild(item);
-      items.push(item);
-    }
-
-    dialog.appendChild(list);
-    overlay.appendChild(dialog);
-    document.body.appendChild(overlay);
-
-    function updateSelection() {
-      items.forEach((el, i) =>
-        el.classList.toggle("selected", i === selectedIndex),
-      );
-      items[selectedIndex].scrollIntoView({ block: "nearest" });
-    }
-
-    function cleanup() {
-      document.removeEventListener("keydown", onKey);
-      overlay.remove();
-    }
-
-    function onKey(e) {
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        selectedIndex = (selectedIndex + 1) % allOptions.length;
-        updateSelection();
-      } else if (e.key === "ArrowUp") {
-        e.preventDefault();
-        selectedIndex =
-          (selectedIndex - 1 + allOptions.length) % allOptions.length;
-        updateSelection();
-      } else if (e.key === "Enter") {
-        e.preventDefault();
-        cleanup();
-        resolve(selectedIndex === 0 ? null : allOptions[selectedIndex]);
-      } else if (e.key === "Escape") {
-        e.preventDefault();
-        cleanup();
-        resolve(null);
-      }
-    }
-
-    document.addEventListener("keydown", onKey);
-    overlay.addEventListener("click", (e) => {
-      if (e.target === overlay) {
-        cleanup();
-        resolve(null);
-      }
-    });
+    setupScriptOptions = ["None", ...scripts];
+    setupScriptResolve = resolve;
+    renderSetupScriptItems("");
+    setupScriptPicker.open();
   });
 }
 

--- a/src/session-search.js
+++ b/src/session-search.js
@@ -174,10 +174,6 @@ function renderResults(query) {
       <div class="session-search-meta">${path}</div>
     `;
 
-    item.addEventListener("click", () => {
-      picker.close();
-      _actions.selectSession(s);
-    });
     item.addEventListener("mouseenter", () => picker.updateSelection(i));
     list.appendChild(item);
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -947,59 +947,20 @@ body.dock-resizing-v {
   margin: 0;
 }
 
-/* Setup script picker */
-.setup-script-overlay {
-  display: flex;
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
-  background: rgba(0, 0, 0, 0.5);
-  align-items: flex-start;
-  justify-content: center;
-  padding-top: 80px;
-}
-
-.setup-script-dialog {
-  width: 360px;
-  background: #161616;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
-  padding: 16px;
-}
-
+/* Setup script picker (title/subtitle inside shared overlay-picker) */
 .setup-script-title {
   font-size: 14px;
   font-weight: 600;
   color: var(--text);
   margin-bottom: 4px;
+  padding: 12px 16px 0;
 }
 
 .setup-script-subtitle {
   font-size: 12px;
   color: var(--text-dim);
-  margin-bottom: 12px;
-}
-
-.setup-script-list {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  max-height: 300px;
-  overflow-y: auto;
-}
-
-.setup-script-item {
-  padding: 8px 12px;
-  font-size: 13px;
-  border-radius: 4px;
-  cursor: pointer;
-  color: var(--text);
-}
-
-.setup-script-item:hover,
-.setup-script-item.selected {
-  background: var(--accent-dim);
+  margin-bottom: 0;
+  padding: 0 16px;
 }
 
 /* Custom session dialog */


### PR DESCRIPTION
## Summary
- Migrated `showSetupScriptPicker()` from hand-rolled DOM/keyboard/overlay to `createPickerOverlay`
- Added native item click handling to `createPickerOverlay` (delegated listener on `listEl`)
- Removed duplicate click listeners from command palette, session search, and setup script picker
- Replaced 7 custom CSS rules with shared `overlay-picker` classes (kept only title/subtitle styles)

## Test plan
- [ ] Open Cockpit, click "+" to create new session with setup scripts in `~/.open-cockpit/setup-scripts/`
- [ ] Verify picker appears with filter input, arrow key navigation, Enter/Escape, click-to-select all work
- [ ] Verify command palette (⌘P) item clicks still work
- [ ] Verify session search (⌘K) item clicks still work
- [ ] `npm test` — 316 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)