### PR TITLE
feat: command palette recency + restart session command

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -238,7 +238,6 @@ Direct slot access by pool index. Works even on error-status slots that have no 
 | `ui-state` | -- | `{ type: "ui-state", activeSessionId, sessions }` |
 | `session-select` | `sessionId` | `{ type: "ok" }` |
 | `relaunch` | -- | `{ type: "ok", message }` — rebuilds from source then restarts |
-| `quit` | -- | `{ type: "ok", message }` — gracefully quits the app (triggers cleanup) |
 
 `screenshot` captures the BrowserWindow contents. If the window has never been shown (hidden mode), it briefly shows the window off-screen to force a paint, then re-hides it.
 

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -64,6 +64,7 @@ All shortcuts appear in the command palette (`Cmd+/`). The `COMMANDS` array in `
 | `Cmd+Shift+B` | Toggle Bell (mute/unmute notifications) |
 | `Cmd+Shift+A` | Run Agent (open agent picker) |
 | `Cmd+Shift+R` | Relaunch App (rebuild + restart main process) |
+| *(unbound)* | Restart Current Session (archived/offloaded) |
 | *(unbound)* | Toggle Pane Focus (editor ↔ terminal) |
 | *(unbound)* | Split Right |
 | *(unbound)* | Split Down |

--- a/src/api-handlers.js
+++ b/src/api-handlers.js
@@ -399,12 +399,6 @@ function buildApiHandlers() {
     return { type: "ok", message: "Relaunching..." };
   };
 
-  handlers["quit"] = async () => {
-    const { app } = require("electron");
-    setTimeout(() => app.quit(), 100);
-    return { type: "ok", message: "Quitting..." };
-  };
-
   // --- Window visibility (Phase 3: Hidden Dev Mode) ---
   handlers["show"] = async () => {
     _requireMainWindow().show();

--- a/src/command-palette.js
+++ b/src/command-palette.js
@@ -12,6 +12,18 @@ let _actions = {};
 let shortcutConfig = {};
 let COMMANDS = [];
 
+// --- Recent command tracking ---
+let recentCommands = {};
+
+async function loadRecentCommands() {
+  recentCommands = await window.api.getPreference("recentCommands", {});
+}
+
+function recordCommandUsage(commandId) {
+  recentCommands[commandId] = Date.now();
+  window.api.setPreference("recentCommands", recentCommands);
+}
+
 export function initCommandPalette(actions) {
   _actions = actions;
 
@@ -100,6 +112,12 @@ export function initCommandPalette(actions) {
       label: "Archive Current Session",
       shortcutAction: "archive-current-session",
       action: () => _actions.archiveCurrentSession(),
+    },
+    {
+      id: "restart-current-session",
+      label: "Restart Current Session",
+      shortcutAction: "restart-current-session",
+      action: () => _actions.restartCurrentSession(),
     },
     {
       id: "toggle-sidebar",
@@ -256,6 +274,8 @@ export function initCommandPalette(actions) {
     });
   }
 
+  loadRecentCommands();
+
   // Wire palette input events
   dom.commandPaletteInput.addEventListener("input", () => {
     paletteSelectedIndex = 0;
@@ -283,6 +303,7 @@ export function initCommandPalette(actions) {
     if (e.key === "Enter" && filteredCommands.length > 0) {
       e.preventDefault();
       const cmd = filteredCommands[paletteSelectedIndex];
+      recordCommandUsage(cmd.id);
       closeCommandPalette();
       cmd.action();
       return;
@@ -406,13 +427,19 @@ function getCommandShortcut(cmd) {
 
 function renderPaletteList(query) {
   const q = query.toLowerCase();
-  filteredCommands = q
-    ? COMMANDS.filter(
-        (c) =>
-          c.label.toLowerCase().includes(q) ||
-          getCommandShortcut(c).toLowerCase().includes(q),
-      )
-    : COMMANDS.filter((c) => !c.id.startsWith("tab-")); // Hide tab-N from unfiltered list
+  const byRecency = (a, b) =>
+    (recentCommands[b.id] || 0) - (recentCommands[a.id] || 0);
+  if (q) {
+    filteredCommands = COMMANDS.filter(
+      (c) =>
+        c.label.toLowerCase().includes(q) ||
+        getCommandShortcut(c).toLowerCase().includes(q),
+    ).sort(byRecency);
+  } else {
+    filteredCommands = COMMANDS.filter((c) => !c.id.startsWith("tab-")).sort(
+      byRecency,
+    );
+  }
 
   paletteSelectedIndex = Math.min(
     paletteSelectedIndex,
@@ -426,6 +453,7 @@ function renderPaletteList(query) {
     const shortcut = getCommandShortcut(cmd);
     item.innerHTML = `<span class="command-palette-label">${cmd.label}</span><span class="command-palette-shortcut">${shortcut}</span>`;
     item.addEventListener("click", () => {
+      recordCommandUsage(cmd.id);
       closeCommandPalette();
       cmd.action();
     });

--- a/src/main.js
+++ b/src/main.js
@@ -356,6 +356,12 @@ function buildMenu() {
           accelerator: accel("archive-current-session"),
           click: () => send("archive-current-session"),
         },
+        {
+          label: "Restart Current Session",
+          accelerator: accel("restart-current-session"),
+          click: () => send("restart-current-session"),
+          visible: !!accel("restart-current-session"),
+        },
         { type: "separator" },
         {
           label: "Search Sessions",

--- a/src/preload.js
+++ b/src/preload.js
@@ -35,6 +35,7 @@ const channels = [
   "split-down",
   "jump-recent-idle",
   "archive-current-session",
+  "restart-current-session",
   "open-in-cursor",
   "open-pool-settings",
   "session-info",
@@ -249,6 +250,8 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.on("jump-recent-idle", () => callback()),
   onArchiveCurrentSession: (callback) =>
     ipcRenderer.on("archive-current-session", () => callback()),
+  onRestartCurrentSession: (callback) =>
+    ipcRenderer.on("restart-current-session", () => callback()),
   onOpenInCursor: (callback) =>
     ipcRenderer.on("open-in-cursor", () => callback()),
   onOpenPoolSettings: (callback) =>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -680,6 +680,27 @@ async function archiveCurrentSession() {
   await loadSessions();
 }
 
+// --- Restart current archived/offloaded session ---
+
+async function restartCurrentSession() {
+  if (!state.currentSessionId) return;
+  const session = state.cachedSessions.find(
+    (s) => s.sessionId === state.currentSessionId,
+  );
+  if (!session) return;
+  if (session.status !== STATUS.ARCHIVED && session.status !== STATUS.OFFLOADED)
+    return;
+
+  if (session.status === STATUS.ARCHIVED) {
+    try {
+      await window.api.unarchiveSession(session.sessionId);
+    } catch (err) {
+      debugLog("session", `unarchive failed: ${err.message}`);
+    }
+  }
+  await resumeOffloadedSession(session);
+}
+
 // --- Setup script picker ---
 
 function showSetupScriptPicker(scripts) {
@@ -812,6 +833,7 @@ initCommandPalette({
   cycleTabInFocusedLeaf,
   jumpToRecentIdle,
   archiveCurrentSession,
+  restartCurrentSession,
   toggleSidebar,
   togglePaneFocus,
   focusEditor,
@@ -1082,6 +1104,7 @@ window.api.onSplitDown(() => splitFocusedTab("down"));
 window.api.onFocusExternalTerminal(focusCurrentExternalTerminal);
 window.api.onJumpRecentIdle(jumpToRecentIdle);
 window.api.onArchiveCurrentSession(archiveCurrentSession);
+window.api.onRestartCurrentSession(restartCurrentSession);
 window.api.onOpenInCursor(() => {
   if (state.currentSessionCwd) window.api.openInCursor(state.currentSessionCwd);
 });

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -53,6 +53,8 @@ const DEFAULT_SHORTCUTS = {
   "jitter-terminal": "CmdOrCtrl+Shift+J",
   // Relaunch app (rebuild + restart main process)
   "relaunch-app": "CmdOrCtrl+Shift+R",
+  // Restart current archived/offloaded session
+  "restart-current-session": "",
   // Restart daemon (kills all terminals)
   "restart-daemon": "",
   // These are handled via before-input-event, not menu accelerators


### PR DESCRIPTION
## Summary

Cherry-picks the 3 valuable features from the stale `ux-improvements` worktree (now deleted):

- **Command palette recency sorting**: Recently-used commands float to the top, persisted via preferences
- **Restart Current Session**: New command (unbound by default) that unarchives + resumes archived/offloaded sessions in one action
- **Remove `quit` API handler**: Unused — dev instances use process signals, not API quit

## Test plan

- [x] All 473 tests pass
- [ ] Open command palette → use a command → reopen → it should appear near the top
- [ ] View an archived session → run "Restart Current Session" from palette → session resumes
- [ ] Verify `quit` API is gone: `echo '{"type":"quit","id":1}' | socat - UNIX-CONNECT:~/.open-cockpit/api.sock` → should return error