### PR TITLE
Add nvm PATH resolution to git hooks

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -2,6 +2,12 @@
 # Auto-setup worktrees: install deps + build renderer
 # Triggered by: git worktree add, git checkout, git switch
 
+# Ensure node/npm are on PATH (nvm isn't loaded in non-interactive shells)
+if ! command -v node &>/dev/null && [ -d "$HOME/.nvm/versions/node" ]; then
+  _nvm_node=$(ls -d "$HOME/.nvm/versions/node"/* 2>/dev/null | tail -1)
+  [ -n "$_nvm_node" ] && export PATH="$_nvm_node/bin:$PATH"
+fi
+
 # Only run when creating a new worktree or switching branches (not file checkouts)
 # $3 = 1 for branch checkout, 0 for file checkout
 [ "$3" = "1" ] || exit 0

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -2,6 +2,12 @@
 # Auto-rebuild after git pull/merge on the main working tree.
 # Ensures dist/renderer.js stays in sync with src/ changes.
 
+# Ensure node/npm are on PATH (nvm isn't loaded in non-interactive shells)
+if ! command -v node &>/dev/null && [ -d "$HOME/.nvm/versions/node" ]; then
+  _nvm_node=$(ls -d "$HOME/.nvm/versions/node"/* 2>/dev/null | tail -1)
+  [ -n "$_nvm_node" ] && export PATH="$_nvm_node/bin:$PATH"
+fi
+
 # Skip in worktrees (they have post-checkout handling)
 if [ "$(git rev-parse --git-common-dir)" != "$(git rev-parse --git-dir)" ]; then
   exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,6 +3,12 @@ set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 
+# Ensure node/npm are on PATH (nvm isn't loaded in non-interactive shells)
+if ! command -v node &>/dev/null && [ -d "$HOME/.nvm/versions/node" ]; then
+  _nvm_node=$(ls -d "$HOME/.nvm/versions/node"/* 2>/dev/null | tail -1)
+  [ -n "$_nvm_node" ] && export PATH="$_nvm_node/bin:$PATH"
+fi
+
 # Source shared merge-commit check from dotfiles (handles delete-only pushes too)
 [ -f "$HOME/.config/git-hooks/pre-push-base.sh" ] && source "$HOME/.config/git-hooks/pre-push-base.sh" || true
 


### PR DESCRIPTION
## Summary
- Adds nvm PATH detection to `pre-push`, `post-merge`, and `post-checkout` hooks
- Fixes `npm: command not found` errors when hooks run in non-interactive shells (e.g. Claude Code)
- Also fixed in dotfiles `pre-commit-base.sh` (already deployed + pushed)

## Test plan
- [ ] Run `git commit` from Claude Code — prettier runs without error
- [ ] Run `git push` from Claude Code — tests run without error
- [ ] Run `git pull` from Claude Code — post-merge build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)