### PR TITLE
fix: clean new sessions by skipping stale daemon buffer

### DIFF
--- a/docs/terminals.md
+++ b/docs/terminals.md
@@ -10,12 +10,9 @@ Tab labeled "Claude" for pool TUI, "Terminal N" for shells. Pool TUI tabs detach
 
 ## Pool TUI attach strategy
 
-`attachPoolTerminal` fetches the PTY's current dimensions and replay buffer from the daemon, creates xterm at those exact dimensions, and writes the buffer directly. This avoids two pitfalls:
+`attachPoolTerminal` skips the daemon's replay buffer entirely — recycled pool slots' buffers contain old session content from before `/clear`. Instead, it forces a SIGWINCH to trigger Claude's clean redraw. macOS's XNU kernel skips SIGWINCH when `ioctl(TIOCSWINSZ)` sets identical dimensions, so the code "jiggles" the PTY (shrinks by 1 column, then restores) to guarantee delivery.
 
-1. **xterm.js reflow garbling**: Writing an 80×24 buffer into a 200×50 terminal causes xterm to reflow lines, corrupting TUI cursor positioning.
-2. **macOS SIGWINCH suppression**: macOS's XNU kernel skips SIGWINCH when `ioctl(TIOCSWINSZ)` sets the same dimensions (`bcmp` check in `tty_ioctl`). If the PTY already matches the window size, relying on SIGWINCH for a redraw silently fails.
-
-`reportTerminalDims` still reports window size to pool-manager so new pool slots spawn at the correct dimensions from the start (reduces initial resize flash), but it's no longer required for correctness.
+`reportTerminalDims` reports window size to pool-manager so new pool slots spawn at the correct dimensions from the start (reduces initial resize flash).
 
 ## TUI reflow prevention
 
@@ -25,9 +22,7 @@ xterm.js reflow on resize treats all content as reflowable text, re-wrapping lin
 
 Shell terminals are unaffected — reflow is acceptable for normal text output.
 
-**Key invariant**: Pool TUI terminals must never have cursor-positioned content in xterm's buffer when a resize occurs. Either write the buffer at matching dimensions (initial attach) or clear before resize (ongoing resizes).
-
-**macOS-specific**: macOS's XNU kernel skips SIGWINCH when `ioctl(TIOCSWINSZ)` sets the same dimensions (`bcmp` check in `tty_ioctl`). This is why `attachPoolTerminal` fetches PTY dims and writes the buffer at matching dimensions rather than skipping the buffer and relying on SIGWINCH — if the PTY already matches the window size, SIGWINCH never fires.
+**Key invariant**: Pool TUI terminals must never have cursor-positioned content in xterm's buffer when a resize occurs. Skip the buffer entirely (initial attach) or clear before resize (ongoing resizes).
 
 ## Reconnect handling
 

--- a/src/terminal-manager.js
+++ b/src/terminal-manager.js
@@ -337,10 +337,19 @@ export async function attachPoolTerminal(poolTermId) {
   term.loadAddon(fitAddon);
   term.open(container);
 
-  // Write the buffer directly at matching dimensions (no reflow).
-  // Then skip the daemon's replay event to avoid writing it twice.
-  if (ptyInfo?.buffer) {
-    term.write(ptyInfo.buffer);
+  // Skip the daemon's replay event — the buffer contains old session content
+  // from before /clear (the PTY persists across session recycling). Instead of
+  // writing stale content, force a SIGWINCH so Claude redraws cleanly.
+  const hasBuffer = !!ptyInfo?.buffer;
+  if (hasBuffer && ptyInfo.cols && ptyInfo.rows) {
+    // Jiggle PTY dimensions to force SIGWINCH delivery. macOS kernel skips
+    // SIGWINCH when ioctl(TIOCSWINSZ) sets identical dimensions.
+    window.api.ptyResize(
+      poolTermId,
+      Math.max(1, ptyInfo.cols - 1),
+      ptyInfo.rows,
+    );
+    await window.api.ptyResize(poolTermId, ptyInfo.cols, ptyInfo.rows);
   }
 
   const entry = {
@@ -350,7 +359,7 @@ export async function attachPoolTerminal(poolTermId) {
     fitAddon,
     container,
     isPoolTui: true,
-    skipReplay: !!ptyInfo?.buffer,
+    skipReplay: hasBuffer,
     dockTabId: null,
     _resizeHandler: null,
   };


### PR DESCRIPTION
## Summary

- Recycled pool slots' daemon buffer contains old session content from before `/clear` — writing it to xterm caused TUI artifacts in new sessions
- Previously relied on `setupTerminalResize` to clear, but that only fires when dims change — since pool PTYs now spawn at actual window dims, the clear never triggers
- Skip the buffer entirely, force SIGWINCH via dimension jiggle so Claude redraws cleanly

## Test plan

- [ ] Cmd+N with pool running — new session should show clean Claude TUI, no old content
- [ ] Resize window between sessions — still clean
- [ ] Narrow window (cols near 1) — no crash from 0-column resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)