### PR TITLE
fix: dev instances share production state dir when launched from pool sessions

### DIFF
--- a/bin/cockpit-cli
+++ b/bin/cockpit-cli
@@ -131,13 +131,17 @@ if [[ "${1:-}" == "dev" ]]; then
       LAUNCH_ARGS=(--dev --instance "$DEV_SESSION_ID" --parent-pid "$DEV_CLAUDE_PID")
       [ -n "$DEV_HIDDEN" ] && LAUNCH_ARGS+=(--hidden)
 
+      # Unset OPEN_COCKPIT_DIR so the dev instance's bootstrap derives its own
+      # isolated directory from --instance. Without this, the env var inherited
+      # from a base-instance pool session would make the dev instance share
+      # production state (daemon, pool, sockets).
       if [ -n "$DEV_WATCH" ]; then
         # dev:watch uses scripts/dev-watch.js — pass electron args after "--"
         (cd "$PROJECT_DIR" && \
-          nohup node scripts/dev-watch.js -- "${LAUNCH_ARGS[@]}" > /dev/null 2>&1 &)
+          OPEN_COCKPIT_DIR= nohup node scripts/dev-watch.js -- "${LAUNCH_ARGS[@]}" > /dev/null 2>&1 &)
       else
         (cd "$PROJECT_DIR" && npm run build && \
-          nohup npx electron . "${LAUNCH_ARGS[@]}" > /dev/null 2>&1 &)
+          OPEN_COCKPIT_DIR= nohup npx electron . "${LAUNCH_ARGS[@]}" > /dev/null 2>&1 &)
       fi
       echo "Dev instance launched: $DEV_SESSION_ID" >&2
       echo "  Dir: $dev_instance_dir" >&2

--- a/src/main.js
+++ b/src/main.js
@@ -32,13 +32,13 @@
   }
   if (instanceName) {
     process.env.OPEN_COCKPIT_INSTANCE_NAME = instanceName;
-    if (!process.env.OPEN_COCKPIT_DIR) {
-      process.env.OPEN_COCKPIT_DIR = require("path").join(
-        require("os").homedir(),
-        ".open-cockpit-dev",
-        instanceName,
-      );
-    }
+    // Always override — OPEN_COCKPIT_DIR may be inherited from a base-instance
+    // pool session, which would cause the dev instance to share production state.
+    process.env.OPEN_COCKPIT_DIR = require("path").join(
+      require("os").homedir(),
+      ".open-cockpit-dev",
+      instanceName,
+    );
     console.log(`[open-cockpit] Instance: ${instanceName}`);
     console.log(`[open-cockpit] Dir:      ${process.env.OPEN_COCKPIT_DIR}`);
     console.log(


### PR DESCRIPTION
## Summary

- When `cockpit-cli --dev dev launch` runs inside a pool session, the base instance's `OPEN_COCKPIT_DIR` env var is inherited. The bootstrap in `main.js` had a `if (!process.env.OPEN_COCKPIT_DIR)` guard that skipped setting the dev directory, causing the dev instance to use the production state directory — sharing daemon, pool, and sockets with the base instance.
- Quitting such a dev instance **destroys the production pool** (dev instances destroy their pool on quit).
- Fix: always override `OPEN_COCKPIT_DIR` when `--instance` is provided (main.js), and unset the env var before launching the Electron process (cockpit-cli).

## Test plan

- [x] All 473 tests pass
- [ ] Launch dev instance from within a pool session, verify `Dir:` output shows `~/.open-cockpit-dev/<id>/` not `~/.open-cockpit/`
- [ ] Quit the dev instance, verify the production pool is unaffected