### PR TITLE
docs: improve sessions, terminals, and hooks docs

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -24,4 +24,10 @@ Resolves the session ID via the PID mapping written by `session-pid-map.sh`.
 
 ## Idle signal hooks → `idle-signal.sh`
 
-Detects when sessions become idle (waiting for user input) or start processing. Writes signal files to `~/.open-cockpit/idle-signals/<PID>`. See [idle-signals.md](idle-signals.md) for full lifecycle details, the `.pending` deferred-write mechanism, all actors, and failure modes.
+Detects when sessions become idle (waiting for user input) or start processing. Writes signal files to `~/.open-cockpit/idle-signals/<PID>`.
+
+- **Stop** hook: writes idle signal after a 5s deferred verify (`.pending` file PID mechanism prevents false positives on re-prompts)
+- **UserPromptSubmit** hook: clears idle signal unconditionally (session is now processing)
+- **PostToolUse** hook: clears idle signal but preserves `pool-init`/`session-clear` triggers (these mark genuinely idle sessions that shouldn't lose their signal during Claude's initial tool-use turn)
+
+See [idle-signals.md](idle-signals.md) for full lifecycle details, all actors, and failure modes.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -63,13 +63,16 @@ Pool slots can be pinned to prevent LRU offloading:
 
 ## Origin tags
 
-Sessions in the sidebar display an origin tag:
-- **pool** (green) — spawned by the pool manager (`OPEN_COCKPIT_POOL=1` env var)
-- **custom** (cyan) — standalone sessions spawned via Cmd+Shift+N (`OPEN_COCKPIT_CUSTOM=1` env var)
-- **sub-claude** (purple) — spawned by sub-claude (`SUB_CLAUDE=1` env var)
-- **ext** (gray) — external sessions (no known env markers)
+Sessions in the sidebar display an origin tag (constants defined in `src/session-statuses.js` as `ORIGIN`):
 
-Detection uses `ps eww <PID>` to read process environment. Results are cached by PID.
+| Origin | Color | Env var | Description |
+|--------|-------|---------|-------------|
+| `pool` | green | `OPEN_COCKPIT_POOL=1` | Spawned by pool manager |
+| `custom` | cyan | `OPEN_COCKPIT_CUSTOM=1` | Standalone via Cmd+Shift+N |
+| `sub-claude` | purple | `SUB_CLAUDE=1` | Spawned by sub-claude plugin |
+| `ext` | gray | *(none)* | External sessions |
+
+Detection logic is in `src/parse-origins.js` — reads process environment via `ps eww <PID>`. Results are cached by PID in `src/session-discovery.js`.
 
 ## Custom sessions
 

--- a/docs/terminals.md
+++ b/docs/terminals.md
@@ -29,6 +29,14 @@ Shell terminals are unaffected — reflow is acceptable for normal text output.
 
 **macOS-specific**: macOS's XNU kernel skips SIGWINCH when `ioctl(TIOCSWINSZ)` sets the same dimensions (`bcmp` check in `tty_ioctl`). This is why `attachPoolTerminal` fetches PTY dims and writes the buffer at matching dimensions rather than skipping the buffer and relying on SIGWINCH — if the PTY already matches the window size, SIGWINCH never fires.
 
+## Reconnect handling
+
+When reconnecting to a session after app restart, `reconnectTerminal()` writes the PTY's saved buffer at matching dimensions. If the window has since changed size, `fitAddon.fit()` would reflow the buffer, garbling TUI content. To prevent this, entries are flagged with `_hasReconnectBuffer` — on the first resize, `setupTerminalResize` clears the buffer and lets SIGWINCH trigger a full redraw.
+
+## API-created tabs
+
+Tabs created via `cockpit-cli term open` or the `session-term-open` API are discovered by the renderer via `discoverExtraTerminals()`, which queries the daemon for all terminals belonging to the session and attaches any that aren't already tracked. The renderer is notified via the `api-term-opened` IPC event.
+
 ## Programmatic terminal access
 
 Sessions can discover and interact with their own terminal tabs via the `session-terminals` API and `cockpit-cli term` commands. All `term` subcommands auto-detect the caller's session ID by walking PID ancestry (checks `~/.open-cockpit/session-pids/<PID>`), so no target is needed when calling from within a Claude session.


### PR DESCRIPTION
## Summary
- **sessions.md**: origin tags as table, references `ORIGIN` constants and `parse-origins.js`
- **terminals.md**: added reconnect buffer handling + API-created tabs sections
- **hooks.md**: expanded idle signal hooks with per-hook behavior details

Follow-up to #313 (CLAUDE.md slim-down).

## Test plan
- [ ] Docs accurately reflect current code behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)