### PR TITLE
fix: don't detach pool-slot PTYs as orphans during reconnect

### DIFF
--- a/src/terminal-manager.js
+++ b/src/terminal-manager.js
@@ -645,9 +645,15 @@ export async function reconnectAllPtys() {
   // Reconnect each session's terminals (skip orphaned terminals with no session)
   for (const [sid, sessionPtys] of bySession) {
     if (sid === "__none__") {
-      debugLog("startup", `detaching ${sessionPtys.length} orphaned PTYs`);
-      for (const p of sessionPtys) {
-        window.api.ptyDetach(p.termId).catch(() => {});
+      // Don't detach pool-slot PTYs — they may not have a sessionId yet
+      // (trackNewSlot hasn't resolved). Detaching them would orphan the
+      // Claude process and break pool status detection.
+      const orphans = sessionPtys.filter((p) => !p.isPoolTui);
+      if (orphans.length > 0) {
+        debugLog("startup", `detaching ${orphans.length} orphaned PTYs`);
+        for (const p of orphans) {
+          window.api.ptyDetach(p.termId).catch(() => {});
+        }
       }
       continue;
     }


### PR DESCRIPTION
## Summary

- `reconnectAllPtys()` detaches all PTYs without a `sessionId`, but pool-slot PTYs may not have one yet (`trackNewSlot` hasn't resolved)
- Detaching them orphans the Claude process and breaks pool status detection
- Fix: filter out pool-slot PTYs (`isPoolTui`) before detaching

Cherry-picked from #357 (rest superseded by the registry-based restore system on main).

## Test plan

- [x] All 473 tests pass
- [ ] Reload app while pool slots are still in STARTING state — verify they aren't detached