### PR TITLE
fix: Cmd+Shift+R intercepted by Electron forceReload

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -398,7 +398,11 @@ function buildMenu() {
       label: "View",
       submenu: [
         { role: "reload" },
-        { role: "forceReload" },
+        {
+          label: "Force Reload",
+          role: "forceReload",
+          accelerator: "CmdOrCtrl+Alt+R",
+        },
         {
           label: "Relaunch App",
           accelerator: accel("relaunch-app"),


### PR DESCRIPTION
## Summary
- Electron's built-in `forceReload` role has `Cmd+Shift+R` as default accelerator, shadowing our Relaunch App shortcut
- Move forceReload to `Cmd+Alt+R` so Cmd+Shift+R correctly triggers rebuild + relaunch

## Test plan
- [ ] Cmd+Shift+R — app rebuilds from source and relaunches (debug.log shows `buildAndRelaunch`)
- [ ] Cmd+Alt+R — force reloads renderer (old forceReload behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)