### PR TITLE
feat: sub-agent origin tag for sessions with parent

### DIFF
--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -184,7 +184,7 @@ async function offloadSession(
   sessionId,
   termId,
   claudeSessionId,
-  { cwd, gitRoot, pid } = {},
+  { cwd, gitRoot, pid, origin } = {},
 ) {
   // Get terminal buffer and render to readable text
   let snapshot = null;
@@ -205,7 +205,7 @@ async function offloadSession(
     gitRoot,
     claudeSessionId,
     snapshot,
-    origin: ORIGIN.POOL,
+    origin: origin || ORIGIN.POOL,
   });
   // Clean up terminal input cache for the offloaded slot
   const { terminalHasInputCache } = getSessionDiscovery();
@@ -347,6 +347,15 @@ function enrichSessionsWithGraphData(sessions) {
     }
   }
   if (graphChanged) writeSessionGraph(graph);
+
+  // Override origin for sessions with a parent (sub-agents).
+  // Env-based detection assigns POOL/CUSTOM because sub-agents inherit
+  // their parent's env vars. The graph is the source of truth.
+  for (const s of sessions) {
+    if (s.parentSessionId) {
+      s.origin = ORIGIN.SUB_AGENT;
+    }
+  }
 }
 
 // Render raw PTY buffer into readable screen text using a headless terminal.
@@ -1091,6 +1100,7 @@ async function executeOffload(target) {
     cwd: target.cwd,
     gitRoot: target.gitRoot,
     pid: target.pid,
+    origin: target.origin,
   });
 }
 

--- a/src/pool.js
+++ b/src/pool.js
@@ -250,6 +250,7 @@ function findOffloadTargets(pool, sessionMap, minFresh = 1) {
       pid: slot.pid,
       cwd: vs?.cwd,
       gitRoot: vs?.gitRoot,
+      origin: vs?.origin,
     };
   });
 }

--- a/src/session-statuses.js
+++ b/src/session-statuses.js
@@ -7,6 +7,7 @@ const ORIGIN = {
   POOL: "pool",
   CUSTOM: "custom",
   SUB_CLAUDE: "sub-claude",
+  SUB_AGENT: "sub-agent",
   EXT: "ext",
 };
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -18,6 +18,7 @@
   --yellow: #ffff00;
   --mauve: #ff00ff;
   --blue: #00aaff;
+  --peach: #ffa050;
 }
 
 html,
@@ -291,6 +292,11 @@ body {
 .session-origin-custom {
   color: #00ccff;
   background: rgba(0, 204, 255, 0.1);
+}
+
+.session-origin-sub-agent {
+  color: var(--peach);
+  background: rgba(255, 160, 80, 0.1);
 }
 
 .session-origin-stale {
@@ -786,6 +792,11 @@ body.dock-resizing-v {
 .session-search-tag.origin-sub-claude {
   color: var(--mauve);
   border: 1px solid rgba(255, 0, 255, 0.3);
+}
+
+.session-search-tag.origin-sub-agent {
+  color: var(--peach);
+  border: 1px solid rgba(255, 160, 80, 0.3);
 }
 
 .session-search-tag.origin-ext {


### PR DESCRIPTION
## Summary
- Sessions spawned by other Claude sessions (via cockpit-cli, Agent tool, or sub-claude) now show a **sub-agent** tag (peach) instead of incorrectly inheriting "pool"
- Origin detection uses the session graph (parentSessionId) as source of truth, overriding env-based detection that was fooled by inherited env vars
- Offload metadata now preserves the actual origin instead of hardcoding "pool"

## Root cause
Sub-agents inherit `OPEN_COCKPIT_POOL=1` from their parent's environment. `parse-origins.js` checks this env var first, so all pool-spawned sub-agents were tagged as "pool".

## Test plan
- [ ] Spawn a sub-agent via cockpit-cli start — should show "sub-agent" tag (peach)
- [ ] Pool sessions without children still show "pool" tag (green)
- [ ] Offloaded sub-agents retain "sub-agent" origin in archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)