### PR TITLE
fix: CLI subcommands silently eat -v/--verbosity flag

### DIFF
--- a/bin/cockpit-cli
+++ b/bin/cockpit-cli
@@ -533,6 +533,8 @@ case "$CMD" in
     while [[ $# -gt 0 ]]; do
       case "$1" in
         --block) BLOCK=true; shift ;;
+        -v|--verbosity) VERBOSITY="${2:?verbosity level required}"; shift 2 ;;
+        -*) echo "Unknown option: $1" >&2; exit 1 ;;
         *) PROMPT="$1"; shift ;;
       esac
     done
@@ -614,6 +616,8 @@ case "$CMD" in
       case "$1" in
         --block) BLOCK=true; shift ;;
         --help|-h) echo "Usage: cockpit-cli start <prompt> [--block]" >&2; exit 0 ;;
+        -v|--verbosity) VERBOSITY="${2:?verbosity level required}"; shift 2 ;;
+        -*) echo "Unknown option: $1" >&2; exit 1 ;;
         *) PROMPT="$1"; shift ;;
       esac
     done
@@ -687,6 +691,8 @@ case "$CMD" in
     while [[ $# -gt 0 ]]; do
       case "$1" in
         --block) BLOCK=true; shift ;;
+        -v|--verbosity) VERBOSITY="${2:?verbosity level required}"; shift 2 ;;
+        -*) echo "Unknown option: $1" >&2; exit 1 ;;
         *) PROMPT="$1"; shift ;;
       esac
     done


### PR DESCRIPTION
## Summary
- Add `-v|--verbosity` handling to `start`, `prompt`, and `followup` subcommand parsers so the flag works in any position (not just before the subcommand)
- Reject unknown flags with an error instead of silently treating them as the prompt

Closes #381

## Test plan
- [x] Manual: `cockpit-cli start "say exactly: test" --block -v response` → correct prompt sent, response filtered
- [x] Manual: `cockpit-cli followup <id> "say exactly: test" --block -v response` → same
- [x] Manual: `cockpit-cli followup <id> "hello" --unknown-flag` → error "Unknown option"
- [x] All 474 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)