### PR TITLE
fix: centralize SIGWINCH jiggle in doFit for robustness

### DIFF
--- a/src/dock-helpers.js
+++ b/src/dock-helpers.js
@@ -104,6 +104,14 @@ export function setupTerminalResize(entry) {
         window.api.ptyResize(entry.termId, cols, rows);
         // Report dims so future pool spawns use actual terminal size
         window.api.reportTerminalDims(cols, rows);
+        // Dims changed → SIGWINCH delivered naturally, redraw satisfied
+        delete entry._needsRedraw;
+      } else if (entry._needsRedraw) {
+        // Pool TUI needs a SIGWINCH but dims match. Jiggle to force delivery
+        // (macOS kernel skips SIGWINCH when ioctl sets identical dimensions).
+        delete entry._needsRedraw;
+        window.api.ptyResize(entry.termId, Math.max(1, cols - 1), rows);
+        window.api.ptyResize(entry.termId, cols, rows);
       } else {
         // Dimensions unchanged — force repaint for DOM reattachment cases
         // where the canvas renderer is stale. Skipped when dimensions changed

--- a/src/terminal-manager.js
+++ b/src/terminal-manager.js
@@ -339,6 +339,7 @@ export async function attachPoolTerminal(poolTermId) {
 
   // Skip the daemon's replay event — the buffer may contain old session
   // content from before /clear (the PTY persists across session recycling).
+  // Request a SIGWINCH redraw once the terminal becomes visible (doFit).
   const hasBuffer = !!ptyInfo?.buffer;
 
   const entry = {
@@ -349,6 +350,7 @@ export async function attachPoolTerminal(poolTermId) {
     container,
     isPoolTui: true,
     skipReplay: hasBuffer,
+    _needsRedraw: true,
     dockTabId: null,
     _resizeHandler: null,
   };
@@ -371,17 +373,6 @@ export async function attachPoolTerminal(poolTermId) {
 
   wireTerminalInput(term, poolTermId);
   setupTerminalResize(entry);
-
-  // Force SIGWINCH AFTER attach so Claude's redraw output reaches our terminal.
-  // Jiggle dimensions because macOS kernel skips SIGWINCH for identical dims.
-  if (hasBuffer && ptyInfo.cols && ptyInfo.rows) {
-    window.api.ptyResize(
-      poolTermId,
-      Math.max(1, ptyInfo.cols - 1),
-      ptyInfo.rows,
-    );
-    await window.api.ptyResize(poolTermId, ptyInfo.cols, ptyInfo.rows);
-  }
 
   // Register with dock
   dockRegisterTerminal(entry);
@@ -658,8 +649,9 @@ export async function reconnectTerminal(ptyInfo) {
 
   if (ptyInfo.buffer) {
     if (entry.isPoolTui) {
-      // Pool TUI: skip stale buffer, will jiggle SIGWINCH after attach
+      // Pool TUI: skip stale buffer, doFit will jiggle SIGWINCH when visible
       entry.skipReplay = true;
+      entry._needsRedraw = true;
     } else {
       // Shell: write buffer to restore scrollback
       term.write(ptyInfo.buffer);
@@ -687,16 +679,6 @@ export async function reconnectTerminal(ptyInfo) {
 
   wireTerminalInput(term, ptyInfo.termId);
   setupTerminalResize(entry);
-
-  // Force SIGWINCH AFTER attach so Claude's redraw reaches our terminal
-  if (entry.isPoolTui && ptyInfo.buffer && ptyInfo.cols && ptyInfo.rows) {
-    window.api.ptyResize(
-      ptyInfo.termId,
-      Math.max(1, ptyInfo.cols - 1),
-      ptyInfo.rows,
-    );
-    await window.api.ptyResize(ptyInfo.termId, ptyInfo.cols, ptyInfo.rows);
-  }
 
   return entry;
 }


### PR DESCRIPTION
## Summary

- Remove scattered SIGWINCH jiggle calls from `attachPoolTerminal` and `reconnectTerminal` — they were timing-dependent and unreliable
- Set `_needsRedraw` flag on pool TUI entries instead
- `doFit` (the single choke point for terminal visibility) handles the jiggle when the terminal actually becomes visible in the DOM
- Covers ALL paths: new session, reconnect, tab switch, layout restore

## Test plan

- [ ] Cmd+N repeatedly — Claude TUI always visible, never blank
- [ ] Switch between sessions — TUI redraws on each switch
- [ ] Restart app — existing sessions reconnect with visible TUI
- [ ] Open/close dev instances — sessions remain clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)