### PR TITLE
Fix first-prompt status stuck on typing

### DIFF
--- a/src/session-discovery.js
+++ b/src/session-discovery.js
@@ -811,6 +811,13 @@ async function getSessionsUncached() {
         const jsonlPath = jsonlPathCache.get(sessionId);
         if (isActivated) {
           status = STATUS.PROCESSING;
+        } else if (poolSlot) {
+          // Pool sessions always have idle signals when idle (pool-init,
+          // stop, tool, permission, session-clear). syncPoolStatuses
+          // recreates missing pool-init signals for fresh slots. So a
+          // missing idle signal on a pool session means UserPromptSubmit
+          // cleared it — the session is processing its first prompt.
+          status = STATUS.PROCESSING;
         } else {
           // "user" needle: this path only runs when idle signal is absent
           // (prompt just submitted), so "user" entries are real, not /clear artifacts.


### PR DESCRIPTION
## Summary

- Pool sessions always have idle signals when idle (pool-init, stop, tool, permission, session-clear)
- On first prompt, `UserPromptSubmit` clears the idle signal, but the session isn't "activated" yet (pool-init trigger is in `FRESH_TRIGGERS`)
- The `transcriptContains` fallback failed because: (1) JSONL user entry isn't written yet when the hook fires, and (2) the fingerprint-based cache doesn't capture JSONL content changes, so the stale "typing" result persisted for up to 30s
- Fix: for pool sessions with no idle signal + not activated → PROCESSING (safe because `syncPoolStatuses` recreates missing pool-init signals for fresh slots)

## Test plan

- [ ] Start a fresh pool session, submit a prompt → should show "processing" immediately (not "typing")
- [ ] After Claude responds → should show "idle"
- [ ] Submit second prompt → should show "processing" (via existing `isActivated` path)
- [ ] Fresh pool slots with no user interaction → should still show "fresh"
- [ ] External/custom sessions still work as before (not affected by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)