### PR TITLE
fix: idle signal for resumed sessions after daemon crash

### DIFF
--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -1778,6 +1778,9 @@ async function poolResume(sessionId) {
                   `Failed to re-tag orphaned terminals: ${err.message}`,
                 );
               }
+              // /resume is a local command — no model processing happens, so
+              // the Stop hook never fires. Create an idle signal immediately.
+              createFreshIdleSignal(slot.pid, newSessionId);
             }
             invalidateSessionsCache();
           },


### PR DESCRIPTION
## Summary
- `/resume` is a local command that doesn't trigger the Stop hook, so restored sessions after daemon crash never got an idle signal — permanently stuck as "processing" in the UI
- Creates a fresh idle signal immediately in the `onResolved` callback of `poolResume`'s `trackNewSlot`

## Test plan
- [ ] Kill the daemon while sessions are active
- [ ] Verify sessions get restored and show as idle (not processing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)