### PR TITLE
fix: cascade-archive children server-side

### DIFF
--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -52,7 +52,7 @@ Sessions track who started them and parent-child relationships in `~/.open-cockp
 - CLI also detects parent by walking PPID chain → `~/.open-cockpit/session-pids/`
 - API: `pool-start` accepts optional `parentSessionId`; `get-session-graph` returns the full graph
 - `get-sessions` response enriched with `parentSessionId` and `initiator` fields
-- **Child session archiving**: Dead child sessions are NOT independently auto-archived — they stay under their parent and only get archived when the parent is archived (depth-first cascade)
+- **Child session archiving**: Children always stay grouped under their parent. `archiveSession()` cascade-archives all descendants depth-first (server-side). Dead children are never independently auto-archived — they wait for the parent's cascade. Children without snapshot/intention are preserved on disk if they have a `parentSessionId` in the graph.
 
 ## Session pinning
 

--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -462,9 +462,27 @@ async function saveExternalClearOffload(oldSessionId, pid) {
 // Archive a session: mark its offload meta as archived.
 // For live pool sessions, offload first (snapshot + /clear), then mark archived.
 // For already-offloaded sessions, just flip the archived flag.
-async function archiveSession(sessionId) {
+// Get all descendant session IDs from the graph, depth-first (deepest first).
+function getDescendantsFromGraph(sessionId, graph) {
+  const result = [];
+  const visited = new Set();
+  function walk(id) {
+    for (const [childId, entry] of Object.entries(graph)) {
+      if (entry.parentSessionId === id && !visited.has(childId)) {
+        visited.add(childId);
+        walk(childId);
+        result.push(childId);
+      }
+    }
+  }
+  walk(sessionId);
+  return result;
+}
+
+// Archive a single session (no cascade). Handles live pool sessions, offloaded,
+// and dead sessions. Callers handle invalidateSessionsCache().
+async function archiveSingleSession(sessionId) {
   validateSessionId(sessionId);
-  const { invalidateSessionsCache } = getSessionDiscovery();
   const meta = readOffloadMeta(sessionId);
   if (meta) {
     // Already offloaded — just mark as archived
@@ -474,7 +492,6 @@ async function archiveSession(sessionId) {
       path.join(OFFLOADED_DIR, sessionId, "meta.json"),
       JSON.stringify(meta, null, 2),
     );
-    invalidateSessionsCache();
     return;
   }
 
@@ -508,17 +525,35 @@ async function archiveSession(sessionId) {
       JSON.stringify(updatedMeta, null, 2),
     );
   } else {
-    // No offload data yet — create archive-only meta via writeOffloadMeta
+    // No offload data yet — create archive-only meta
     await writeOffloadMeta(sessionId, {
       claudeSessionId: sessionId,
       archived: true,
     });
   }
-  // Kill any orphaned extra terminals for this session immediately
   killOrphanedTerminals(sessionId);
+}
 
-  // Offloaded children are cascade-archived in getOffloadedSessions() on next
-  // session discovery pass — no need to duplicate that logic here.
+// Archive a session and all its descendants (cascade, depth-first).
+async function archiveSession(sessionId) {
+  validateSessionId(sessionId);
+  const { invalidateSessionsCache } = getSessionDiscovery();
+
+  // Cascade: archive all descendants depth-first (deepest first)
+  const graph = readSessionGraph();
+  const descendants = getDescendantsFromGraph(sessionId, graph);
+  for (const childId of descendants) {
+    try {
+      await archiveSingleSession(childId);
+    } catch (err) {
+      _debugLog(
+        "main",
+        `Failed to cascade-archive child ${childId}: ${err.message}`,
+      );
+    }
+  }
+
+  await archiveSingleSession(sessionId);
   invalidateSessionsCache();
 }
 

--- a/src/session-discovery.js
+++ b/src/session-discovery.js
@@ -522,6 +522,7 @@ async function getOffloadedSessions() {
   } catch {
     return [];
   }
+  const graph = readJsonSync(SESSION_GRAPH_FILE, {});
   const sessions = [];
   for (const dir of dirs) {
     try {
@@ -529,9 +530,14 @@ async function getOffloadedSessions() {
       if (!meta) continue;
       const snapshotFile = path.join(OFFLOADED_DIR, dir, "snapshot.log");
       const hasSnapshot = fs.existsSync(snapshotFile);
+      // Preserve child sessions whose parent still exists (even without
+      // snapshot/intention) so they stay grouped under their parent.
+      const parentId = graph[dir]?.parentSessionId;
+      const isChildWithParent =
+        parentId && fs.existsSync(path.join(OFFLOADED_DIR, parentId));
 
-      // Delete empty sessions (no snapshot + no intention) — they were never used
-      if (!hasSnapshot && !meta.intentionHeading) {
+      // Delete empty sessions (no snapshot + no intention) — they were never used.
+      if (!hasSnapshot && !meta.intentionHeading && !isChildWithParent) {
         try {
           fs.rmSync(path.join(OFFLOADED_DIR, dir), { recursive: true });
           // Clean up empty intention file if it exists
@@ -597,10 +603,6 @@ async function getOffloadedSessions() {
       );
     }
   }
-
-  // Children follow their parent's section in the UI (via session graph),
-  // but are never cascade-archived — they stay offloaded so the parent can
-  // resume conversations with them when reloaded.
 
   return sessions;
 }
@@ -866,9 +868,9 @@ async function getSessionsUncached() {
   sessions.length = 0;
   sessions.push(...dedupedSessions);
 
-  // Archive dead sessions (save as archived without snapshot)
-  // Child sessions (sub-agents) are NOT independently archived — they stay
-  // grouped under their parent and only get archived when the parent is archived.
+  // Archive dead sessions (save as archived without snapshot).
+  // Child sessions are never independently auto-archived — archiveSession()
+  // cascade-archives all descendants when the parent is archived.
   const poolForArchive = readPool();
   const poolSessionIdsForArchive = new Set();
   if (poolForArchive) {
@@ -877,19 +879,23 @@ async function getSessionsUncached() {
     }
   }
   const sessionGraph = readJsonSync(SESSION_GRAPH_FILE, {});
-  const sessionIdSet = new Set(sessions.map((s) => s.sessionId));
   for (let i = sessions.length - 1; i >= 0; i--) {
     const s = sessions[i];
     if (s.status !== STATUS.DEAD) continue;
 
-    // Skip auto-archive for child sessions whose parent exists — they'll be
-    // archived when the parent is archived (depth-first cascade in renderer)
+    // Skip auto-archive for child sessions whose parent still exists — they'll
+    // be cascade-archived when parent is archived via archiveSession().
+    // If the parent is completely gone (no live session, no offload data), let
+    // the child be auto-archived normally to prevent orphan accumulation.
     const graphEntry = sessionGraph[s.sessionId];
-    if (
-      graphEntry?.parentSessionId &&
-      sessionIdSet.has(graphEntry.parentSessionId)
-    ) {
-      continue;
+    if (graphEntry?.parentSessionId) {
+      const parentLive = sessions.some(
+        (p) => p.sessionId === graphEntry.parentSessionId,
+      );
+      const parentOffloaded =
+        !parentLive &&
+        fs.existsSync(path.join(OFFLOADED_DIR, graphEntry.parentSessionId));
+      if (parentLive || parentOffloaded) continue;
     }
 
     const offloadDir = path.join(OFFLOADED_DIR, s.sessionId);

--- a/src/session-sidebar.js
+++ b/src/session-sidebar.js
@@ -443,7 +443,8 @@ function getAliveDescendants(sessionId) {
   return descendants.filter((s) => s.alive);
 }
 
-// Archive with child check: warns if session has alive descendants, archives depth-first
+// Archive with child check: warns if session has alive descendants, then
+// delegates to server which cascade-archives all descendants depth-first.
 async function archiveWithChildCheck(session) {
   const aliveDescendants = getAliveDescendants(session.sessionId);
 
@@ -453,16 +454,6 @@ async function archiveWithChildCheck(session) {
       aliveDescendants,
     );
     if (!confirmed) return;
-
-    // Archive depth-first: deepest descendants first, then parent
-    const descendants = getDescendantsDepthFirst(session.sessionId);
-    for (const desc of descendants) {
-      try {
-        await window.api.archiveSession(desc.sessionId);
-      } catch (err) {
-        console.error("Failed to archive child session:", desc.sessionId, err);
-      }
-    }
   }
 
   try {


### PR DESCRIPTION
## Summary

- `archiveSession()` now cascade-archives all descendants depth-first before archiving the parent (server-side, works from API too)
- Dead children no longer get silently discarded or independently auto-archived — they stay grouped under their parent
- Children without snapshot/intention are preserved on disk as long as their parent exists
- Orphan safety: children of vanished parents still get auto-archived normally

## What was broken

1. `archiveWithChildCheck` only cascade-archived when **alive** descendants existed. If all children were dead (finished sub-agents), they were left to auto-archive independently — which discarded them if they had no intention heading
2. `getOffloadedSessions` deleted children without snapshot/intention from disk
3. Auto-archive checked parent existence only in live sessions, missing offloaded/archived parents

## Test plan

- [x] All 473 existing tests pass
- [ ] Archive a parent session with dead children → children stay grouped under parent in archive
- [ ] Archive a parent with alive children → confirmation dialog, then all archived together
- [ ] Restart an archived parent → children still visible under parent
- [ ] Orphaned children (parent manually deleted) eventually get auto-archived