### PR TITLE
feat: hidden dev mode + remote control (Phase 3 & 5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,5 +182,6 @@ Save plans to `docs/plans/` (e.g. `docs/plans/2026-03-09-feature-name.md`).
 - [docs/agents.md](docs/agents.md) — Custom agent scripts
 - [docs/shortcuts.md](docs/shortcuts.md) — Keyboard shortcuts reference
 - [docs/theme.md](docs/theme.md) — Color scheme, directory colors
+- [docs/dev-instances.md](docs/dev-instances.md) — Dev instances, hidden mode, remote control
 - [docs/debug-logging.md](docs/debug-logging.md) — Debug logging
 - [docs/testing/](docs/testing/) — Testing philosophy, isolation strategy

--- a/bin/cockpit-cli
+++ b/bin/cockpit-cli
@@ -1247,6 +1247,23 @@ case "$CMD" in
   pty-kill)     json="{\"type\":\"pty-kill\",\"id\":1,\"termId\":${1:?termId required}}"; send_api "$json" ;;
   ping)         json="{\"type\":\"ping\",\"id\":1}"; send_api "$json" ;;
   relaunch)     json="{\"type\":\"relaunch\",\"id\":1}"; send_api "$json" ;;
+  show)         json="{\"type\":\"show\",\"id\":1}"; send_api "$json" ;;
+  hide)         json="{\"type\":\"hide\",\"id\":1}"; send_api "$json" ;;
+  screenshot)
+    RESULT=$(send_api "{\"type\":\"screenshot\",\"id\":1}" 10)
+    check_error "$RESULT"
+    if [ "${1:-}" = "--raw" ]; then
+      echo "$RESULT" | jq -r '.image' | base64 -d
+    else
+      echo "$RESULT"
+    fi
+    ;;
+  ui-state)     json="{\"type\":\"ui-state\",\"id\":1}"; send_api "$json" ;;
+  session-select)
+    SID="${1:?sessionId required}"
+    json="{\"type\":\"session-select\",\"id\":1,\"sessionId\":$(printf '%s' "$SID" | jq -Rs .)}"
+    send_api "$json"
+    ;;
   get-session-graph) json="{\"type\":\"get-session-graph\",\"id\":1}"; send_api "$json" ;;
   pool-min-fresh)
     if [ -z "${1:-}" ]; then
@@ -1469,6 +1486,14 @@ Targets: Most commands accept a <target> which can be:
   slot read <index>              Read terminal buffer
   slot write <index> <data>      Write to terminal (interprets escape sequences)
   slot status <index>            Slot details (status, sessionId, termId, pid)
+
+─── WINDOW CONTROL ──────────────────────────────────────────────────────────
+
+  show                           Show the window
+  hide                           Hide the window
+  screenshot [--raw]             Capture window screenshot (base64 JSON, or --raw PNG)
+  ui-state                       Get UI state (active session, session list)
+  session-select <id>            Switch the active session in the UI
 
 ─── LOW-LEVEL ───────────────────────────────────────────────────────────────
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -124,6 +124,19 @@ cockpit-cli slot write 3 "hello"                     # Write to terminal
 cockpit-cli slot status 3                            # Slot details
 ```
 
+### Window control
+
+```bash
+cockpit-cli show                                     # Show the window
+cockpit-cli hide                                     # Hide the window
+cockpit-cli screenshot                               # Capture screenshot (base64 JSON)
+cockpit-cli screenshot --raw > shot.png              # Save screenshot as PNG file
+cockpit-cli ui-state                                 # Get UI state (active session, session list)
+cockpit-cli session-select <id>                      # Switch active session in the UI
+```
+
+These work on any instance: `cockpit-cli --instance my-dev show`.
+
 ### Low-level
 
 ```bash
@@ -212,6 +225,22 @@ Direct slot access by pool index. Works even on error-status slots that have no 
 `session-term-open` spawns a new shell at the session's cwd (or an explicit `cwd`). `session-term-close` refuses to close the TUI tab on pool sessions.
 
 `session-term-run` sends a command to a shell tab, polls for a shell prompt to reappear, and returns the output (everything between the command echo and the next prompt). Refuses TUI tabs. Throws on timeout with partial output.
+
+### Window Control
+| Command | Fields | Response |
+|---------|--------|----------|
+| `show` | -- | `{ type: "ok" }` |
+| `hide` | -- | `{ type: "ok" }` |
+| `screenshot` | -- | `{ type: "screenshot", image }` — `image` is base64-encoded PNG |
+| `ui-state` | -- | `{ type: "ui-state", activeSessionId, sessions }` |
+| `session-select` | `sessionId` | `{ type: "ok" }` |
+| `relaunch` | -- | `{ type: "ok", message }` — rebuilds from source then restarts |
+
+`screenshot` captures the BrowserWindow contents. If the window has never been shown (hidden mode), it briefly shows the window off-screen to force a paint, then re-hides it.
+
+`ui-state` returns the renderer's view of the world: which session is selected and the full session list with status, project, cwd, origin, and pool status. Unlike `get-sessions` (which queries from the main process), this reflects what the user sees in the sidebar.
+
+`session-select` switches the active session in the UI (sidebar highlight, terminal view, editor). Fire-and-forget — does not wait for the switch to complete.
 
 ### Terminals (low-level)
 | Command | Fields | Response |

--- a/docs/dev-instances.md
+++ b/docs/dev-instances.md
@@ -1,0 +1,204 @@
+# Dev Instances
+
+Dev instances run Open Cockpit in isolated sandboxes — separate state directories, sockets, and daemons — so you can test changes without touching the base (production) instance.
+
+## Quick start
+
+```bash
+# From a worktree:
+cd .wt/my-feature/
+npm run dev                     # Visible window, auto-named "my-feature"
+npm run dev:hidden              # No window — API only
+npm run dev:watch               # Visible + auto-rebuild on src/ changes
+
+# With explicit name:
+electron . --instance my-test --dev
+electron . --instance my-test --dev --hidden
+```
+
+## How it works
+
+One env var — `OPEN_COCKPIT_DIR` — scopes everything. The `--instance` flag (or worktree auto-detection) sets it:
+
+| Instance | `OPEN_COCKPIT_DIR` | State dir |
+|----------|-------------------|-----------|
+| **Base** (production) | _(unset)_ | `~/.open-cockpit/` |
+| **Dev** | `~/.open-cockpit-dev/<name>/` | same |
+| **Test** | `~/.open-cockpit-test/<name>/` | same |
+
+All paths — pool.json, daemon socket, API socket, intentions, session-pids — derive from `OPEN_COCKPIT_DIR`. No branching logic, no special cases.
+
+### Instance naming
+
+- **Worktree auto-detect**: `.wt/<name>/` in the cwd → instance name `<name>`
+- **Explicit**: `--instance <name>` flag
+- **Requirement**: `--dev` flag always requires a name (errors if run from root repo without `--instance`)
+
+### CLI routing
+
+Address any instance by name:
+
+```bash
+cockpit-cli --instance my-feature pool status
+cockpit-cli --instance my-feature screenshot --raw > debug.png
+cockpit-cli --instance my-feature session-select abc123
+```
+
+The CLI resolves the socket at `~/.open-cockpit-dev/<name>/api.sock`.
+
+## Hidden mode
+
+`--hidden` starts the app without a visible window. The full Electron renderer still runs — DOM is rendered, IPC is active, sessions work — but nothing appears on screen. Control everything via the API.
+
+```bash
+npm run dev:hidden              # Launch hidden from worktree
+```
+
+### Why use it?
+
+- **Agent testing**: Spin up headless instances for automated test harnesses
+- **CI pipelines**: Run the full app without a display (Electron's offscreen rendering)
+- **Background monitoring**: Keep an instance running without dock/taskbar clutter
+
+### Showing and hiding at runtime
+
+```bash
+cockpit-cli --instance my-dev show     # Make window visible
+cockpit-cli --instance my-dev hide     # Hide again
+```
+
+The `show` command also works as a debugging escape hatch — if you launched hidden and need to inspect the UI, just `show`.
+
+## Remote control
+
+Observe and interact with any instance via CLI or API socket.
+
+### Screenshot
+
+```bash
+# Save as PNG file
+cockpit-cli --instance my-dev screenshot --raw > /tmp/debug.png
+
+# Get base64 JSON (for programmatic use)
+cockpit-cli --instance my-dev screenshot | jq -r '.image' | base64 -d > shot.png
+```
+
+Screenshots capture the full BrowserWindow at native resolution. For hidden windows that were never shown, the handler briefly shows the window off-screen to force a paint, then re-hides it.
+
+### UI state
+
+```bash
+cockpit-cli --instance my-dev ui-state | jq .
+```
+
+Returns:
+```json
+{
+  "type": "ui-state",
+  "activeSessionId": "e196e609-...",
+  "sessions": [
+    {
+      "sessionId": "e196e609-...",
+      "status": "fresh",
+      "project": "my-project",
+      "cwd": "/Users/me/projects/my-project",
+      "origin": "pool",
+      "poolStatus": "fresh"
+    }
+  ]
+}
+```
+
+This reflects the **renderer's** view — what's visible in the sidebar, which session is selected. Compare with `get-sessions` which queries from the main process.
+
+### Session selection
+
+```bash
+# Switch active session (sidebar + terminal + editor update)
+cockpit-cli --instance my-dev session-select <sessionId>
+```
+
+Fire-and-forget — the UI updates asynchronously.
+
+### Full workflow example
+
+```bash
+# 1. Launch hidden instance
+cd .wt/my-feature && npm run dev:hidden
+
+# 2. Init pool with 2 slots
+cockpit-cli --instance my-feature pool init 2
+
+# 3. Wait for sessions to be ready
+sleep 10
+
+# 4. Send a prompt
+cockpit-cli --instance my-feature start "fix the login bug" --block
+
+# 5. Check what the UI looks like
+cockpit-cli --instance my-feature screenshot --raw > /tmp/result.png
+
+# 6. Read the result
+cockpit-cli --instance my-feature result @0
+
+# 7. Clean up
+cockpit-cli --instance my-feature pool destroy
+```
+
+## Auto-rebuild (dev:watch)
+
+`npm run dev:watch` starts a file watcher sidecar alongside the Electron process:
+
+1. `fs.watch` monitors `src/` recursively
+2. On change, debounces 300ms, then runs `npm run build`
+3. The dev instance polls `dist/renderer.js` mtime every 2s
+4. When the mtime changes, `app.relaunch()` restarts the main process
+5. Sessions survive via the daemon — terminals reconnect on reload
+
+Total turnaround: edit a file → app restarts in ~2 seconds.
+
+## Lifecycle
+
+### What happens on quit
+
+- **Dev instances** auto-destroy their pool on quit (daemon stays alive briefly for cleanup)
+- **Base instance** leaves the daemon and pool alive — terminals persist across restarts
+- **Relaunch** (`Cmd+Shift+R` or `cockpit-cli relaunch`) skips pool destroy — sessions survive
+
+### Stale processes
+
+`app.relaunch()` spawns a new process, but parent shell wrappers may linger. Worktree deletion doesn't kill associated instances.
+
+**Kill a specific worktree's instance:**
+```bash
+cd .wt/my-feature
+DAEMON_PID=$(cat ~/.open-cockpit/pty-daemon.pid 2>/dev/null || echo NONE)
+lsof -c Electron 2>/dev/null | awk -v dir="$(pwd)" '/cwd/ && $NF == dir {print $2}' | \
+  grep -v "^${DAEMON_PID}$" | sort -u | xargs kill 2>/dev/null
+```
+
+**Clean up stale dev state dirs:**
+```bash
+ls ~/.open-cockpit-dev/
+# Remove dirs for instances you no longer need
+rm -rf ~/.open-cockpit-dev/old-feature/
+```
+
+## Daemon stale detection
+
+When the daemon source code (`pty-daemon.js`, `platform.js`, `secure-fs.js`) is newer than the running daemon process, the app shows a "Daemon code updated" banner. Click "Restart daemon" to apply — this kills all terminal connections (sessions survive, but terminals must reconnect).
+
+The daemon restart is also available via:
+- Command palette: "Restart Daemon"
+- CLI: `cockpit-cli --instance my-dev` then use the `restart-daemon` IPC
+
+## Comparison with base instance
+
+| Feature | Base (`npm start`) | Dev (`npm run dev`) |
+|---------|-------------------|---------------------|
+| State dir | `~/.open-cockpit/` | `~/.open-cockpit-dev/<name>/` |
+| Auto-updater | Active | Disabled |
+| Pool on quit | Preserved | Destroyed |
+| Build polling | No | Yes (2s interval) |
+| `--hidden` | Not supported | Supported |
+| Window title | "Open Cockpit" | "Open Cockpit [name]" |

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "esbuild src/renderer.js --bundle --outfile=dist/renderer.js --platform=browser --format=iife",
     "start": "npm run build && electron .",
     "dev": "npm run build && electron . --dev",
+    "dev:hidden": "npm run build && electron . --dev --hidden",
     "dev:watch": "node scripts/dev-watch.js",
     "postinstall": "command -v electron-builder >/dev/null && electron-builder install-app-deps || true",
     "prepare": "git config core.hooksPath .githooks",

--- a/src/api-handlers.js
+++ b/src/api-handlers.js
@@ -68,6 +68,13 @@ function init({ getMainWindow }) {
   _getMainWindow = getMainWindow;
 }
 
+/** Get main window or throw if unavailable. */
+function _requireMainWindow() {
+  const win = _getMainWindow();
+  if (!win || win.isDestroyed()) throw new Error("No window");
+  return win;
+}
+
 // --- Pool interaction helpers (used by API-only handlers) ---
 
 function findSlotBySessionId(sessionId) {
@@ -390,6 +397,55 @@ function buildApiHandlers() {
       app.exit(0);
     }, 100);
     return { type: "ok", message: "Relaunching..." };
+  };
+
+  // --- Window visibility (Phase 3: Hidden Dev Mode) ---
+  handlers["show"] = async () => {
+    _requireMainWindow().show();
+    return { type: "ok" };
+  };
+
+  handlers["hide"] = async () => {
+    _requireMainWindow().hide();
+    return { type: "ok" };
+  };
+
+  // --- Remote control (Phase 5) ---
+  handlers["screenshot"] = async () => {
+    const win = _requireMainWindow();
+    // Hidden windows that were never shown don't paint the DOM.
+    // Move off-screen, show briefly to force a paint, then re-hide.
+    const wasVisible = win.isVisible();
+    if (!wasVisible) {
+      const pos = win.getPosition();
+      win.setPosition(-9999, -9999);
+      win.showInactive();
+      await new Promise((r) => setTimeout(r, 200));
+      const image = await win.webContents.capturePage();
+      win.hide();
+      win.setPosition(pos[0], pos[1]);
+      return { type: "screenshot", image: image.toPNG().toString("base64") };
+    }
+    const image = await win.webContents.capturePage();
+    return { type: "screenshot", image: image.toPNG().toString("base64") };
+  };
+
+  handlers["ui-state"] = async () => {
+    const win = _requireMainWindow();
+    // executeJavaScript is the standard Electron pattern for main→renderer data retrieval.
+    // The global is set up in renderer.js and returns a plain object (safe to serialize).
+    const uiState = await win.webContents.executeJavaScript(
+      `window.__getUiState ? window.__getUiState() : null`,
+    );
+    if (!uiState)
+      throw new Error("UI state not available (renderer not ready)");
+    return { type: "ui-state", ...uiState };
+  };
+
+  handlers["session-select"] = async (msg) => {
+    if (!msg.sessionId) throw new Error("sessionId required");
+    _requireMainWindow().webContents.send("api-session-select", msg.sessionId);
+    return { type: "ok" };
   };
 
   handlers["pty-read"] = async (msg) => {

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,10 @@
     const wtMatch = process.cwd().match(/\/\.wt\/([^/]+)/);
     if (wtMatch) instanceName = wtMatch[1];
   }
+  // --hidden flag: run without a visible window (agents interact via API)
+  if (argv.includes("--hidden")) {
+    process.env.OPEN_COCKPIT_HIDDEN = "1";
+  }
   // --dev flag requires an instance name (from --instance or worktree auto-detect)
   if (argv.includes("--dev") && !instanceName) {
     console.error(
@@ -137,9 +141,11 @@ function createWindow() {
     );
   }
 
+  const isHidden = process.env.OPEN_COCKPIT_HIDDEN === "1";
   mainWindow = new BrowserWindow({
     width: 1000,
     height: 700,
+    show: !isHidden,
     title: INSTANCE_NAME ? `Open Cockpit [${INSTANCE_NAME}]` : "Open Cockpit",
     titleBarStyle: "hiddenInset",
     webPreferences: {

--- a/src/preload.js
+++ b/src/preload.js
@@ -45,6 +45,7 @@ const channels = [
   "pool-slots-recovered",
   "update-status-changed",
   "daemon-stale",
+  "api-session-select",
 ];
 for (const ch of channels) ipcRenderer.removeAllListeners(ch);
 
@@ -270,4 +271,10 @@ contextBridge.exposeInMainWorld("api", {
 
   // Relaunch app (rebuild + restart main process)
   relaunchApp: () => ipcRenderer.invoke("relaunch-app"),
+
+  // Remote control: session select via API
+  onApiSessionSelect: (callback) =>
+    ipcRenderer.on("api-session-select", (_e, sessionId) =>
+      callback(sessionId),
+    ),
 });

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1175,6 +1175,27 @@ window.api.onIntentionChanged((content) => {
   }
 });
 
+// --- Remote control (Phase 5) ---
+
+// Expose UI state for the `ui-state` API endpoint (called via executeJavaScript)
+window.__getUiState = () => ({
+  activeSessionId: state.currentSessionId,
+  sessions: state.cachedSessions.map((s) => ({
+    sessionId: s.sessionId,
+    status: s.status,
+    project: s.project || null,
+    cwd: s.cwd || null,
+    origin: s.origin || null,
+    poolStatus: s.poolStatus || null,
+  })),
+});
+
+// Select session via API
+window.api.onApiSessionSelect(async (sessionId) => {
+  const session = state.cachedSessions.find((s) => s.sessionId === sessionId);
+  if (session) selectSession(session);
+});
+
 // --- Startup ---
 
 loadDirColors()


### PR DESCRIPTION
## Summary

- **Hidden mode** (`--hidden`): run dev instances without a visible window, control via API
- **Remote control**: `screenshot`, `ui-state`, `session-select`, `show`/`hide` API endpoints + CLI commands
- **Documentation**: comprehensive `docs/dev-instances.md` covering the full dev instance workflow

## Test plan

- [x] 474 unit/integration tests pass
- [x] Manual: hidden instance launches, API responds, no window visible
- [x] Manual: `show`/`hide` toggles window visibility
- [x] Manual: `screenshot` captures UI (handles never-shown windows by moving off-screen)
- [x] Manual: `ui-state` returns active session + session list
- [x] Manual: `session-select` switches active session, confirmed via `ui-state`
- [x] Manual: `screenshot --raw` pipes valid PNG

🤖 Generated with [Claude Code](https://claude.com/claude-code)