### PR TITLE
fix: add debug logging for silently swallowed failures

### DIFF
--- a/docs/debug-logging.md
+++ b/docs/debug-logging.md
@@ -40,9 +40,9 @@ Log rotates at 2 MB. Previous log is kept as `debug.log.1`. Only one generation 
 |-----|--------------|
 | `renderer:session` | Session selection, race-condition aborts (with generation counter) |
 | `renderer:pool` | Offload attempts, fresh-slot polling, poll timeouts, resume failures |
-| `renderer:term` | Terminal attach failures |
+| `renderer:term` | Terminal attach/detach/kill failures |
 | `renderer:editor` | Intention save failures |
-| `renderer:startup` | PTY reconnection count, orphaned PTY detach |
+| `renderer:startup` | PTY reconnection count, orphaned PTY detach, shortcut config failures |
 
 ### Main (`main`)
 

--- a/src/main.js
+++ b/src/main.js
@@ -550,7 +550,12 @@ app.whenReady().then(async () => {
 
   // Poll fresh terminal buffers for input detection (ground truth)
   setInterval(
-    () => sessionDiscovery.pollTerminalInput().catch(() => {}),
+    () =>
+      sessionDiscovery
+        .pollTerminalInput()
+        .catch((err) =>
+          debugLog("main", "pollTerminalInput failed", err.message),
+        ),
     10_000,
   );
 

--- a/src/pool-ui.js
+++ b/src/pool-ui.js
@@ -2,6 +2,7 @@ import {
   showNotification,
   STATUS_CLASSES,
   escapeHtml,
+  debugLog,
 } from "./renderer-state.js";
 import { STATUS, POOL_STATUS, UPDATE_STATUS } from "./session-statuses.js";
 import { FitAddon } from "@xterm/addon-fit";
@@ -112,7 +113,11 @@ async function openSlotTerminalPopup(slot) {
           otherEntry.term.rows,
         );
       } else {
-        window.api.ptyDetach(slot.termId).catch(() => {});
+        window.api
+          .ptyDetach(slot.termId)
+          .catch((e) =>
+            debugLog("pool", `detach failed termId=${slot.termId}`, e.message),
+          );
       }
       term.dispose();
     },

--- a/src/pty-daemon.js
+++ b/src/pty-daemon.js
@@ -245,14 +245,22 @@ function handleSpawn(socket, msg) {
 
 function handleWrite(msg) {
   const entry = terminals.get(msg.termId);
-  if (entry && !entry.meta.exited) {
+  if (!entry) {
+    console.error(`[pty-daemon] write: unknown termId=${msg.termId}`);
+    return;
+  }
+  if (!entry.meta.exited) {
     entry.proc.write(msg.data);
   }
 }
 
 function handleResize(msg) {
   const entry = terminals.get(msg.termId);
-  if (entry && !entry.meta.exited) {
+  if (!entry) {
+    console.error(`[pty-daemon] resize: unknown termId=${msg.termId}`);
+    return;
+  }
+  if (!entry.meta.exited) {
     entry.proc.resize(msg.cols, msg.rows);
     entry.meta.cols = msg.cols;
     entry.meta.rows = msg.rows;
@@ -340,19 +348,23 @@ function handleAttach(socket, msg) {
 
 function handleDetach(socket, msg) {
   const entry = terminals.get(msg.termId);
-  if (entry) {
-    entry.clients.delete(socket);
-    // Clean up exited terminals with no attached clients
-    if (entry.meta.exited && entry.clients.size === 0) {
-      terminals.delete(msg.termId);
-      resetIdleTimer();
-    }
+  if (!entry) {
+    console.error(`[pty-daemon] detach: unknown termId=${msg.termId}`);
+    return;
+  }
+  entry.clients.delete(socket);
+  // Clean up exited terminals with no attached clients
+  if (entry.meta.exited && entry.clients.size === 0) {
+    terminals.delete(msg.termId);
+    resetIdleTimer();
   }
 }
 
 function handleClearBuffer(socket, msg) {
   const entry = terminals.get(msg.termId);
-  if (entry) {
+  if (!entry) {
+    console.error(`[pty-daemon] clear-buffer: unknown termId=${msg.termId}`);
+  } else {
     entry.chunks = [];
     entry.chunksLen = 0;
   }
@@ -365,7 +377,9 @@ function handleClearBuffer(socket, msg) {
 
 function handleSetSession(socket, msg) {
   const entry = terminals.get(msg.termId);
-  if (entry) {
+  if (!entry) {
+    console.error(`[pty-daemon] set-session: unknown termId=${msg.termId}`);
+  } else {
     entry.meta.sessionId = msg.sessionId;
   }
   sendTo(socket, {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -371,7 +371,11 @@ async function resumeOffloadedSession(session) {
     if (oldCached) {
       for (const entry of oldCached.terminals) {
         if (activeTermIds.has(entry.termId)) continue;
-        window.api.ptyDetach(entry.termId).catch(() => {});
+        window.api
+          .ptyDetach(entry.termId)
+          .catch((e) =>
+            debugLog("term", `detach failed termId=${entry.termId}`, e.message),
+          );
         disposeTerminalEntry(entry, state.dock);
       }
     }
@@ -637,11 +641,24 @@ async function archiveCurrentSession() {
     const pty = allPtys.find(
       (p) => p.sessionId === session.sessionId && !p.exited,
     );
-    if (pty) window.api.ptyKill(pty.termId).catch(() => {});
+    if (pty)
+      window.api
+        .ptyKill(pty.termId)
+        .catch((e) =>
+          debugLog("term", `kill failed termId=${pty.termId}`, e.message),
+        );
     destroySessionTerminals(session.sessionId);
   } else if (session.origin !== ORIGIN.POOL && session.alive && session.pid) {
     // External/sub-claude session: close external terminal
-    window.api.closeExternalTerminal(session.pid).catch(() => {});
+    window.api
+      .closeExternalTerminal(session.pid)
+      .catch((e) =>
+        debugLog(
+          "term",
+          `closeExternalTerminal failed pid=${session.pid}`,
+          e.message,
+        ),
+      );
   }
 
   // Archive in background (with child check + confirmation if needed)
@@ -1080,7 +1097,9 @@ loadDirColors().then(async () => {
   try {
     const shortcuts = await window.api.getShortcuts();
     setShortcutConfig(shortcuts);
-  } catch {}
+  } catch (err) {
+    debugLog("startup", "getShortcuts failed", err.message);
+  }
 
   await reconnectAllPtys();
   const POLL_INTERVAL = 30000; // Safety net — events handle normal refresh

--- a/src/terminal-manager.js
+++ b/src/terminal-manager.js
@@ -463,7 +463,11 @@ export async function closeTerminal(index) {
     ? state.dock.getTabLeafId(entry.dockTabId)
     : null;
 
-  await window.api.ptyDetach(entry.termId).catch(() => {});
+  await window.api
+    .ptyDetach(entry.termId)
+    .catch((e) =>
+      debugLog("term", `detach failed termId=${entry.termId}`, e.message),
+    );
   await window.api.ptyKill(entry.termId);
   disposeTerminalEntry(entry, state.dock);
   state.terminals.splice(index, 1);
@@ -527,11 +531,19 @@ export function destroySessionTerminals(sessionId, { keepAlive = false } = {}) {
   const cached = sessionTerminals.get(sessionId);
   if (!cached) return;
   for (const entry of cached.terminals) {
-    window.api.ptyDetach(entry.termId).catch(() => {});
+    window.api
+      .ptyDetach(entry.termId)
+      .catch((e) =>
+        debugLog("term", `detach failed termId=${entry.termId}`, e.message),
+      );
     // Don't kill pool TUI terminals — the Claude process must stay alive.
     // With keepAlive, also skip killing extra shells (they survive in daemon).
     if (!entry.isPoolTui && !keepAlive) {
-      window.api.ptyKill(entry.termId).catch(() => {});
+      window.api
+        .ptyKill(entry.termId)
+        .catch((e) =>
+          debugLog("term", `kill failed termId=${entry.termId}`, e.message),
+        );
     }
     const activeDock = sessionId === state.currentSessionId ? state.dock : null;
     disposeTerminalEntry(entry, activeDock);
@@ -545,9 +557,17 @@ export function killAllTerminals() {
     destroySessionTerminals(sid);
   }
   for (const entry of state.terminals) {
-    window.api.ptyDetach(entry.termId).catch(() => {});
+    window.api
+      .ptyDetach(entry.termId)
+      .catch((e) =>
+        debugLog("term", `detach failed termId=${entry.termId}`, e.message),
+      );
     if (!entry.isPoolTui) {
-      window.api.ptyKill(entry.termId).catch(() => {});
+      window.api
+        .ptyKill(entry.termId)
+        .catch((e) =>
+          debugLog("term", `kill failed termId=${entry.termId}`, e.message),
+        );
     }
     disposeTerminalEntry(entry, state.dock);
   }
@@ -694,7 +714,15 @@ export async function reconnectAllPtys() {
     if (sid === "__none__") {
       debugLog("startup", `detaching ${sessionPtys.length} orphaned PTYs`);
       for (const p of sessionPtys) {
-        window.api.ptyDetach(p.termId).catch(() => {});
+        window.api
+          .ptyDetach(p.termId)
+          .catch((e) =>
+            debugLog(
+              "startup",
+              `orphan detach failed termId=${p.termId}`,
+              e.message,
+            ),
+          );
       }
       continue;
     }
@@ -825,7 +853,11 @@ window.api.onApiTermClosed((sessionId, termId) => {
   if (idx === -1) return;
 
   const entry = state.terminals[idx];
-  window.api.ptyDetach(entry.termId).catch(() => {});
+  window.api
+    .ptyDetach(entry.termId)
+    .catch((e) =>
+      debugLog("term", `detach failed termId=${entry.termId}`, e.message),
+    );
   disposeTerminalEntry(entry, state.dock);
   state.terminals.splice(idx, 1);
 


### PR DESCRIPTION
## Summary

- **pty-daemon**: Log unknown `termId` in `handleWrite`, `handleResize`, `handleDetach`, `handleClearBuffer`, `handleSetSession`
- **terminal-manager**: Replace all `.catch(() => {})` on PTY detach/kill with `debugLog` calls
- **renderer**: Log `getShortcuts` failure, PTY cleanup failures, `closeExternalTerminal` failures
- **main**: Log `pollTerminalInput` failures (was silent `.catch(() => {})`)
- **pool-ui**: Log PTY detach failure on slot preview close

Zero silent swallows remain across the codebase.

## Test plan

- [ ] Tail `~/.open-cockpit/debug.log` — verify no spurious errors during normal operation
- [ ] Kill daemon mid-session — verify cleanup failures are logged, not silently swallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)