### PR TITLE
fix: make renderer startup resilient to PTY reconnect failures

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1148,37 +1148,42 @@ window.api.onIntentionChanged((content) => {
 
 // --- Startup ---
 
-loadDirColors().then(async () => {
-  // Load shortcut config for command palette display
-  try {
-    const shortcuts = await window.api.getShortcuts();
-    setShortcutConfig(shortcuts);
-  } catch {}
+loadDirColors()
+  .then(async () => {
+    // Load shortcut config for command palette display
+    try {
+      const shortcuts = await window.api.getShortcuts();
+      setShortcutConfig(shortcuts);
+    } catch {}
 
-  await reconnectAllPtys();
-  const POLL_INTERVAL = 30000; // Safety net — events handle normal refresh
-  let sessionPollInterval = setInterval(loadSessions, POLL_INTERVAL);
-  loadSessions();
+    await reconnectAllPtys();
 
-  // Event-driven refresh: main process pushes (already debounced) when
-  // idle-signals/session-pids change. Reset poll timer on each event since
-  // polling only needs to kick in when events stop working.
-  window.api.onSessionsChanged(() => {
+    const POLL_INTERVAL = 30000; // Safety net — events handle normal refresh
+    let sessionPollInterval = setInterval(loadSessions, POLL_INTERVAL);
     loadSessions();
-    clearInterval(sessionPollInterval);
-    sessionPollInterval = setInterval(loadSessions, POLL_INTERVAL);
-  });
 
-  // Pause polling when window is hidden to save CPU
-  document.addEventListener("visibilitychange", () => {
-    if (document.hidden) {
+    // Event-driven refresh: main process pushes (already debounced) when
+    // idle-signals/session-pids change. Reset poll timer on each event since
+    // polling only needs to kick in when events stop working.
+    window.api.onSessionsChanged(() => {
+      loadSessions();
       clearInterval(sessionPollInterval);
-      sessionPollInterval = null;
-    } else {
-      if (!sessionPollInterval) {
-        loadSessions();
-        sessionPollInterval = setInterval(loadSessions, POLL_INTERVAL);
+      sessionPollInterval = setInterval(loadSessions, POLL_INTERVAL);
+    });
+
+    // Pause polling when window is hidden to save CPU
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) {
+        clearInterval(sessionPollInterval);
+        sessionPollInterval = null;
+      } else {
+        if (!sessionPollInterval) {
+          loadSessions();
+          sessionPollInterval = setInterval(loadSessions, POLL_INTERVAL);
+        }
       }
-    }
+    });
+  })
+  .catch((err) => {
+    debugLog("startup", "renderer startup failed:", err.message);
   });
-});

--- a/src/terminal-manager.js
+++ b/src/terminal-manager.js
@@ -651,10 +651,22 @@ export async function reconnectAllPtys() {
       }
       continue;
     }
+    const results = await Promise.allSettled(
+      sessionPtys.map((p) => reconnectTerminal(p)),
+    );
     const entries = [];
-    for (const p of sessionPtys) {
-      entries.push(await reconnectTerminal(p));
+    for (let i = 0; i < results.length; i++) {
+      const r = results[i];
+      if (r.status === "fulfilled") {
+        entries.push(r.value);
+      } else {
+        debugLog(
+          "startup",
+          `failed to reconnect termId=${sessionPtys[i].termId} session=${sid}: ${r.reason.message}`,
+        );
+      }
     }
+    if (entries.length === 0) continue; // All terminals failed — skip session
     const savedLayout = await window.api.loadLayout(sid);
     sessionTerminals.set(sid, {
       terminals: entries,


### PR DESCRIPTION
## Summary

- Individual PTY attach failures no longer kill the entire renderer startup chain (`loadSessions`, event listeners, session polling all stopped)
- PTY reconnects now run in parallel via `Promise.allSettled` (faster startup)
- Added `.catch()` on the startup promise chain to log errors to `debug.log` instead of silently swallowing them
- Failed reconnects are logged with termId and sessionId for debugging

## Root cause

`reconnectAllPtys()` was `await`ed without try/catch inside a `.then()` chain that had no `.catch()`. A single PTY attach failure would reject the promise, skipping `loadSessions()` and `onSessionsChanged` listener setup — leaving the sidebar permanently empty until Cmd+N triggered a manual `loadSessions()`.

## Test plan

- [ ] Cmd+R with active sessions → sidebar populates immediately
- [ ] Kill a PTY mid-reconnect → other sessions still appear, error logged in `~/.open-cockpit/debug.log`
- [ ] `npm test` passes (442/442)

🤖 Generated with [Claude Code](https://claude.com/claude-code)