### PR TITLE
fix: retry send_api on empty socket responses

### DIFF
--- a/bin/cockpit-cli
+++ b/bin/cockpit-cli
@@ -302,8 +302,8 @@ send_api() {
   local attempt result
 
   for attempt in 1 2 3; do
-    result=$(_send_api_once "$json" "$timeout") && true
-    local rc=$?
+    local rc=0
+    result=$(_send_api_once "$json" "$timeout") || rc=$?
     if [[ $rc -ne 0 ]]; then
       return $rc
     fi
@@ -312,7 +312,7 @@ send_api() {
       return 0
     fi
     # Empty response — retry after brief delay
-    sleep 0.2
+    [[ $attempt -lt 3 ]] && sleep 0.2
   done
   echo "Error: API returned empty response after 3 attempts" >&2
   return 1


### PR DESCRIPTION
## Summary

- `cockpit-cli start` sometimes returns exit 0 with no output — session is created but the session ID is silently lost
- Root cause: `send_api` via socat/node can return empty data on transient socket issues, and `jq` returns exit 0 on empty input, so the error goes undetected
- Fix: split `send_api` into a retry wrapper + `_send_api_once`, retrying up to 3 times with 200ms delay on empty responses
- Depends on #376 for test fixes

## Test plan

- [x] All 474 tests pass
- [x] Manual testing: `cockpit-cli start` returns session ID consistently
- [x] `cockpit-cli ping` works unchanged