### PR TITLE
Change command palette shortcut to ⌘⇧P

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -55,7 +55,7 @@ All shortcuts appear in the command palette (`Cmd+/`). The `COMMANDS` array in `
 | `Ctrl+Alt+Cmd+C` | Open in Cursor |
 | `Escape` | Focus Terminal |
 | `Cmd+K` | Search Sessions |
-| `Cmd+/` | Command Palette |
+| `Cmd+Shift+P` | Command Palette |
 | `Cmd+,` | Pool Settings |
 | `Cmd+Alt+]` / `[` | Focus Next / Previous Pane |
 | `Alt+Right` | Toggle Child Sessions (expand/collapse) |

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -28,7 +28,7 @@ const DEFAULT_SHORTCUTS = {
   "jump-recent-idle": "CmdOrCtrl+J",
   "archive-current-session": "CmdOrCtrl+D",
   "open-in-cursor": "Ctrl+Alt+Cmd+C",
-  "toggle-command-palette": "CmdOrCtrl+/",
+  "toggle-command-palette": "CmdOrCtrl+Shift+P",
   "open-pool-settings": "CmdOrCtrl+,",
   // Dock panel management
   "focus-next-pane": "CmdOrCtrl+Alt+]",


### PR DESCRIPTION
## Summary
- Changes the default command palette shortcut from `⌘/` to `⌘⇧P` to match the standard convention (VS Code, etc.)

## Test plan
- [ ] Open app, press `⌘⇧P` — command palette opens
- [ ] Verify `⌘/` no longer triggers it (unless user has a custom override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)