### PR TITLE
fix: custom session spawn failing due to hook ERR and env leak

### DIFF
--- a/hooks/session-pid-map.sh
+++ b/hooks/session-pid-map.sh
@@ -10,23 +10,6 @@ source "$(dirname "$0")/common.sh"
 
 mkdir -p "$SESSION_PIDS_DIR"
 
-# Ensure cockpit-cli is accessible at a stable path and on PATH
-OC_BIN_DIR="$OC_DIR/bin"
-PLUGIN_CLI="$(dirname "$0")/../bin/cockpit-cli"
-if [ -f "$PLUGIN_CLI" ]; then
-    target="$(cd "$(dirname "$PLUGIN_CLI")" && pwd)/cockpit-cli"
-    if [ "$(readlink "$OC_BIN_DIR/cockpit-cli" 2>/dev/null)" != "$target" ]; then
-        mkdir -p "$OC_BIN_DIR"
-        ln -sf "$target" "$OC_BIN_DIR/cockpit-cli"
-    fi
-    # Also symlink into /usr/local/bin so it's on PATH without shell config changes
-    if [ -d /usr/local/bin ] && [ -w /usr/local/bin ]; then
-        if [ "$(readlink /usr/local/bin/cockpit-cli 2>/dev/null)" != "$OC_BIN_DIR/cockpit-cli" ]; then
-            ln -sf "$OC_BIN_DIR/cockpit-cli" /usr/local/bin/cockpit-cli 2>/dev/null || true
-        fi
-    fi
-fi
-
 # Read session_id from JSON stdin (avoid python3 startup overhead)
 input=""
 read -t 1 -r input 2>/dev/null || true
@@ -36,6 +19,26 @@ session_id=$(json_get "$input" "session_id") || true
 
 # $PPID is the Claude process that spawned this hook
 echo "$session_id" > "$SESSION_PIDS_DIR/$PPID"
+
+# --- Best-effort CLI symlinks (non-critical) ---
+# Failures here must not prevent session registration above.
+{
+    OC_BIN_DIR="$OC_DIR/bin"
+    PLUGIN_CLI="$(dirname "$0")/../bin/cockpit-cli"
+    if [ -f "$PLUGIN_CLI" ]; then
+        target="$(cd "$(dirname "$PLUGIN_CLI")" && pwd)/cockpit-cli"
+        if [ "$(readlink "$OC_BIN_DIR/cockpit-cli" 2>/dev/null)" != "$target" ]; then
+            mkdir -p "$OC_BIN_DIR"
+            ln -sf "$target" "$OC_BIN_DIR/cockpit-cli"
+        fi
+        # Also symlink into /usr/local/bin so it's on PATH without shell config changes
+        if [ -d /usr/local/bin ] && [ -w /usr/local/bin ]; then
+            if [ "$(readlink /usr/local/bin/cockpit-cli 2>/dev/null)" != "$OC_BIN_DIR/cockpit-cli" ]; then
+                ln -sf "$OC_BIN_DIR/cockpit-cli" /usr/local/bin/cockpit-cli 2>/dev/null || true
+            fi
+        fi
+    fi
+} 2>/dev/null || true
 
 # Clean up stale entries (PIDs that no longer exist)
 for f in "$SESSION_PIDS_DIR"/*; do

--- a/src/pty-daemon.js
+++ b/src/pty-daemon.js
@@ -121,10 +121,12 @@ function handleSpawn(socket, msg) {
   const cwd = msg.cwd || os.homedir();
   const termId = nextTermId++;
 
-  // Strip Claude session env vars
+  // Strip Claude session env vars and origin-tagging vars inherited from daemon parent
   const cleanEnv = { ...process.env, TERM: "xterm-256color" };
   delete cleanEnv.CLAUDECODE;
   delete cleanEnv.CLAUDE_CODE_SESSION_ID;
+  delete cleanEnv.OPEN_COCKPIT_POOL;
+  delete cleanEnv.OPEN_COCKPIT_CUSTOM;
   cleanEnv.PATH = joinPathEnv(EXTRA_PATH_DIRS, process.env.PATH);
 
   // Merge caller-provided env overrides (e.g. OPEN_COCKPIT_POOL for origin tagging)


### PR DESCRIPTION
## Summary

- **Hook ordering**: `session-pid-map.sh` wrote the PID file (critical for session registration) AFTER the CLI symlink section. If symlink setup hit an ERR (`set -e` + line 28), the script exited before writing the PID file → `ptyWaitSession` timed out → "Custom session failed to register". Fix: move PID file write before symlinks, wrap symlinks in `|| true`.
- **Env leak**: The PTY daemon inherited `OPEN_COCKPIT_POOL=1` from its parent env. All spawned sessions got both `POOL` and `CUSTOM` env vars, but `detectOrigin` checks `POOL` first → custom sessions were misclassified as pool origin. Fix: strip origin-tagging vars from `cleanEnv` before merging `msg.env`.

## Test plan

- [x] All 473 existing tests pass
- [ ] Cmd+Shift+N → custom session spawns and appears in sidebar
- [ ] Custom session shows `origin: custom` (not pool)
- [ ] Pool sessions still work normally after daemon restart