### PR TITLE
Only auto-release plugin when plugin files change

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,6 +3,10 @@ name: Auto-release plugin
 on:
   push:
     branches: [main]
+    paths:
+      - "hooks/**"
+      - "skills/**"
+      - ".claude-plugin/**"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Adds path filter to auto-release workflow: only triggers on changes to `hooks/`, `skills/`, or `.claude-plugin/`
- App-only changes (shortcuts, renderer, etc.) no longer produce unnecessary plugin releases
- Manual release still available via `workflow_dispatch`

## Test plan
- [ ] Push an app-only change to main — verify auto-release does NOT run
- [ ] Push a hooks/ change to main — verify auto-release runs
- [ ] Trigger manual release via Actions UI — verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)