### PR TITLE
fix: atomic pool slot claiming prevents race on concurrent start

### DIFF
--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -1385,11 +1385,25 @@ async function poolClean() {
   return cleaned;
 }
 
+// Serialize withFreshSlot calls so concurrent callers can't double-offload
+// the same session or race into the claim phase simultaneously.
+// Separate from withPoolLock because offloadSession acquires it internally.
+let _freshSlotQueue = Promise.resolve();
+
 // Ensure a fresh slot exists, then atomically claim and return it.
 // The claimFn receives (pool, slot) inside the lock and should perform
 // the slot-specific work (send prompt / resume command, mark busy, etc.).
 // Returns whatever claimFn returns.
-async function withFreshSlot(claimFn) {
+function withFreshSlot(claimFn) {
+  const p = _freshSlotQueue.then(() => _withFreshSlotInner(claimFn));
+  _freshSlotQueue = p.then(
+    () => {},
+    () => {},
+  ); // keep chain alive
+  return p;
+}
+
+async function _withFreshSlotInner(claimFn) {
   const { getSessions } = getSessionDiscovery();
   // Phase 1: check if offload is needed (inside lock)
   const needsOffload = await checkOffloadNeeded();


### PR DESCRIPTION
## Summary

- Concurrent `cockpit-cli start` calls could race through `withFreshSlot()`'s three-phase flow, causing double-offload of the same session or two callers claiming the same fresh slot
- Adds a dedicated async queue (`_freshSlotQueue`) that serializes the entire `withFreshSlot` operation — separate from `withPoolLock` because `offloadSession` acquires it internally (nesting would deadlock)

## Test plan

- [ ] `npm test` passes (316/316)
- [ ] Manual: run `cockpit-cli start "task one" & cockpit-cli start "task two" & wait` — verify different session IDs returned

Fixes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)