### PR TITLE
fix: use OPEN_COCKPIT_DIR for shortcuts and hook logs

### DIFF
--- a/hooks/log-error.sh
+++ b/hooks/log-error.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Logs hook errors to ~/.open-cockpit/logs/hooks.log with rotation.
+# Logs hook errors to $OPEN_COCKPIT_DIR/logs/hooks.log with rotation.
 #
 # Usage (source from hook scripts):
 #   source "$(dirname "$0")/log-error.sh"
@@ -10,7 +10,7 @@
 # Note: This sets a trap on ERR. If a hook needs its own ERR trap,
 # it must call _hook_log_error manually from within it.
 
-HOOK_LOG_DIR="$HOME/.open-cockpit/logs"
+HOOK_LOG_DIR="${OPEN_COCKPIT_DIR:-$HOME/.open-cockpit}/logs"
 HOOK_LOG_FILE="$HOOK_LOG_DIR/hooks.log"
 HOOK_LOG_MAX_SIZE=102400  # 100KB
 

--- a/src/agent-picker.js
+++ b/src/agent-picker.js
@@ -60,7 +60,7 @@ export async function showAgentPicker() {
 
   if (allAgents.length === 0) {
     _actions.showNotification(
-      "No agents found. Create scripts in ~/.open-cockpit/agents/",
+      "No agents found. Create scripts in the agents/ directory.",
     );
     return;
   }

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -1,17 +1,13 @@
 // Shortcut configuration system
-// Stores user overrides in ~/.open-cockpit/shortcuts.json
+// Stores user overrides in $OPEN_COCKPIT_DIR/shortcuts.json
 // Missing keys use defaults from DEFAULT_SHORTCUTS
 
 const fs = require("fs");
 const path = require("path");
-const os = require("os");
 const { secureMkdirSync, secureWriteFileSync } = require("./secure-fs");
+const { OPEN_COCKPIT_DIR } = require("./paths");
 
-const SHORTCUTS_FILE = path.join(
-  os.homedir(),
-  ".open-cockpit",
-  "shortcuts.json",
-);
+const SHORTCUTS_FILE = path.join(OPEN_COCKPIT_DIR, "shortcuts.json");
 
 // Default shortcut mappings: action ID -> Electron accelerator string
 // Empty string = unbound by default


### PR DESCRIPTION
## Summary

- `shortcuts.js` hardcoded `~/.open-cockpit/shortcuts.json` — now imports `OPEN_COCKPIT_DIR` from `paths.js`
- `hooks/log-error.sh` hardcoded `~/.open-cockpit/logs` — now uses `${OPEN_COCKPIT_DIR:-...}` fallback
- `agent-picker.js` notification no longer references a hardcoded path

Missed in #360 (instance isolation via `OPEN_COCKPIT_DIR`).

## Test plan

- [x] All 474 tests pass
- [ ] Verify shortcut overrides work in dev instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)