### PR TITLE
fix: skip stale buffer for pool TUI on reconnect

### DIFF
--- a/docs/terminals.md
+++ b/docs/terminals.md
@@ -26,7 +26,10 @@ Shell terminals are unaffected — reflow is acceptable for normal text output.
 
 ## Reconnect handling
 
-When reconnecting to a session after app restart, `reconnectTerminal()` writes the PTY's saved buffer at matching dimensions. If the window has since changed size, `fitAddon.fit()` would reflow the buffer, garbling TUI content. To prevent this, entries are flagged with `_hasReconnectBuffer` — on the first resize, `setupTerminalResize` clears the buffer and lets SIGWINCH trigger a full redraw.
+When reconnecting to a session after app restart, `reconnectTerminal()` handles pool TUI and shell terminals differently:
+
+- **Pool TUI**: Skips the daemon buffer entirely (may contain stale content) and forces a SIGWINCH via dimension jiggle, same as `attachPoolTerminal`.
+- **Shell**: Writes the buffer at matching dimensions to restore scrollback. Flagged with `_hasReconnectBuffer` so `setupTerminalResize` clears on first resize if dims changed, preventing reflow garbling.
 
 ## API-created tabs
 

--- a/src/terminal-manager.js
+++ b/src/terminal-manager.js
@@ -657,11 +657,26 @@ export async function reconnectTerminal(ptyInfo) {
   };
 
   if (ptyInfo.buffer) {
-    term.write(ptyInfo.buffer);
-    entry.skipReplay = true;
-    // Flag so setupTerminalResize clears on first fit if dims changed,
-    // preventing reflow garbling of cursor-positioned content.
-    entry._hasReconnectBuffer = true;
+    if (entry.isPoolTui) {
+      // Pool TUI: skip stale buffer (may contain old session content from
+      // before /clear). Force SIGWINCH via dimension jiggle so Claude redraws.
+      entry.skipReplay = true;
+      if (ptyInfo.cols && ptyInfo.rows) {
+        window.api.ptyResize(
+          ptyInfo.termId,
+          Math.max(1, ptyInfo.cols - 1),
+          ptyInfo.rows,
+        );
+        await window.api.ptyResize(ptyInfo.termId, ptyInfo.cols, ptyInfo.rows);
+      }
+    } else {
+      // Shell: write buffer to restore scrollback
+      term.write(ptyInfo.buffer);
+      entry.skipReplay = true;
+      // Flag so setupTerminalResize clears on first fit if dims changed,
+      // preventing reflow garbling of cursor-positioned content.
+      entry._hasReconnectBuffer = true;
+    }
   }
 
   pendingTerminals.set(ptyInfo.termId, entry);


### PR DESCRIPTION
## Summary

- `reconnectTerminal()` now skips the daemon buffer for pool TUI terminals (may contain old session content) and forces SIGWINCH via dimension jiggle
- Shell terminals still get buffer replay for scrollback restoration
- Completes the stale-buffer fix series (#318, #319)

## Test plan

- [ ] Restart app with active pool session — Claude TUI redraws cleanly
- [ ] Restart app with shell tabs — scrollback is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)