### PR TITLE
fix: resumed sessions incorrectly categorized as typing

### DIFF
--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -161,14 +161,18 @@ async function sendCommandToTerminal(termId, command) {
 }
 
 // Create a fresh idle signal file for a pool slot
-function createFreshIdleSignal(pid, sessionId, trigger = "pool-init") {
+function createFreshIdleSignal(
+  pid,
+  sessionId,
+  { trigger = "pool-init", transcript = "" } = {},
+) {
   secureMkdirSync(IDLE_SIGNALS_DIR, { recursive: true });
   secureWriteFileSync(
     path.join(IDLE_SIGNALS_DIR, String(pid)),
     JSON.stringify({
       cwd: os.homedir(),
       session_id: sessionId,
-      transcript: "",
+      transcript,
       ts: Math.floor(Date.now() / 1000),
       trigger,
     }),
@@ -1782,7 +1786,14 @@ async function poolResume(sessionId) {
               // the Stop hook never fires. Create an idle signal immediately.
               // Use "resume" trigger (not in FRESH_TRIGGERS) so the session is
               // recognized as previously active → IDLE instead of fresh/typing.
-              createFreshIdleSignal(slot.pid, newSessionId, "resume");
+              // Include real transcript path so transcriptContains can also
+              // detect prior assistant messages as a secondary signal.
+              const { findJsonlPath } = getSessionDiscovery();
+              const transcriptPath = (await findJsonlPath(newSessionId)) || "";
+              createFreshIdleSignal(slot.pid, newSessionId, {
+                trigger: "resume",
+                transcript: transcriptPath,
+              });
             }
             invalidateSessionsCache();
           },


### PR DESCRIPTION
## Summary

- Resumed sessions were showing as "typing" instead of "idle" because `createFreshIdleSignal` used the `"pool-init"` trigger for both new and resumed sessions
- `"pool-init"` is in `FRESH_TRIGGERS`, so resumed sessions were treated as unactivated — combined with `transcript: ""`, the system couldn't detect prior activity and fell through to `freshOrTyping()` where PTY buffer content made them TYPING
- Fix: pass `"resume"` trigger for resumed sessions, which is not in `FRESH_TRIGGERS`, so the session is correctly marked as activated → IDLE

## Test plan

- [ ] Resume an offloaded session → verify it shows as idle (not typing)
- [ ] Fresh pool slots still show as fresh
- [ ] Typing in a fresh slot still transitions to typing correctly