### PR TITLE
feat: session-owned dev instances with auto-cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,14 +20,14 @@ Runtime paths: `~/.open-cockpit/` (see [docs/architecture.md](docs/architecture.
 
 See [docs/dev-instances.md](docs/dev-instances.md) for full details.
 
-- `npm run dev` — dev instance, auto-named from worktree (e.g. `.wt/my-feature/` → `--instance my-feature`)
-- `npm run dev:watch` — same + auto-rebuild on `src/` changes, app auto-relaunches
-- Dev instances require a name — `npm run dev` from root repo (not a worktree) errors
+- **From Claude sessions**: `cockpit-cli --dev dev launch --hidden` — session-owned, auto-cleanup on exit
+- **Manual** (worktree): `npm run dev` / `npm run dev:watch` — auto-named from `.wt/<name>/`
+- All `cockpit-cli` commands work with `--dev` flag to target this session's dev instance
 
 ## Reloading after changes
 
-- **With `dev:watch`**: automatic — edit src/, app rebuilds and relaunches within ~2s
-- **Without `dev:watch`**: `npm run build`, then Cmd+R (renderer only) or Cmd+Shift+R (full rebuild + relaunch)
+- **With `--watch`** (`cockpit-cli --dev dev launch --watch`): automatic — edit src/, app rebuilds and relaunches within ~2s
+- **Without `--watch`**: `npm run build`, then Cmd+R (renderer only) or Cmd+Shift+R (full rebuild + relaunch)
 - **Daemon** (`pty-daemon.js`): in-app banner warns when daemon code is stale, click "Restart daemon" (kills all terminals)
 
 ## Native modules

--- a/bin/cockpit-cli
+++ b/bin/cockpit-cli
@@ -13,22 +13,172 @@ export PATH
 # --- Global flags (parsed before socket resolution) ---
 VERBOSITY="raw"
 INSTANCE_FLAG=""
+DEV_FLAG=""
 while [[ ${1:-} =~ ^- ]]; do
   case "$1" in
     -v|--verbosity) VERBOSITY="${2:?verbosity level required (raw|response|conversation|full)}"; shift 2 ;;
     --instance) INSTANCE_FLAG="${2:?instance name required}"; shift 2 ;;
+    --dev) DEV_FLAG=1; shift ;;
     *) break ;;
   esac
 done
 
+# --- Resolve --dev flag to session-owned instance name ---
+# Reuses detect_session_id pattern but against the base instance's session-pids dir,
+# and also captures the matched PID (the parent Claude process).
+BASE_OC_DIR="$HOME/.open-cockpit"
+if [ -n "$DEV_FLAG" ]; then
+  DEV_SESSION_ID=""
+  DEV_CLAUDE_PID=""
+  _pid=$$
+  while [[ -n "$_pid" && "$_pid" -gt 1 ]]; do
+    if [[ -f "$BASE_OC_DIR/session-pids/$_pid" ]]; then
+      DEV_SESSION_ID=$(cat "$BASE_OC_DIR/session-pids/$_pid" 2>/dev/null | tr -d '[:space:]')
+      DEV_CLAUDE_PID="$_pid"
+      break
+    fi
+    _pid=$(ps -o ppid= -p "$_pid" 2>/dev/null | tr -d '[:space:]')
+  done
+  if [ -z "$DEV_SESSION_ID" ]; then
+    echo "Error: --dev could not detect parent Claude session ID." >&2
+    echo "Make sure you're running this from within a Claude Code session." >&2
+    exit 1
+  fi
+  INSTANCE_FLAG="$DEV_SESSION_ID"
+fi
+
+# Send quit signal to a dev instance via its API socket. Args: <instance_dir>
+send_dev_quit() {
+  local dir="$1"
+  [ -S "$dir/api.sock" ] || return 0
+  node -e "const s=require('net').createConnection('$dir/api.sock');s.on('connect',()=>{s.write('{\"type\":\"quit\",\"id\":1}\n');setTimeout(()=>process.exit(0),500)});s.on('error',()=>process.exit(0))" 2>/dev/null || true
+  # Poll for daemon to exit (up to 2s) instead of fixed sleep
+  local i=0
+  while [ $i -lt 20 ] && [ -f "$dir/pty-daemon.pid" ]; do
+    local dpid; dpid=$(cat "$dir/pty-daemon.pid" 2>/dev/null | tr -d '[:space:]')
+    [[ -n "$dpid" ]] && kill -0 "$dpid" 2>/dev/null || break
+    sleep 0.1
+    i=$((i + 1))
+  done
+}
+
+# Force-kill daemon for a dev instance. Args: <instance_dir>
+kill_dev_daemon() {
+  local dir="$1"
+  [ -f "$dir/pty-daemon.pid" ] || return 0
+  local dpid; dpid=$(cat "$dir/pty-daemon.pid" 2>/dev/null | tr -d '[:space:]')
+  if [[ -n "$dpid" ]] && kill -0 "$dpid" 2>/dev/null; then
+    kill "$dpid" 2>/dev/null || true
+    echo "Killed daemon (PID $dpid)." >&2
+  fi
+}
+
 # --- Resolve state directory ---
-# Priority: --instance flag > OPEN_COCKPIT_DIR env var > default (~/.open-cockpit)
+# Priority: --instance/--dev flag > OPEN_COCKPIT_DIR env var > default (~/.open-cockpit)
 if [ -n "$INSTANCE_FLAG" ]; then
   OC_DIR="$HOME/.open-cockpit-dev/$INSTANCE_FLAG"
 elif [ -n "${OPEN_COCKPIT_DIR:-}" ]; then
   OC_DIR="$OPEN_COCKPIT_DIR"
 else
-  OC_DIR="$HOME/.open-cockpit"
+  OC_DIR="$BASE_OC_DIR"
+fi
+
+# --- Handle 'dev' subcommand (before socket resolution — instance may not exist yet) ---
+if [[ "${1:-}" == "dev" ]]; then
+  shift
+  DEV_SUB="${1:-help}"; shift 2>/dev/null || true
+
+  # Require --dev flag for all dev subcommands
+  if [ -z "$DEV_FLAG" ]; then
+    echo "Error: 'dev' subcommand requires --dev flag." >&2
+    exit 1
+  fi
+
+  dev_instance_dir="$HOME/.open-cockpit-dev/$DEV_SESSION_ID"
+
+  case "$DEV_SUB" in
+    launch)
+      # Parse launch options
+      DEV_HIDDEN=""
+      DEV_WATCH=""
+      DEV_CWD=""
+      while [[ ${1:-} =~ ^- ]]; do
+        case "$1" in
+          --hidden) DEV_HIDDEN=1; shift ;;
+          --watch) DEV_WATCH=1; shift ;;
+          --cwd) DEV_CWD="${2:?cwd required}"; shift 2 ;;
+          *) echo "Unknown launch option: $1" >&2; exit 1 ;;
+        esac
+      done
+
+      # 1:1 enforcement — kill existing dev instance for this session
+      if [ -S "$dev_instance_dir/api.sock" ] || [ -f "$dev_instance_dir/pty-daemon.pid" ]; then
+        echo "Killing existing dev instance for session $DEV_SESSION_ID..." >&2
+        send_dev_quit "$dev_instance_dir"
+        kill_dev_daemon "$dev_instance_dir"
+      fi
+
+      # Find the project root (where package.json is)
+      if [ -n "$DEV_CWD" ]; then
+        PROJECT_DIR="$DEV_CWD"
+      else
+        # Default: the open-cockpit repo this CLI lives in
+        PROJECT_DIR="$SCRIPT_DIR/.."
+      fi
+      PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd)"
+
+      # Build launch args
+      LAUNCH_ARGS=(--dev --instance "$DEV_SESSION_ID" --parent-pid "$DEV_CLAUDE_PID")
+      [ -n "$DEV_HIDDEN" ] && LAUNCH_ARGS+=(--hidden)
+
+      if [ -n "$DEV_WATCH" ]; then
+        # dev:watch uses scripts/dev-watch.js — pass electron args after "--"
+        (cd "$PROJECT_DIR" && \
+          nohup node scripts/dev-watch.js -- "${LAUNCH_ARGS[@]}" > /dev/null 2>&1 &)
+      else
+        (cd "$PROJECT_DIR" && npm run build && \
+          nohup npx electron . "${LAUNCH_ARGS[@]}" > /dev/null 2>&1 &)
+      fi
+      echo "Dev instance launched: $DEV_SESSION_ID" >&2
+      echo "  Dir: $dev_instance_dir" >&2
+      echo "  Parent PID: $DEV_CLAUDE_PID" >&2
+      echo "  CLI: cockpit-cli --dev <command>" >&2
+      exit 0
+      ;;
+    kill)
+      send_dev_quit "$dev_instance_dir"
+      kill_dev_daemon "$dev_instance_dir"
+      rm -f "$dev_instance_dir/api.sock" "$dev_instance_dir/pty-daemon.sock" "$dev_instance_dir/pty-daemon.pid" 2>/dev/null
+      echo "Dev instance cleaned up." >&2
+      exit 0
+      ;;
+    status)
+      if [ -S "$dev_instance_dir/api.sock" ]; then
+        echo "running"
+        echo "  Dir: $dev_instance_dir" >&2
+        if [ -f "$dev_instance_dir/pty-daemon.pid" ]; then
+          daemon_pid=$(cat "$dev_instance_dir/pty-daemon.pid" 2>/dev/null | tr -d '[:space:]')
+          if [[ -n "$daemon_pid" ]] && kill -0 "$daemon_pid" 2>/dev/null; then
+            echo "  Daemon: PID $daemon_pid (alive)" >&2
+          else
+            echo "  Daemon: not running" >&2
+          fi
+        fi
+      else
+        echo "stopped"
+      fi
+      exit 0
+      ;;
+    help|*)
+      echo "Usage: cockpit-cli --dev dev <subcommand>" >&2
+      echo "" >&2
+      echo "Subcommands:" >&2
+      echo "  launch [--hidden] [--watch] [--cwd <dir>]   Start dev instance for this session" >&2
+      echo "  kill                                         Kill dev instance + daemon" >&2
+      echo "  status                                       Check if dev instance is running" >&2
+      exit 0
+      ;;
+  esac
 fi
 
 # --- Resolve API socket ---
@@ -1395,6 +1545,8 @@ Usage: cockpit-cli [-v <level>] <command> [args...]
 Global flags:
   -v, --verbosity <level>        Output filter for result/capture/wait/--block
                                  Levels: raw (default), response, conversation, full
+  --dev                          Auto-detect parent Claude session, route to its dev instance
+  --instance <name>              Target a specific named instance
 
 Targets: Most commands accept a <target> which can be:
   • Full session ID (UUID)        e.g. 2947bf12-d307-499c-b50c-719f253a0e54
@@ -1498,6 +1650,14 @@ Targets: Most commands accept a <target> which can be:
   ui-state                       Get UI state (active session, session list)
   session-select <id>            Switch the active session in the UI
 
+─── DEV INSTANCES (session-owned) ───────────────────────────────────────
+
+  dev launch [--hidden] [--watch] [--cwd <dir>]
+                                   Start a dev instance owned by this Claude session
+                                   Requires --dev flag. 1:1 per session (auto-kills old)
+  dev kill                         Kill this session's dev instance + daemon
+  dev status                       Check if dev instance is running
+
 ─── LOW-LEVEL ───────────────────────────────────────────────────────────────
 
   ping                           Health check
@@ -1534,6 +1694,11 @@ Targets: Most commands accept a <target> which can be:
 
   cockpit-cli agents                                     # List available agents
   cockpit-cli agent code-review --staged                 # Run a named agent
+
+  cockpit-cli --dev dev launch --hidden             # Start dev instance for this session
+  cockpit-cli --dev pool init 3                     # Init pool on dev instance
+  cockpit-cli --dev start "fix bug" --block         # Send prompt to dev instance
+  cockpit-cli --dev dev kill                        # Kill dev instance + daemon
 USAGE
     [[ "$CMD" != "help" ]] && exit 1
     exit 0

--- a/docs/api.md
+++ b/docs/api.md
@@ -138,7 +138,7 @@ cockpit-cli ui-state                                 # Get UI state (active sess
 cockpit-cli session-select <id>                      # Switch active session in the UI
 ```
 
-These work on any instance: `cockpit-cli --instance my-dev show`.
+These work on any instance: `cockpit-cli --dev show` (session-owned) or `cockpit-cli --instance my-dev show` (named).
 
 ### Low-level
 
@@ -238,6 +238,7 @@ Direct slot access by pool index. Works even on error-status slots that have no 
 | `ui-state` | -- | `{ type: "ui-state", activeSessionId, sessions }` |
 | `session-select` | `sessionId` | `{ type: "ok" }` |
 | `relaunch` | -- | `{ type: "ok", message }` — rebuilds from source then restarts |
+| `quit` | -- | `{ type: "ok", message }` — gracefully quits the app (triggers cleanup) |
 
 `screenshot` captures the BrowserWindow contents. If the window has never been shown (hidden mode), it briefly shows the window off-screen to force a paint, then re-hides it.
 

--- a/docs/dev-instances.md
+++ b/docs/dev-instances.md
@@ -2,215 +2,151 @@
 
 Dev instances run Open Cockpit in isolated sandboxes — separate state directories, sockets, and daemons — so you can test changes without touching the base (production) instance.
 
-## Launching
-
-Do not use `open -a Electron.app`, `electron .`, or `npx electron .` — these skip `npm run build` and set `ELECTRON_RUN_AS_NODE=1`.
-
-`cd` into your worktree first:
-
-```bash
-DAEMON_PID=$(cat ~/.open-cockpit/pty-daemon.pid 2>/dev/null || echo NONE); lsof -c Electron 2>/dev/null | awk -v dir="$(pwd)" '/cwd/ && $NF == dir {print $2}' | grep -v "^${DAEMON_PID}$" | sort -u | xargs kill 2>/dev/null; sleep 0.5; unset ELECTRON_RUN_AS_NODE && nohup npm run dev > /dev/null 2>&1 &
-```
-
-Do not use `pkill -f electron` or `killall Electron` — these can kill other instances.
+Each Claude session can own **at most one** dev instance, named by its session ID. When the Claude session dies, its dev instance and daemon are automatically cleaned up.
 
 ## Quick start
 
 ```bash
-# From a worktree:
-cd .wt/my-feature/
-npm run dev                     # Visible window, auto-named "my-feature"
-npm run dev:hidden              # No window — API only
-npm run dev:watch               # Visible + auto-rebuild on src/ changes
+# Launch a dev instance (auto-detects session ID, kills existing one first)
+cockpit-cli --dev dev launch --hidden
 
-# With explicit name:
-electron . --instance my-test --dev
-electron . --instance my-test --dev --hidden
+# Use the dev instance (--dev auto-routes to this session's instance)
+cockpit-cli --dev pool init 3
+cockpit-cli --dev start "fix the bug" --block
+cockpit-cli --dev screenshot --raw > /tmp/debug.png
+
+# Check status
+cockpit-cli --dev dev status
+
+# Kill explicitly (also happens automatically when Claude session exits)
+cockpit-cli --dev dev kill
+```
+
+## Launch options
+
+```bash
+cockpit-cli --dev dev launch                    # Visible window
+cockpit-cli --dev dev launch --hidden           # No window (API only)
+cockpit-cli --dev dev launch --watch            # Auto-rebuild on src/ changes
+cockpit-cli --dev dev launch --cwd /path/to/oc  # Use specific project dir
 ```
 
 ## How it works
 
-One env var — `OPEN_COCKPIT_DIR` — scopes everything. The `--instance` flag (or worktree auto-detection) sets it:
+1. `--dev` flag walks the PPID chain to find the parent Claude session ID (via `~/.open-cockpit/session-pids/`)
+2. Uses the session ID as the instance name → state at `~/.open-cockpit-dev/<session-id>/`
+3. `dev launch` passes `--parent-pid` to the Electron app
+4. A watchdog checks the parent PID every 10s — if dead, pool destroyed + daemon killed + app quit
+5. `dev launch` enforces 1:1 — kills any existing dev instance for this session before starting
 
-| Instance | `OPEN_COCKPIT_DIR` | State dir |
-|----------|-------------------|-----------|
-| **Base** (production) | _(unset)_ | `~/.open-cockpit/` |
-| **Dev** | `~/.open-cockpit-dev/<name>/` | same |
-| **Test** | `~/.open-cockpit-test/<name>/` | same |
+One env var — `OPEN_COCKPIT_DIR` — scopes everything:
 
-All paths — pool.json, daemon socket, API socket, intentions, session-pids — derive from `OPEN_COCKPIT_DIR`. No branching logic, no special cases.
+| Instance | State dir |
+|----------|-----------|
+| **Base** (production) | `~/.open-cockpit/` |
+| **Dev** | `~/.open-cockpit-dev/<session-id>/` |
 
-### Instance naming
-
-- **Worktree auto-detect**: `.wt/<name>/` in the cwd → instance name `<name>`
-- **Explicit**: `--instance <name>` flag
-- **Requirement**: `--dev` flag always requires a name (errors if run from root repo without `--instance`)
-
-### CLI routing
-
-Address any instance by name:
-
-```bash
-cockpit-cli --instance my-feature pool status
-cockpit-cli --instance my-feature screenshot --raw > debug.png
-cockpit-cli --instance my-feature session-select abc123
-```
-
-The CLI resolves the socket at `~/.open-cockpit-dev/<name>/api.sock`.
+All paths (pool.json, daemon socket, API socket, etc.) derive from this directory.
 
 ## Hidden mode
 
-`--hidden` starts the app without a visible window. The full Electron renderer still runs — DOM is rendered, IPC is active, sessions work — but nothing appears on screen. Control everything via the API.
+`--hidden` starts the app without a visible window. The Electron renderer still runs — DOM, IPC, sessions all work — but nothing appears on screen. Control everything via the API.
+
+Show/hide at runtime:
 
 ```bash
-npm run dev:hidden              # Launch hidden from worktree
+cockpit-cli --dev show      # Make window visible
+cockpit-cli --dev hide      # Hide again
 ```
-
-### Why use it?
-
-- **Agent testing**: Spin up headless instances for automated test harnesses
-- **CI pipelines**: Run the full app without a display (Electron's offscreen rendering)
-- **Background monitoring**: Keep an instance running without dock/taskbar clutter
-
-### Showing and hiding at runtime
-
-```bash
-cockpit-cli --instance my-dev show     # Make window visible
-cockpit-cli --instance my-dev hide     # Hide again
-```
-
-The `show` command also works as a debugging escape hatch — if you launched hidden and need to inspect the UI, just `show`.
 
 ## Remote control
 
-Observe and interact with any instance via CLI or API socket.
-
-### Screenshot
-
 ```bash
-# Save as PNG file
-cockpit-cli --instance my-dev screenshot --raw > /tmp/debug.png
-
-# Get base64 JSON (for programmatic use)
-cockpit-cli --instance my-dev screenshot | jq -r '.image' | base64 -d > shot.png
+cockpit-cli --dev screenshot --raw > /tmp/debug.png    # Save screenshot
+cockpit-cli --dev ui-state                             # Get UI state
+cockpit-cli --dev pool status                          # Pool health
+cockpit-cli --dev ls                                   # List sessions
 ```
 
-Screenshots capture the full BrowserWindow at native resolution. For hidden windows that were never shown, the handler briefly shows the window off-screen to force a paint, then re-hides it.
-
-### UI state
-
-```bash
-cockpit-cli --instance my-dev ui-state | jq .
-```
-
-Returns:
-```json
-{
-  "type": "ui-state",
-  "activeSessionId": "e196e609-...",
-  "sessions": [
-    {
-      "sessionId": "e196e609-...",
-      "status": "fresh",
-      "project": "my-project",
-      "cwd": "/Users/me/projects/my-project",
-      "origin": "pool",
-      "poolStatus": "fresh"
-    }
-  ]
-}
-```
-
-This reflects the **renderer's** view — what's visible in the sidebar, which session is selected. Compare with `get-sessions` which queries from the main process.
-
-### Session selection
-
-```bash
-# Switch active session (sidebar + terminal + editor update)
-cockpit-cli --instance my-dev session-select <sessionId>
-```
-
-Fire-and-forget — the UI updates asynchronously.
-
-### Full workflow example
+## Full workflow example
 
 ```bash
 # 1. Launch hidden instance
-cd .wt/my-feature && npm run dev:hidden
+cockpit-cli --dev dev launch --hidden
 
-# 2. Init pool with 2 slots
-cockpit-cli --instance my-feature pool init 2
+# 2. Init pool
+cockpit-cli --dev pool init 2
 
 # 3. Wait for sessions to be ready
 sleep 10
 
 # 4. Send a prompt
-cockpit-cli --instance my-feature start "fix the login bug" --block
+cockpit-cli --dev start "fix the login bug" --block
 
 # 5. Check what the UI looks like
-cockpit-cli --instance my-feature screenshot --raw > /tmp/result.png
+cockpit-cli --dev screenshot --raw > /tmp/result.png
 
 # 6. Read the result
-cockpit-cli --instance my-feature result @0
+cockpit-cli --dev result @0
 
-# 7. Clean up
-cockpit-cli --instance my-feature pool destroy
+# 7. Kill (or just let it auto-clean when this session exits)
+cockpit-cli --dev dev kill
 ```
 
 ## Auto-rebuild (dev:watch)
 
-`npm run dev:watch` starts a file watcher sidecar alongside the Electron process:
+`cockpit-cli --dev dev launch --watch` starts a file watcher alongside the Electron process:
 
 1. `fs.watch` monitors `src/` recursively
-2. On change, debounces 300ms, then runs `npm run build`
-3. The dev instance polls `dist/renderer.js` mtime every 2s
-4. When the mtime changes, `app.relaunch()` restarts the main process
-5. Sessions survive via the daemon — terminals reconnect on reload
+2. On change → debounce 300ms → `npm run build`
+3. Dev instance polls `dist/renderer.js` mtime every 2s → `app.relaunch()`
+4. Sessions survive via the daemon — terminals reconnect on reload
 
-Total turnaround: edit a file → app restarts in ~2 seconds.
+Edit → app restarts in ~2 seconds.
 
 ## Lifecycle
 
 ### What happens on quit
 
-- **Dev instances** auto-destroy their pool on quit (daemon stays alive briefly for cleanup)
+- **Dev instances** auto-destroy their pool and daemon on quit
 - **Base instance** leaves the daemon and pool alive — terminals persist across restarts
+- **Parent watchdog** auto-quits when the parent Claude session dies
 - **Relaunch** (`Cmd+Shift+R` or `cockpit-cli relaunch`) skips pool destroy — sessions survive
 
-### Stale processes
+### Stale state cleanup
 
-`app.relaunch()` spawns a new process, but parent shell wrappers may linger. Worktree deletion doesn't kill associated instances.
-
-**Kill a specific worktree's instance:**
-```bash
-cd .wt/my-feature
-DAEMON_PID=$(cat ~/.open-cockpit/pty-daemon.pid 2>/dev/null || echo NONE)
-lsof -c Electron 2>/dev/null | awk -v dir="$(pwd)" '/cwd/ && $NF == dir {print $2}' | \
-  grep -v "^${DAEMON_PID}$" | sort -u | xargs kill 2>/dev/null
-```
-
-**Clean up stale dev state dirs:**
 ```bash
 ls ~/.open-cockpit-dev/
-# Remove dirs for instances you no longer need
-rm -rf ~/.open-cockpit-dev/old-feature/
+rm -rf ~/.open-cockpit-dev/<stale-session-id>/
 ```
 
-## Daemon stale detection
+### Daemon stale detection
 
-When the daemon source code (`pty-daemon.js`, `platform.js`, `secure-fs.js`) is newer than the running daemon process, the app shows a "Daemon code updated" banner. Click "Restart daemon" to apply — this kills all terminal connections (sessions survive, but terminals must reconnect).
-
-The daemon restart is also available via:
-- Command palette: "Restart Daemon"
-- CLI: `cockpit-cli --instance my-dev` then use the `restart-daemon` IPC
+When daemon source code is newer than the running daemon, the app shows a "Daemon code updated" banner. Click "Restart daemon" to apply (kills terminal connections, sessions survive).
 
 ## Comparison with base instance
 
-| Feature | Base (`npm start`) | Dev (`npm run dev`) |
-|---------|-------------------|---------------------|
-| State dir | `~/.open-cockpit/` | `~/.open-cockpit-dev/<name>/` |
+| Feature | Base (`npm start`) | Dev (`cockpit-cli --dev dev launch`) |
+|---------|-------------------|--------------------------------------|
+| State dir | `~/.open-cockpit/` | `~/.open-cockpit-dev/<session-id>/` |
 | Auto-updater | Active | Disabled |
 | Pool on quit | Preserved | Destroyed |
-| Build polling | No | Yes (2s interval) |
+| Daemon on quit | Preserved | Killed |
+| Parent watchdog | No | Yes |
 | `--hidden` | Not supported | Supported |
-| Window title | "Open Cockpit" | "Open Cockpit [name]" |
+| Window title | "Open Cockpit" | "Open Cockpit [session-id]" |
+
+## Manual instances (advanced)
+
+For development outside Claude sessions, you can still use `--instance` directly:
+
+```bash
+cd .wt/my-feature/
+npm run dev              # Auto-named from worktree
+npm run dev:hidden       # Headless
+npm run dev:watch        # Auto-rebuild
+
+cockpit-cli --instance my-feature pool status
+```
+
+These don't have parent-PID watchdog or 1:1 enforcement.

--- a/src/api-handlers.js
+++ b/src/api-handlers.js
@@ -399,6 +399,12 @@ function buildApiHandlers() {
     return { type: "ok", message: "Relaunching..." };
   };
 
+  handlers["quit"] = async () => {
+    const { app } = require("electron");
+    setTimeout(() => app.quit(), 100);
+    return { type: "ok", message: "Quitting..." };
+  };
+
   // --- Window visibility (Phase 3: Hidden Dev Mode) ---
   handlers["show"] = async () => {
     _requireMainWindow().show();

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,12 @@
   if (argv.includes("--hidden")) {
     process.env.OPEN_COCKPIT_HIDDEN = "1";
   }
+  // --parent-pid flag: dev instance lifecycle tied to parent Claude session
+  // Stored as module-level global (not env var) to avoid leaking to child processes.
+  const parentPidIdx = argv.indexOf("--parent-pid");
+  if (parentPidIdx !== -1 && argv[parentPidIdx + 1]) {
+    global.__OPEN_COCKPIT_PARENT_PID = parseInt(argv[parentPidIdx + 1], 10);
+  }
   // --dev flag requires an instance name (from --instance or worktree auto-detect)
   if (argv.includes("--dev") && !instanceName) {
     console.error(
@@ -36,7 +42,7 @@
     console.log(`[open-cockpit] Instance: ${instanceName}`);
     console.log(`[open-cockpit] Dir:      ${process.env.OPEN_COCKPIT_DIR}`);
     console.log(
-      `[open-cockpit] CLI:      cockpit-cli --instance ${instanceName} <command>`,
+      `[open-cockpit] CLI:      cockpit-cli --dev <command>  (or --instance ${instanceName})`,
     );
   }
 })();
@@ -964,6 +970,28 @@ app.whenReady().then(async () => {
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });
+
+  // --- Parent-PID watchdog for session-owned dev instances ---
+  // If --parent-pid was given, monitor that process. When it dies, clean up and quit.
+  const parentPid = global.__OPEN_COCKPIT_PARENT_PID || null;
+  if (parentPid && INSTANCE_NAME) {
+    debugLog("main", `parent-pid watchdog: monitoring PID ${parentPid}`);
+    const watchdogInterval = setInterval(async () => {
+      if (!isPidAlive(parentPid)) {
+        clearInterval(watchdogInterval);
+        debugLog(
+          "main",
+          `parent PID ${parentPid} is dead — cleaning up dev instance`,
+        );
+        await Promise.all([
+          poolManager.poolDestroy().catch(() => {}),
+          daemonClient.stopDaemon().catch(() => {}),
+        ]);
+        instancePoolDestroyed = true;
+        app.quit();
+      }
+    }, 10000);
+  }
 });
 
 let instancePoolDestroyed = false;
@@ -996,10 +1024,13 @@ app.on("before-quit", (e) => {
     const timeout = new Promise((_, reject) =>
       setTimeout(() => reject(new Error("timeout")), 5000),
     );
-    Promise.race([poolManager.poolDestroy(), timeout])
-      .then(() => debugLog("main", "instance pool destroyed on quit"))
+    Promise.race([
+      Promise.all([poolManager.poolDestroy(), daemonClient.stopDaemon()]),
+      timeout,
+    ])
+      .then(() => debugLog("main", "instance pool + daemon destroyed on quit"))
       .catch((err) =>
-        debugLog("main", "instance pool destroy failed on quit:", err.message),
+        debugLog("main", "instance cleanup failed on quit:", err.message),
       )
       .finally(() => {
         instancePoolDestroyed = true;


### PR DESCRIPTION
## Summary

- Each Claude session can own at most one dev instance, named by its session ID
- `cockpit-cli --dev` auto-detects parent session and routes all commands to its dev instance
- Parent-PID watchdog auto-quits dev instance when Claude session dies
- Fix: dev instances now kill their daemon on quit (was only disconnecting the socket)
- 1:1 enforcement: `dev launch` kills existing instance before starting a new one
- `poolDestroy` + `stopDaemon` now run in parallel for faster shutdown

## Test plan

- [x] `cockpit-cli --dev dev launch --hidden` — launches, names by session ID
- [x] `cockpit-cli --dev ping` — routes correctly
- [x] `cockpit-cli --dev dev status` — reports running/stopped
- [x] `cockpit-cli --dev dev kill` — graceful quit + daemon killed + state cleaned
- [x] All 474 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)