### PR TITLE
fix: restore jitter terminal shortcut lost in #340 merge

### DIFF
--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -224,6 +224,12 @@ export function initCommandPalette(actions) {
       shortcutAction: "run-agent",
       action: () => _actions.showAgentPicker(),
     },
+    {
+      id: "jitter-terminal",
+      label: "Jitter Terminal (Clear Artifacts)",
+      shortcutAction: "jitter-terminal",
+      action: () => _actions.jitterCurrentTerminal(),
+    },
   ];
 
   // Also add Tab 1-9 commands

--- a/src/main.js
+++ b/src/main.js
@@ -329,6 +329,11 @@ function buildMenu() {
           click: () => send("open-pool-settings"),
         },
         {
+          label: "Jitter Terminal",
+          accelerator: accel("jitter-terminal"),
+          click: () => send("jitter-terminal"),
+        },
+        {
           label: "Toggle Bell",
           accelerator: accel("toggle-bell"),
           click: () => send("toggle-bell"),

--- a/src/preload.js
+++ b/src/preload.js
@@ -39,6 +39,7 @@ const channels = [
   "open-pool-settings",
   "session-info",
   "toggle-bell",
+  "jitter-terminal",
   "session-search",
   "run-agent",
   "pool-slots-recovered",
@@ -173,6 +174,8 @@ contextBridge.exposeInMainWorld("api", {
   getAllSessionStats: () => ipcRenderer.invoke("get-all-session-stats"),
   onOpenSessionInfo: (callback) =>
     ipcRenderer.on("session-info", () => callback()),
+  onJitterTerminal: (callback) =>
+    ipcRenderer.on("jitter-terminal", () => callback()),
 
   // Dialog state — suppresses global shortcuts while a modal is open
   setDialogOpen: (open) => ipcRenderer.send("dialog-open", open),

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -53,6 +53,8 @@ const DEFAULT_SHORTCUTS = {
   "session-info": "CmdOrCtrl+I",
   // Agents
   "run-agent": "CmdOrCtrl+Shift+A",
+  // Debug: jitter current terminal to clear artifacts
+  "jitter-terminal": "CmdOrCtrl+Shift+J",
   // These are handled via before-input-event, not menu accelerators
   "next-terminal-tab-alt": "Ctrl+Tab",
   "prev-terminal-tab-alt": "Ctrl+Shift+Tab",


### PR DESCRIPTION
## Summary

- Restores the jitter terminal shortcut (⌘⇧J) wiring that was accidentally removed during the #340 merge
- Adds back: menu item in main.js, shortcut default in shortcuts.js, IPC channel + bridge in preload.js, command palette entry in command-palette.js
- The renderer.js implementation (from #339 / cb79039) was already intact — only the wiring was missing

## Test plan

- [ ] Press ⌘⇧J — should trigger terminal jitter (cols+1 then back)
- [ ] Open command palette — "Jitter Terminal (Clear Artifacts)" should appear
- [ ] Check View menu — "Jitter Terminal" item should be present before "Toggle Bell"
- [ ] Verify shortcut is configurable in pool settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)