### PR TITLE
feat: auto-resume offloaded sessions in pool-followup

### DIFF
--- a/bin/cockpit-cli
+++ b/bin/cockpit-cli
@@ -546,7 +546,7 @@ case "$CMD" in
     PROMPT_JSON=$(printf '%s' "$PROMPT" | jq -Rs .)
 
     json="{\"type\":\"pool-followup\",\"id\":1,\"sessionId\":\"$SID\",\"prompt\":$PROMPT_JSON}"
-    RESULT=$(send_api "$json")
+    RESULT=$(send_api "$json" 180)
     check_error "$RESULT"
 
     if $BLOCK; then
@@ -697,7 +697,7 @@ case "$CMD" in
 
     PROMPT_JSON=$(printf '%s' "$PROMPT" | jq -Rs .)
     json="{\"type\":\"pool-followup\",\"id\":1,\"sessionId\":\"$SESSION_ID\",\"prompt\":$PROMPT_JSON}"
-    RESULT=$(send_api "$json")
+    RESULT=$(send_api "$json" 180)
     check_error "$RESULT"
     SID=$(json_field "$RESULT" "sessionId")
 

--- a/src/api-handlers.js
+++ b/src/api-handlers.js
@@ -55,6 +55,7 @@ const {
   getMinFreshSlots,
   setMinFreshSlots,
   poolResume,
+  readOffloadMeta,
   withFreshSlot,
   readIntention,
   writeIntention,
@@ -479,8 +480,40 @@ function buildApiHandlers() {
   handlers["pool-followup"] = async (msg) => {
     if (!msg.sessionId) throw new Error("sessionId required");
     if (!msg.prompt) throw new Error("prompt required");
+
+    // Auto-resume offloaded sessions so callers don't need to manage pool state
+    let sessionId = msg.sessionId;
+    const currentPool = readPool();
+    const inSlot =
+      currentPool && currentPool.slots.some((s) => s.sessionId === sessionId);
+    if (!inSlot && readOffloadMeta(sessionId)) {
+      const { slotIndex } = await poolResume(sessionId);
+      // After /resume the session gets a new ID. Wait by slot index
+      // until the new session is idle.
+      await poll(
+        async () => {
+          const pool = readPool();
+          const slot = pool?.slots?.[slotIndex];
+          if (!slot?.sessionId) return null;
+          const sessions = await getSessions();
+          const session = sessions.find((s) => s.sessionId === slot.sessionId);
+          if (session?.status === STATUS.IDLE) return true;
+          if (session && !session.alive)
+            throw new Error("Session died during resume");
+          return null;
+        },
+        {
+          interval: 1000,
+          initialDelay: 2000,
+          timeout: 120000,
+          label: "waiting for resumed session",
+        },
+      );
+      sessionId = readPool().slots[slotIndex].sessionId;
+    }
+
     return withPoolLock(async () => {
-      const { pool, slot } = findSlotBySessionId(msg.sessionId);
+      const { pool, slot } = findSlotBySessionId(sessionId);
       const status = await getEffectiveSlotStatus(slot);
       if (status !== POOL_STATUS.IDLE)
         throw new Error(`Session is ${status}, expected idle`);


### PR DESCRIPTION
## Summary

- `pool-followup` now transparently resumes offloaded sessions before sending the prompt — callers no longer need to check pool state or call `resume` manually
- CLI timeout for followup commands increased from 5s to 180s to accommodate the resume + idle wait cycle

## Test plan

- [x] Manual test: offloaded session → `followup` → auto-resumes → prompt delivered → correct response
- [x] Manual test: in-slot session → `followup` → works as before (no resume path)
- [x] All 474 unit tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)