### PR TITLE
fix: skip e2e tests in CI

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,7 +1,14 @@
 import { defineConfig } from "vitest/config";
 
+const ciExcludes = process.env.CI ? ["**/e2e-*.test.js"] : [];
+
 export default defineConfig({
   test: {
-    exclude: ["**/node_modules/**", "**/.claude/**", "**/.wt/**"],
+    exclude: [
+      "**/node_modules/**",
+      "**/.claude/**",
+      "**/.wt/**",
+      ...ciExcludes,
+    ],
   },
 });


### PR DESCRIPTION
## Summary

- E2e tests (`e2e-*.test.js`) spawn real Claude processes and always fail on CI runners (no `claude` CLI)
- Exclude them in `vitest.config.js` when `CI` env var is set
- All 27 unit/integration test files still run; e2e tests run locally as before

## Test plan

- [x] `npm test` locally → 30 files, 469 tests pass (e2e included)
- [x] `CI=true npm test` → 27 files, 463 tests pass (e2e excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)