### PR TITLE
ci: add bin/ to auto-release paths trigger

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "hooks/**"
       - "skills/**"
+      - "bin/**"
       - ".claude-plugin/**"
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- `bin/cockpit-cli` ships with the plugin but wasn't in the auto-release paths filter
- Changes to it wouldn't trigger a new plugin release, leaving users on stale versions

## Test plan
- [ ] Future `bin/` changes should trigger auto-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)