### PR TITLE
docs: add branching rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,8 +128,18 @@ Tag push → CI builds all platforms → publish the draft. See [docs/releasing.
 
 `.githooks/` (auto-configured via `prepare` script):
 - `pre-commit` — prettier
+- `pre-push` — runs tests + rejects merge commits in feature branches
 - `post-checkout` — auto-install deps + build for worktrees
 - `post-merge` — auto-build after pull
+
+## Branching
+
+**Rebase, never merge.** Feature branches must not contain merge commits — the pre-push hook and CI (`no-merge-commits.yml`) enforce this. To update a branch:
+```bash
+git fetch origin
+git rebase origin/main
+```
+Merge commits inside feature branches can silently drop code during conflict resolution (see #340).
 
 ## Worktree setup
 


### PR DESCRIPTION
## Summary

- Document rebase-only policy for feature branches
- Add pre-push hook to git hooks list
- Reference #340 as the motivating incident and the CI/hook enforcement

This ensures agents and contributors know to use `git rebase origin/main` instead of `git merge origin/main` when updating branches.

## Test plan

- [x] CLAUDE.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)