### PR TITLE
fix: show actual app version in settings

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -385,11 +385,7 @@ let ownsApiSocket = false;
 app.whenReady().then(async () => {
   debugLog("main", `starting${IS_DEV ? " (dev)" : ""} pid=${process.pid}`);
 
-  // Read app version once from plugin.json
-  const pluginJson = readJsonSync(
-    path.join(__dirname, "..", ".claude-plugin", "plugin.json"),
-  );
-  const cachedAppVersion = pluginJson?.version || PLUGIN_VERSION.UNKNOWN;
+  const cachedAppVersion = app.getVersion();
 
   // Start watching installed_plugins.json for version changes
   startPluginVersionWatch();


### PR DESCRIPTION
## Summary

- `cachedAppVersion` was sourced from `.claude-plugin/plugin.json` instead of `package.json`, so the "App Version" in Settings always showed the plugin version
- Replaced with `app.getVersion()` which reads the real Electron app version

## Test plan

- [ ] Open Settings → General tab → verify App Version and Plugin Version show different values
- [ ] All 469 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)