### PR TITLE
fix: focus terminal after restarting a session

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -400,6 +400,7 @@ async function resumeOffloadedSession(session) {
     await window.api.watchIntention(newSession.sessionId);
   }
   await loadSessions();
+  focusTerminal();
 }
 
 // Poll getSessions until we find the session in a given pool slot


### PR DESCRIPTION
## Summary
- `resumeOffloadedSession()` was missing a `focusTerminal()` call after `loadSessions()`, so restarting a session left the cursor unfocused
- New session creation already handled this via `selectSession()` → `focusTerminal()` — this just adds the same behavior to restart

## Test plan
- [ ] Restart an archived/offloaded session → cursor should be in the terminal