### PR TITLE
docs: slim CLAUDE.md, add architecture.md, expand pool.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,66 +2,11 @@
 
 Electron app + Claude Code plugin for session intention tracking.
 
-## Architecture
+For file map and runtime paths see [docs/architecture.md](docs/architecture.md).
 
-- `src/pty-daemon.js` — **PTY daemon**: standalone process managing all terminals ([docs/pty-daemon.md](docs/pty-daemon.md))
-- `src/api-server.js` — **API server**: Unix socket API for external process control ([docs/api.md](docs/api.md))
-- `src/main.js` — Main process orchestrator: window, IPC wiring, module init
-- `src/paths.js` — Shared path constants for all main-process modules
-- `src/daemon-client.js` — PTY daemon socket communication (init pattern)
-- `src/session-discovery.js` — Session state detection, caching, origin tagging
-- `src/pool-manager.js` — Pool lifecycle, offload/archive, terminal helpers
-- `src/api-handlers.js` — Shared IPC/API handler registry + API-only handlers
-- `src/preload.js` — Context bridge (`api` object)
-- `src/shortcuts.js` — Configurable keyboard shortcuts (defaults, overrides, accelerator matching)
-- `src/pool.js` — Pure pool data structures (readPool, writePool, computePoolHealth)
-- `src/pool-lock.js` — Async mutex for pool.json read-modify-write cycles (`withPoolLock`)
-- `src/session-statuses.js` — Shared status string constants (STATUS enum)
-- `src/platform.js` — Cross-platform abstraction (process introspection, CWD detection, shell config, macOS-only features no-op elsewhere)
-- `src/parse-origins.js` — Session origin detection from `ps eww` output (pool/sub-claude/ext)
-- `src/secure-fs.js` — File helpers: owner-only write (mode 0o600/0o700), `readJsonSync(path, fallback)`
-- `src/terminal-input.js` — Headless terminal emulator for detecting text in Claude's TUI input box
-- `src/sort-sessions.js` — Session display ordering (used by main.js)
-- `src/dock-layout.js` — **Dock system**: recursive split tree, drag-and-drop tabs, resize handles
-- `src/dock-helpers.js` — Dock integration utilities (editor container factory, terminal resize, tab registration)
-- `src/renderer.js` — Renderer orchestrator: session lifecycle, auto-save, IPC wiring, module init
-- `src/renderer-state.js` — Shared mutable state, DOM refs, status classes, utilities
-- `src/editor.js` — CodeMirror 6 live preview editor setup
-- `src/session-sidebar.js` — Session list rendering, directory colors, context menus, snapshots
-- `src/terminal-manager.js` — Terminal creation, attach, switch, close, caching, reconnect, PTY IPC
-- `src/pool-ui.js` — Pool settings panel, slot terminal popup, shortcut settings
-- `src/picker-overlay.js` — Shared overlay picker factory (open/close, keyboard nav, click-outside)
-- `src/command-palette.js` — COMMANDS registry, pane navigation, palette UI
-- `src/session-search.js` — Fuzzy session search overlay (⌘K)
-- `src/session-stats.js` — On-demand JSONL parsing, token/cost stats, sub-agent aggregation
-- `src/stats-ui.js` — Session Info overlay dialog (⌘I)
-- `src/index.html` + `src/styles.css` — Layout, neon red dark theme
-- `bin/cockpit-cli` — CLI for observing and interacting with agents ([docs/api.md](docs/api.md))
-- `skills/cockpit-sessions/` — Skill docs for Claude Code (SKILL.md + sub-skills)
-- `hooks/` — Claude Code plugin hooks ([docs/hooks.md](docs/hooks.md))
-- `.claude-plugin/plugin.json` — Plugin manifest
-- `.github/workflows/auto-release.yml` — CI auto-bumps plugin version on push
-- `.github/workflows/build-release.yml` — CI builds Electron binaries on tag push ([docs/releasing.md](docs/releasing.md))
+## Launching
 
-## Key paths
-
-- `~/.open-cockpit/pool.json` — Pool state
-- `~/.open-cockpit/pool-settings.json` — Pool settings (session flags)
-- `~/.open-cockpit/session-pids/<PID>` — Session ID mapping
-- `~/.open-cockpit/intentions/<session_id>.md` — Intention files
-- `~/.open-cockpit/idle-signals/<PID>` — Idle signal files
-- `~/.open-cockpit/session-graph.json` — Parent-child relationships
-- `~/.open-cockpit/offloaded/<sessionId>/` — Offloaded/archived data
-- `~/.open-cockpit/shortcuts.json` — Keyboard shortcut overrides
-- `~/.open-cockpit/setup-scripts/` — Setup scripts for Cmd+N
-- `~/.open-cockpit/colors.json` — Directory color overrides
-- `~/.open-cockpit/debug.log` — Debug log (rotates at 2 MB)
-- `~/.open-cockpit/api.sock` / `api-dev.sock` — API sockets
-- `~/.open-cockpit/pty-daemon.sock` / `pty-daemon.pid` — PTY daemon
-
-## Launching the app
-
-Do not use `open -a Electron.app`, `electron .`, or `npx electron .` — these skip `npm run build` and set `ELECTRON_RUN_AS_NODE=1`.
+Never use `open -a Electron.app`, `electron .`, or `npx electron .` — these skip `npm run build` and set `ELECTRON_RUN_AS_NODE=1`.
 
 ### Restart production
 
@@ -69,11 +14,9 @@ Do not use `open -a Electron.app`, `electron .`, or `npx electron .` — these s
 cd ~/projects/open-cockpit && DAEMON_PID=$(cat ~/.open-cockpit/pty-daemon.pid 2>/dev/null || echo NONE); lsof -c Electron 2>/dev/null | awk -v dir="$(pwd)" '/cwd/ && $NF == dir {print $2}' | grep -v "^${DAEMON_PID}$" | sort -u | xargs kill 2>/dev/null; sleep 0.5; unset ELECTRON_RUN_AS_NODE && nohup npm start > /dev/null 2>&1 &
 ```
 
-Confirm with the user before restarting production — it disrupts all active sessions.
+Confirm with the user first — disrupts all active sessions. No window? Kill stale instances: `pkill -f "Electron.*open-cockpit"`, then relaunch.
 
-**No window?** Stale instances. Kill all: `pkill -f "Electron.*open-cockpit"`, then relaunch.
-
-### Launch dev instance
+### Dev instance
 
 `cd` into your worktree first:
 
@@ -81,29 +24,7 @@ Confirm with the user before restarting production — it disrupts all active se
 DAEMON_PID=$(cat ~/.open-cockpit/pty-daemon.pid 2>/dev/null || echo NONE); lsof -c Electron 2>/dev/null | awk -v dir="$(pwd)" '/cwd/ && $NF == dir {print $2}' | grep -v "^${DAEMON_PID}$" | sort -u | xargs kill 2>/dev/null; sleep 0.5; unset ELECTRON_RUN_AS_NODE && nohup npm run dev > /dev/null 2>&1 &
 ```
 
-### Kill only your worktree's instance
-
-```bash
-DAEMON_PID=$(cat ~/.open-cockpit/pty-daemon.pid 2>/dev/null || echo NONE); lsof -c Electron 2>/dev/null | awk -v dir="$(pwd)" '/cwd/ && $NF == dir {print $2}' | grep -v "^${DAEMON_PID}$" | sort -u | xargs kill 2>/dev/null
-```
-
-Do not use `pkill -f electron` or `killall Electron` — these can kill other instances.
-
-## Releasing
-
-Two independent pipelines: **plugin** (automatic) and **app** (manual).
-
-### Plugin releases
-
-Every push to `main` auto-bumps `.claude-plugin/plugin.json` and updates the marketplace. Just push — CI handles it.
-
-**Requires:** `APP_ID` and `APP_PRIVATE_KEY` secrets (Plugin Release Bot GitHub App).
-
-### App releases
-
-Tag push → CI builds all platforms → publish the draft. See [docs/releasing.md](docs/releasing.md) for full steps, secrets, and troubleshooting.
-
-## Dev vs production
+Kill only your instance: same command without the `npm run dev` part.
 
 - `npm start` — production (don't touch during dev)
 - `npm run dev` — dev instance, separate user data, safe to restart
@@ -115,24 +36,22 @@ Tag push → CI builds all platforms → publish the draft. See [docs/releasing.
 - **Main process** (`main.js`, `preload.js`): kill and restart dev instance
 - **Daemon** (`pty-daemon.js`): `kill $(cat ~/.open-cockpit/pty-daemon.pid)`, restart app (kills all terminals)
 
+## Releasing
+
+- **Plugin**: every push to `main` auto-bumps version and updates marketplace. Just push.
+- **App**: tag push → CI builds → publish draft. See [docs/releasing.md](docs/releasing.md).
+
 ## Native modules
 
-`node-pty` must be compiled for Electron's Node version. Happens automatically via `postinstall`. Manual rebuild: `npx electron-builder install-app-deps`
+`node-pty` compiles for Electron's Node version via `postinstall`. Manual rebuild: `npx electron-builder install-app-deps`. Symptom if skipped: "Daemon request timeout" on pool init.
 
-**Symptom if skipped:** Pool init fails with "Daemon request timeout" — daemon crashes on `spawn` due to ABI mismatch.
+## Git & worktrees
 
-## Git hooks
+`.githooks/` (auto-configured): `pre-commit` (prettier), `post-checkout` (auto-install + build), `post-merge` (auto-build).
 
-`.githooks/` (auto-configured via `prepare` script):
-- `pre-commit` — prettier
-- `post-checkout` — auto-install deps + build for worktrees
-- `post-merge` — auto-build after pull
+Worktrees auto-setup via `post-checkout`. Never use `isolation: "worktree"` from inside `.wt/`.
 
-## Worktree setup
-
-Worktrees auto-setup via `post-checkout`. Never use `isolation: "worktree"` from inside a `.wt/` directory.
-
-Merging: always merge from root worktree without `--delete-branch`:
+Merging — always from root worktree:
 ```bash
 cd ~/projects/open-cockpit
 gh pr merge <number> --squash
@@ -144,23 +63,25 @@ git pull
 ## Conventions
 
 - **Every user-facing action must have a keyboard shortcut.** See [docs/shortcuts.md](docs/shortcuts.md).
-- **Every UI element must be keyboard-accessible.** Arrow key navigation, never require mouse.
-- **Every action a user can do, a Claude session should also be able to do.** Use the API to test programmatically.
+- **Every UI element must be keyboard-accessible.** Arrow keys, never require mouse.
+- **Every action a user can do, a Claude session should also be able to do.** Use the API.
 - Electron: contextIsolation, sandbox off (preload needs npm packages)
 - CodeMirror 6 bundled with esbuild
-- Auto-save 500ms debounce, file watching via `fs.watchFile` (polling)
 - Plugin version in `.claude-plugin/plugin.json`, marketplace in `EliasSchlie/claude-plugins`
 
-## Further docs
+## Docs
 
-- [docs/releasing.md](docs/releasing.md) — App release workflow, code signing, secrets
-- [docs/sessions.md](docs/sessions.md) — Session lifecycle, idle detection, archiving, graph, pinning, origins
-- [docs/pool.md](docs/pool.md) — Pool management internals
-- [docs/terminals.md](docs/terminals.md) — Terminal tab model, attach strategy, programmatic access
-- [docs/pty-daemon.md](docs/pty-daemon.md) — PTY daemon architecture, protocol, debugging
-- [docs/api.md](docs/api.md) — Programmatic API (Unix socket, CLI)
-- [docs/idle-signals.md](docs/idle-signals.md) — Idle signal lifecycle, actors, failure modes
-- [docs/hooks.md](docs/hooks.md) — Plugin hooks
-- [docs/shortcuts.md](docs/shortcuts.md) — Keyboard shortcuts reference
-- [docs/theme.md](docs/theme.md) — Color scheme, directory colors
-- [docs/debug-logging.md](docs/debug-logging.md) — Debug logging
+| Topic | Link |
+|-------|------|
+| Architecture & file map | [docs/architecture.md](docs/architecture.md) |
+| Session lifecycle | [docs/sessions.md](docs/sessions.md) |
+| Pool management | [docs/pool.md](docs/pool.md) |
+| Idle signals | [docs/idle-signals.md](docs/idle-signals.md) |
+| Terminals | [docs/terminals.md](docs/terminals.md) |
+| PTY daemon | [docs/pty-daemon.md](docs/pty-daemon.md) |
+| API & CLI | [docs/api.md](docs/api.md) |
+| Plugin hooks | [docs/hooks.md](docs/hooks.md) |
+| Keyboard shortcuts | [docs/shortcuts.md](docs/shortcuts.md) |
+| Releasing | [docs/releasing.md](docs/releasing.md) |
+| Theme & colors | [docs/theme.md](docs/theme.md) |
+| Debug logging | [docs/debug-logging.md](docs/debug-logging.md) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,81 @@
+# Architecture
+
+Electron app + Claude Code plugin for session intention tracking.
+
+## Source files
+
+### Main process
+
+| File | Purpose |
+|------|---------|
+| `src/main.js` | Main process orchestrator: window, IPC wiring, module init |
+| `src/paths.js` | Shared path constants for all main-process modules |
+| `src/daemon-client.js` | PTY daemon socket communication (init pattern) |
+| `src/session-discovery.js` | Session state detection, caching, origin tagging |
+| `src/pool-manager.js` | Pool lifecycle, offload/archive, terminal helpers |
+| `src/api-handlers.js` | Shared IPC/API handler registry + API-only handlers |
+| `src/preload.js` | Context bridge (`api` object) |
+| `src/shortcuts.js` | Configurable keyboard shortcuts (defaults, overrides, accelerator matching) |
+| `src/pool.js` | Pure pool data structures (readPool, writePool, computePoolHealth) |
+| `src/pool-lock.js` | Async mutex for pool.json read-modify-write cycles (`withPoolLock`) |
+| `src/session-statuses.js` | Shared constants: STATUS, POOL_STATUS, ORIGIN enums |
+| `src/platform.js` | Cross-platform abstraction (process introspection, CWD, shell config) |
+| `src/parse-origins.js` | Session origin detection from `ps eww` output |
+| `src/secure-fs.js` | File helpers: owner-only write (mode 0o600/0o700), `readJsonSync` |
+| `src/terminal-input.js` | Headless terminal emulator for detecting text in Claude's TUI input box |
+| `src/sort-sessions.js` | Session display ordering |
+
+### Standalone processes
+
+| File | Purpose |
+|------|---------|
+| `src/pty-daemon.js` | PTY daemon: standalone process managing all terminals ([docs](pty-daemon.md)) |
+| `src/api-server.js` | Unix socket API for external process control ([docs](api.md)) |
+
+### Renderer (ES modules)
+
+| File | Purpose |
+|------|---------|
+| `src/renderer.js` | Renderer orchestrator: session lifecycle, auto-save, IPC wiring, module init |
+| `src/renderer-state.js` | Shared mutable state, DOM refs, status classes, utilities |
+| `src/editor.js` | CodeMirror 6 live preview editor setup |
+| `src/session-sidebar.js` | Session list rendering, directory colors, context menus, snapshots |
+| `src/terminal-manager.js` | Terminal creation, attach, switch, close, caching, reconnect, PTY IPC |
+| `src/pool-ui.js` | Pool settings panel, slot terminal popup, shortcut settings |
+| `src/picker-overlay.js` | Shared overlay picker factory (open/close, keyboard nav, click-outside) |
+| `src/command-palette.js` | COMMANDS registry, pane navigation, palette UI |
+| `src/session-search.js` | Fuzzy session search overlay (⌘K) |
+| `src/session-stats.js` | On-demand JSONL parsing, token/cost stats, sub-agent aggregation |
+| `src/stats-ui.js` | Session Info overlay dialog (⌘I) |
+| `src/dock-layout.js` | Dock system: recursive split tree, drag-and-drop tabs, resize handles |
+| `src/dock-helpers.js` | Dock integration utilities (editor container factory, terminal resize) |
+
+### Other
+
+| File | Purpose |
+|------|---------|
+| `src/index.html` + `src/styles.css` | Layout, neon red dark theme |
+| `bin/cockpit-cli` | CLI for observing and interacting with agents ([docs](api.md)) |
+| `skills/cockpit-sessions/` | Skill docs for Claude Code (SKILL.md + sub-skills) |
+| `hooks/` | Claude Code plugin hooks ([docs](hooks.md)) |
+| `.claude-plugin/plugin.json` | Plugin manifest |
+| `.github/workflows/auto-release.yml` | CI auto-bumps plugin version on push |
+| `.github/workflows/build-release.yml` | CI builds Electron binaries on tag push ([docs](releasing.md)) |
+
+## Key paths
+
+| Path | Purpose |
+|------|---------|
+| `~/.open-cockpit/pool.json` | Pool state |
+| `~/.open-cockpit/pool-settings.json` | Pool settings (session flags) |
+| `~/.open-cockpit/session-pids/<PID>` | Session ID mapping |
+| `~/.open-cockpit/intentions/<session_id>.md` | Intention files |
+| `~/.open-cockpit/idle-signals/<PID>` | Idle signal files |
+| `~/.open-cockpit/session-graph.json` | Parent-child relationships |
+| `~/.open-cockpit/offloaded/<sessionId>/` | Offloaded/archived data |
+| `~/.open-cockpit/shortcuts.json` | Keyboard shortcut overrides |
+| `~/.open-cockpit/setup-scripts/` | Setup scripts for Cmd+N |
+| `~/.open-cockpit/colors.json` | Directory color overrides |
+| `~/.open-cockpit/debug.log` | Debug log (rotates at 2 MB) |
+| `~/.open-cockpit/api.sock` / `api-dev.sock` | API sockets |
+| `~/.open-cockpit/pty-daemon.sock` / `pty-daemon.pid` | PTY daemon |

--- a/docs/pool.md
+++ b/docs/pool.md
@@ -2,15 +2,46 @@
 
 The app manages a pool of pre-started Claude sessions. Pool state lives in `~/.open-cockpit/pool.json`.
 
-## Operations
+## Slot lifecycle
 
-- **Init**: via UI or API (`pool-init` with size). Spawns Claude sessions via the PTY daemon using `resolveClaudePath()` (finds `claude` binary via `which` + fallback paths). Trust prompt is accepted via buffer polling (not hardcoded delay).
-- **Dead/error slots**: `reconcilePool()` auto-restarts dead and error slots. Runs on startup and every 30s. Orphaned processes are killed via `killSlotProcess()` (daemon + PID fallback) before respawn.
-- **Offloading**: Idle sessions get offloaded (snapshot + `/clear`). External `/clear` is also detected and saved as offloaded.
-- **Archiving**: All dead sessions are auto-archived (`archived: true` in meta.json). Any session can be manually archived via right-click. Pool sessions auto-offload before archiving.
-- **Destroy**: `pool-destroy` kills all slots and removes `pool.json`. Uses `killSlotProcess()` (daemon + PID fallback) to prevent orphans.
-- **Write locking**: All pool.json read-modify-write cycles use `withPoolLock()` to prevent concurrent write races.
-- **Settings UI**: Auto-refreshes every 3s. Clicking a slot row opens an interactive terminal popup attached to the live PTY.
+Each slot moves through: `STARTING` → `IDLE` → `BUSY` → `IDLE` → (offloaded/archived).
+
+- **Init**: `pool-init` spawns Claude sessions via the PTY daemon using `resolveClaudePath()`. Trust prompt is accepted via buffer polling (not hardcoded delay).
+- **Claiming**: `withFreshSlot()` claims an idle slot for a new task. Uses an async queue to serialize concurrent claims, preventing two `cockpit-cli start` calls from grabbing the same slot.
+- **Offloading**: Idle sessions get offloaded (snapshot saved + `/clear` sent) to free slots. External `/clear` is also detected and saved.
+- **Archiving**: Dead sessions are auto-archived (`archived: true` in meta.json). Any session can be manually archived via right-click.
+- **Destroy**: `pool-destroy` kills all slots and removes `pool.json`. Uses `killSlotProcess()` (daemon + PID fallback).
+
+## Reconciliation
+
+`reconcilePool()` runs on startup and every 30s:
+- Restarts dead and error slots
+- Recreates missing idle signals for fresh sessions
+- Kills orphaned processes before respawn
+- Syncs slot statuses with actual session states
+
+## Fresh slot pre-warming
+
+`preWarmPool()` runs on a 30s interval. When the number of fresh (unclaimed) slots drops below `minFreshSlots` (configurable in pool settings, default 1):
+1. Collects all offload targets in a single locked pass via `findOffloadTargets()`
+2. Executes offloads outside the lock to free slots
+3. Reconcile then respawns the freed slots
+
+## Pinning
+
+Slots can be pinned (`pinnedUntil` timestamp) to prevent offloading. Pinned slots are skipped by `findOffloadTarget()` and `selectShrinkCandidates()`. Pinning protects sessions that are idle but should be kept alive (e.g., sessions with ongoing context the user wants to return to).
+
+## Write locking
+
+All pool.json read-modify-write cycles use `withPoolLock()` (async mutex in `pool-lock.js`) to prevent concurrent write races. Always `await` the lock — unawaited calls cause state corruption.
+
+## Settings
+
+`~/.open-cockpit/pool-settings.json` stores:
+- `flags` — CLI flags passed to `claude` on session start
+- `minFreshSlots` — target number of unclaimed slots to maintain (default 1, max 10)
+
+Settings UI auto-refreshes every 3s. Clicking a slot row opens an interactive terminal popup.
 
 ## Plugin update → pool reinit
 
@@ -20,4 +51,11 @@ After pushing to `main`, CI auto-bumps the version and updates the marketplace. 
 2. Destroy the pool (`pool-destroy` via API or UI)
 3. Re-initialize (`pool-init`)
 
-New sessions will have the latest hooks.
+## Key files
+
+| File | Role |
+|------|------|
+| `src/pool.js` | Pure data structures: read/write pool, health computation, offload target selection |
+| `src/pool-manager.js` | Pool lifecycle: init, reconcile, offload, archive, pre-warm, claim |
+| `src/pool-lock.js` | Async mutex for pool.json |
+| `src/pool-ui.js` | Settings panel, slot terminal popup |


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: 167 → 82 lines (51% reduction). Offloaded file map and key paths to `docs/architecture.md`. Removed info duplicated by linked docs. Kept only essentials: launch commands, dev workflow, conventions, doc index.
- **docs/architecture.md** (new): full source file map organized by process boundary (main, renderer, standalone) + runtime paths table
- **docs/pool.md**: 24 → 62 lines. Added slot lifecycle, reconciliation details, fresh slot pre-warming, pinning, write locking, settings, key files table.

## Motivation
CLAUDE.md was loaded every session but contained reference material (38-line file map, 13-line path list) that agents rarely need upfront. Moving it to docs keeps context windows lean while remaining discoverable.

## Test plan
- [ ] New agent sessions can still find architecture info via `docs/architecture.md` link
- [ ] Pool docs now cover pinning, pre-warming, and locking

🤖 Generated with [Claude Code](https://claude.com/claude-code)