### PR TITLE
fix: prevent double-restore race condition

### DIFF
--- a/hooks/session-pid-map.sh
+++ b/hooks/session-pid-map.sh
@@ -42,7 +42,7 @@ for f in "$SESSION_PIDS_DIR"/*; do
     [ -f "$f" ] || continue
     pid=$(basename "$f")
     if ! kill -0 "$pid" 2>/dev/null; then
-        echo "[session-pid-map] Cleanup: removing session-pids/$pid (process dead)" >> "$OC_DIR/debug.log" 2>/dev/null || true
+        printf '%s [hook:session-pid-map] Cleanup: removing session-pids/%s (process dead)\n' "$(date -u '+%Y-%m-%dT%H:%M:%S.000Z')" "$pid" >> "$OC_DIR/debug.log" 2>/dev/null || true
         rm -f "$f"
     fi
 done
@@ -56,7 +56,7 @@ for f in "$SESSION_PIDS_DIR"/*; do
     other_sid=$(cat "$f" 2>/dev/null) || continue
     if [ "$other_sid" = "$session_id" ]; then
         if [ "$f" -ot "$SESSION_PIDS_DIR/$PPID" ]; then
-            echo "[session-pid-map] Dedup: removing session-pids/$pid (same session_id=$session_id as PID $PPID, older file)" >> "$OC_DIR/debug.log" 2>/dev/null || true
+            printf '%s [hook:session-pid-map] Dedup: removing session-pids/%s (same session_id=%s as PID %s, older file)\n' "$(date -u '+%Y-%m-%dT%H:%M:%S.000Z')" "$pid" "$session_id" "$PPID" >> "$OC_DIR/debug.log" 2>/dev/null || true
             rm -f "$f"
         fi
     fi

--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -1682,10 +1682,10 @@ async function poolResume(sessionId) {
   const { invalidateSessionsCache } = getSessionDiscovery();
   validateSessionId(sessionId);
 
-  // Prevent double-restore: if another caller is already restoring this session,
-  // skip silently. This guards against the race where restorePendingSessions and
-  // restoreFromActiveRegistry both try to restore the same session before
-  // trackNewSlot updates pool.json.
+  // Prevent double-restore: guards against the race where restorePendingSessions
+  // and restoreFromActiveRegistry both try to restore the same session before
+  // trackNewSlot updates pool.json. The guard is added after validation so
+  // early throws don't need manual cleanup.
   if (_pendingRestores.has(sessionId)) {
     _debugLog(
       "main",
@@ -1693,16 +1693,14 @@ async function poolResume(sessionId) {
     );
     throw new Error("Session is already being restored");
   }
-  _pendingRestores.add(sessionId);
 
-  // Also check if this session is already live in a pool slot
+  // Check if this session is already live in a pool slot
   const currentPool = readPool();
   if (currentPool) {
     const alreadyLive = currentPool.slots.find(
       (s) => s.sessionId === sessionId,
     );
     if (alreadyLive) {
-      _pendingRestores.delete(sessionId);
       _debugLog(
         "main",
         `poolResume skipped: session ${sessionId} already in slot ${alreadyLive.index} (termId=${alreadyLive.termId})`,
@@ -1712,15 +1710,13 @@ async function poolResume(sessionId) {
   }
 
   const meta = readOffloadMeta(sessionId);
-  if (!meta) {
-    _pendingRestores.delete(sessionId);
-    throw new Error("No offload data for session");
-  }
+  if (!meta) throw new Error("No offload data for session");
   const claudeSessionId = meta.claudeSessionId || meta.sessionId;
-  if (!claudeSessionId) {
-    _pendingRestores.delete(sessionId);
-    throw new Error("No Claude session ID stored");
-  }
+  if (!claudeSessionId) throw new Error("No Claude session ID stored");
+
+  // Add guard after all validation — stays active until trackNewSlot resolves
+  // (which happens async after poolResume returns).
+  _pendingRestores.add(sessionId);
 
   let result;
   try {


### PR DESCRIPTION
## Summary

- **Root cause**: `restorePendingSessions` and `restoreFromActiveRegistry` both fire after `poolInit`. The first restores a session via `poolResume`, but `trackNewSlot` updates pool.json asynchronously (fire-and-forget). By the time the second restore reads pool.json, the session isn't there yet — so it restores the same session again.
- **Result**: Two pool slots claim the same session ID. The second slot's idle signal references the wrong (pre-resume) session, gets discarded by the `session_id !== sessionId` guard in session-discovery.js, and the session shows as "processing" permanently.
- **Fix**: Module-level `_pendingRestores` Set in `poolResume` acts as a synchronous guard — session ID is added before any async work, removed when tracking completes or fails. Also adds an "already live in pool" check as a second defense layer.
- **Observability**: Added debug logging for `/resume` commands (which slot/PID/termId), and made `session-pid-map.sh` log dedup and stale PID removals to `debug.log` instead of doing them silently.

## Test plan

- [x] All 469 existing tests pass
- [ ] Kill + restart Open Cockpit with an active session — verify single restore, no duplicate slots
- [ ] Check `debug.log` for new `poolResume:` log lines showing slot assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)