### PR TITLE
refactor: source shared pre-push hook from dotfiles

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,49 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-# Skip everything for delete-only pushes (branch cleanup)
-is_delete_only=true
-while read local_ref local_oid remote_ref remote_oid; do
-  if [ "$local_oid" != "0000000000000000000000000000000000000000" ]; then
-    is_delete_only=false
-    break
-  fi
-done
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 
-if [ "$is_delete_only" = true ]; then
-  echo "Delete-only push — skipping checks."
-  exit 0
-fi
+# Source shared merge-commit check from dotfiles (handles delete-only pushes too)
+[ -f "$HOME/.config/git-hooks/pre-push-base.sh" ] && source "$HOME/.config/git-hooks/pre-push-base.sh" || true
 
-# --- Reject merge commits in feature branches ---
-# Merge commits inside feature branches can silently drop code during
-# conflict resolution (see #340). Use 'git rebase origin/main' instead.
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [ "$BRANCH" != "main" ]; then
-  # Compare against origin/main if available, fall back to main
-  BASE=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main 2>/dev/null || true)
-  if [ -n "$BASE" ]; then
-    MERGE_COMMITS=$(git rev-list --merges "$BASE"..HEAD)
-    if [ -n "$MERGE_COMMITS" ]; then
-      echo ""
-      echo "❌ Push rejected: merge commits found in branch '$BRANCH'"
-      echo ""
-      echo "Merge commits can silently drop code during conflict resolution."
-      echo "Found:"
-      for sha in $MERGE_COMMITS; do
-        echo "  - $(git log --format='%h %s' -1 "$sha")"
-      done
-      echo ""
-      echo "Fix: rebase onto main instead:"
-      echo "  git fetch origin"
-      echo "  git rebase origin/main"
-      echo "  git push --force-with-lease"
-      echo ""
-      exit 1
-    fi
-  fi
-fi
-
+# Project-specific: run tests before push
 echo "Running tests before push..."
 npm test
-


### PR DESCRIPTION
## Summary

- Replace 42 lines of inline merge-commit check with sourcing `~/.config/git-hooks/pre-push-base.sh`
- Single source of truth across all repos — updates propagate via `deploy.sh`
- Project-specific `npm test` remains after the shared check

Depends on dotfiles PR #53 (merged).

## Test plan

- [x] Pre-push hook fires on push: "✓ No merge commits in branch."
- [x] All 469 tests pass
- [x] Delete-only push handling delegated to shared base

🤖 Generated with [Claude Code](https://claude.com/claude-code)