### PR TITLE
fix: focus terminal after reload and re-selection

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -105,8 +105,11 @@ function toggleSidebar() {
 // --- Session selection ---
 
 async function selectSession(session) {
-  // If already viewing this session, nothing to do
-  if (session.sessionId === state.currentSessionId) return;
+  // If already viewing this session, just ensure terminal has focus
+  if (session.sessionId === state.currentSessionId) {
+    focusTerminal();
+    return;
+  }
 
   hideCurrentTerminals();
 

--- a/src/terminal-manager.js
+++ b/src/terminal-manager.js
@@ -701,6 +701,9 @@ export async function reconnectAllPtys() {
 
     // Set up dock with restored terminals (including saved layout)
     initDockLayout(state.terminals, cached.dockLayout);
+
+    // Focus the terminal so the user can type immediately
+    focusTerminal();
   }
 }
 


### PR DESCRIPTION
## Summary

- After app reload (Cmd+R), terminals restore but aren't focused — user must click or switch sessions to type. Now `focusTerminal()` is called after `reconnectAllPtys` completes.
- Re-selecting the already-active session in the sidebar was a no-op. Now it focuses the terminal, useful when focus was lost to the editor or elsewhere.

## Test plan

- [x] All 473 existing tests pass
- [ ] Reload app (Cmd+R) → terminal should be focused, typing works immediately
- [ ] Click the already-selected session in sidebar → terminal regains focus