### PR TITLE
fix: ⌘K session search — selection, sub-agent tags, parent expand

### DIFF
--- a/src/parse-origins.js
+++ b/src/parse-origins.js
@@ -2,9 +2,11 @@ const { ORIGIN } = require("./session-statuses");
 
 // Detect origin from an environment string (env vars separated by spaces or null bytes).
 function detectOrigin(envStr) {
+  // SUB_CLAUDE must be checked first: sub-agents spawned from pool/custom
+  // sessions inherit the parent's env vars but should be tagged as sub-claude
+  if (/\bSUB_CLAUDE=1\b/.test(envStr)) return ORIGIN.SUB_CLAUDE;
   if (/\bOPEN_COCKPIT_POOL=1\b/.test(envStr)) return ORIGIN.POOL;
   if (/\bOPEN_COCKPIT_CUSTOM=1\b/.test(envStr)) return ORIGIN.CUSTOM;
-  if (/\bSUB_CLAUDE=1\b/.test(envStr)) return ORIGIN.SUB_CLAUDE;
   return ORIGIN.EXT;
 }
 

--- a/src/picker-overlay.js
+++ b/src/picker-overlay.js
@@ -102,8 +102,9 @@ export function createPickerOverlay({
     }
     if (e.key === "Enter" && count > 0) {
       e.preventDefault();
+      const idx = selectedIndex;
       close();
-      onSelect(selectedIndex);
+      onSelect(idx);
       return;
     }
   });
@@ -118,10 +119,10 @@ export function createPickerOverlay({
     const item = e.target.closest(`.${itemClass}`);
     if (!item) return;
     const items = listEl.querySelectorAll(`.${itemClass}`);
-    const index = Array.from(items).indexOf(item);
-    if (index !== -1) {
+    const idx = Array.from(items).indexOf(item);
+    if (idx !== -1) {
       close();
-      onSelect(index);
+      onSelect(idx);
     }
   });
 

--- a/src/session-search.js
+++ b/src/session-search.js
@@ -2,6 +2,7 @@
 import { state, dom, STATUS_CLASSES, escapeHtml } from "./renderer-state.js";
 import { STATUS, ORIGIN } from "./session-statuses.js";
 import { createPickerOverlay } from "./picker-overlay.js";
+import { expandParentChain } from "./session-sidebar.js";
 
 // Hoisted regex for word boundary detection in fuzzy scoring
 const BOUNDARY_RE = /[\s/\-_.]/;
@@ -22,11 +23,15 @@ export function initSessionSearch(actions) {
     listEl: dom.sessionSearchList,
     onInput: (query) => renderResults(query),
     onSelect: (index) => {
-      _actions.selectSession(filteredSessions[index]);
+      const session = filteredSessions[index];
+      if (!session) return;
+      expandParentChain(session.sessionId);
+      _actions.selectSession(session);
     },
     onOpen: () => renderResults(""),
     onClose: () => {
-      filteredSessions = [];
+      // Don't clear filteredSessions here — onSelect runs after close
+      // and needs the array intact. It's rebuilt on next open anyway.
       _actions.focusTerminal();
     },
     getItemCount: () => filteredSessions.length,

--- a/src/session-sidebar.js
+++ b/src/session-sidebar.js
@@ -705,6 +705,23 @@ function hasSessionChildren(sessionId) {
   return childrenMap.has(sessionId);
 }
 
+// Expand all ancestors of a session so it becomes visible in the sidebar
+function expandParentChain(sessionId) {
+  const session = state.cachedSessions.find((s) => s.sessionId === sessionId);
+  if (!session?.parentSessionId) return;
+  let parentId = session.parentSessionId;
+  let changed = false;
+  while (parentId) {
+    if (!childrenExpanded.has(parentId)) {
+      childrenExpanded.add(parentId);
+      changed = true;
+    }
+    const parent = state.cachedSessions.find((s) => s.sessionId === parentId);
+    parentId = parent?.parentSessionId || null;
+  }
+  if (changed) invalidateSidebar();
+}
+
 export {
   loadDirColors,
   getDirColor,
@@ -720,5 +737,6 @@ export {
   toggleChildrenExpanded,
   isChildrenExpanded,
   hasSessionChildren,
+  expandParentChain,
   archiveWithChildCheck,
 };


### PR DESCRIPTION
## Summary

- **⌘K Enter/click now works**: `close()` triggered `onClose` which cleared `filteredSessions` before `onSelect` could read it → `selectSession(undefined)`. Fixed by not clearing the array in `onClose` (rebuilt on next open anyway).
- **Sub-agents show "sub-claude" tag** instead of "pool": `detectOrigin` checked `OPEN_COCKPIT_POOL=1` before `SUB_CLAUDE=1`, but sub-agents inherit their parent's env vars. Reordered to check `SUB_CLAUDE` first.
- **Auto-expand parent chain**: Selecting a sub-agent via ⌘K now expands all ancestors in the sidebar tree so the session is visible.

## Test plan

- [ ] Open ⌘K, type to filter, press Enter → session navigates
- [ ] Click a session in ⌘K results → session navigates
- [ ] Spawn a sub-agent from a pool session → verify "sub-claude" tag in ⌘K and sidebar
- [ ] Select a nested sub-agent in ⌘K → parent chain auto-expands in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)