### PR TITLE
fix: diagnostics for session/terminal failures, kill orphaned pool processes

### DIFF
--- a/src/pool-manager.js
+++ b/src/pool-manager.js
@@ -1106,7 +1106,10 @@ async function reconcilePool() {
     } catch {}
 
     const pool = readPool();
-    if (!pool) return;
+    if (!pool) {
+      _debugLog("reconcile", "no pool file — skipping");
+      return;
+    }
 
     const { terminalHasInputCache } = getSessionDiscovery();
     let changed = false;
@@ -1116,7 +1119,12 @@ async function reconcilePool() {
     try {
       const resp = await daemonRequest({ type: "list" });
       daemonPtys = new Map(resp.ptys.map((p) => [p.termId, p]));
+      _debugLog(
+        "reconcile",
+        `pool has ${pool.slots.length} slots, daemon has ${daemonPtys.size} PTYs`,
+      );
     } catch {
+      _debugLog("reconcile", "daemon not running — skipping");
       return; // Daemon not running — can't reconcile
     }
 
@@ -1233,6 +1241,68 @@ async function reconcilePool() {
 
     // Prune session graph — remove entries for sessions that no longer exist
     pruneSessionGraph(pool);
+
+    // Clean up orphaned processes: alive PIDs in session-pids that aren't
+    // tracked by any pool slot and have no offload/archive metadata.
+    // These are remnants from previous pool incarnations (e.g., pool was
+    // destroyed and re-created, but old Claude processes survived).
+    const poolPids = new Set(pool.slots.map((s) => String(s.pid)));
+    try {
+      for (const file of fs.readdirSync(SESSION_PIDS_DIR)) {
+        if (poolPids.has(file)) continue; // Tracked by pool — skip
+        const pid = Number(file);
+        if (!Number.isFinite(pid)) continue;
+        if (!isPidAlive(pid)) {
+          // Dead process — just clean up the PID file
+          cleanupPidFiles(file);
+          continue;
+        }
+        // Alive process not tracked by pool — check if it's a known
+        // external/custom session (has offload metadata or is the current
+        // renderer session). Only kill processes that look like orphaned
+        // pool slots (spawned with --dangerously-skip-permissions).
+        const sessionId = fs
+          .readFileSync(path.join(SESSION_PIDS_DIR, file), "utf-8")
+          .trim();
+        if (!sessionId) continue;
+        const meta = readOffloadMeta(sessionId);
+        if (meta) continue; // Has offload data — managed session
+        // Check if the process command includes pool flags (heuristic).
+        // Use /proc on Linux, ps on macOS. Skip on Windows (no reliable way).
+        let cmdLine = "";
+        try {
+          if (process.platform === "linux") {
+            cmdLine = fs.readFileSync(`/proc/${pid}/cmdline`, "utf-8");
+          } else if (process.platform === "darwin") {
+            const { execFileSync } = require("child_process");
+            cmdLine = execFileSync(
+              "ps",
+              ["-p", String(pid), "-o", "command="],
+              {
+                encoding: "utf-8",
+                timeout: 2000,
+              },
+            ).trim();
+          }
+        } catch {
+          /* process inspection failed — skip */
+        }
+        if (cmdLine.includes("--dangerously-skip-permissions")) {
+          _debugLog(
+            "main",
+            `Killing orphaned pool process PID ${pid} session=${sessionId} (not tracked by any pool slot)`,
+          );
+          try {
+            process.kill(pid, "SIGTERM");
+          } catch {
+            /* ESRCH */
+          }
+          cleanupPidFiles(file);
+        }
+      }
+    } catch {
+      /* ENOENT — no session-pids dir */
+    }
   });
 
   // Restore missing sessions OUTSIDE the pool lock to avoid deadlock

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -163,6 +163,17 @@ async function selectSession(session) {
       }
       const slot = pool?.slots.find((s) => s.sessionId === session.sessionId);
       daemonTermId = slot?.termId || null;
+      if (!slot) {
+        debugLog(
+          "session",
+          `pool slot NOT FOUND for session=${session.sessionId} (pool has ${pool?.slots.length} slots, sessionIds: ${pool?.slots.map((s) => s.sessionId?.slice(0, 8)).join(",")})`,
+        );
+      } else {
+        debugLog(
+          "session",
+          `pool slot found: index=${slot.index} termId=${slot.termId} status=${slot.status}`,
+        );
+      }
     } else if (session.origin === "custom") {
       const allPtys = await window.api.ptyList();
       if (gen !== state.sessionGeneration) {
@@ -173,21 +184,30 @@ async function selectSession(session) {
         (p) => p.sessionId === session.sessionId && !p.exited,
       );
       daemonTermId = pty?.termId || null;
+      debugLog(
+        "session",
+        `custom session daemon lookup: ${pty ? `termId=${pty.termId}` : "NOT FOUND"}`,
+      );
     }
 
     if (daemonTermId) {
       // Attach to existing daemon terminal (pool or custom)
       try {
+        debugLog("session", `attaching to daemon termId=${daemonTermId}`);
         await attachPoolTerminal(daemonTermId);
         if (gen !== state.sessionGeneration) {
           debugLog("session", `race abort gen=${gen} at daemonAttach`);
           destroySessionTerminals(session.sessionId);
           return;
         }
-      } catch {
+        debugLog("session", `attached successfully to termId=${daemonTermId}`);
+      } catch (err) {
         debugLog(
           "session",
-          `attach failed for ${daemonTermId}, falling back to shell`,
+          `attach FAILED for termId=${daemonTermId}: ${err.message} — falling back to shell`,
+        );
+        showNotification(
+          `Failed to attach to Claude terminal (termId=${daemonTermId}) — spawned shell instead. Error: ${err.message}`,
         );
         await spawnTerminal(session.cwd);
         if (gen !== state.sessionGeneration) {
@@ -198,6 +218,13 @@ async function selectSession(session) {
       }
     } else if (session.origin === "pool" || session.origin === "custom") {
       // Daemon session but no terminal found — fallback to shell
+      debugLog(
+        "session",
+        `NO daemon terminal for ${session.origin} session=${session.sessionId} — falling back to shell`,
+      );
+      showNotification(
+        `No daemon terminal found for ${session.origin} session — spawned shell instead`,
+      );
       await spawnTerminal(session.cwd);
       if (gen !== state.sessionGeneration) {
         debugLog("session", `race abort gen=${gen} at noTermSpawn`);
@@ -206,6 +233,7 @@ async function selectSession(session) {
       }
     } else {
       // External session: spawn a fresh shell
+      debugLog("session", `external session — spawning shell`);
       await spawnTerminal(session.cwd);
       if (gen !== state.sessionGeneration) {
         debugLog("session", `race abort gen=${gen} at extSpawn`);
@@ -244,13 +272,32 @@ function isFreshPoolSlot(s) {
 // Returns the fresh session object or null if pool is fully busy.
 async function acquireFreshSlot() {
   const sessions = await window.api.getSessions();
+  const poolSessions = sessions.filter((s) => s.origin === "pool");
+  const statusCounts = {};
+  for (const s of poolSessions) {
+    const key = s.poolStatus || s.status;
+    statusCounts[key] = (statusCounts[key] || 0) + 1;
+  }
+  debugLog(
+    "acquire",
+    `${sessions.length} sessions, ${poolSessions.length} pool: ${JSON.stringify(statusCounts)}`,
+  );
 
   // 1. Prefer an existing fresh slot (poolStatus is set by main process)
   const freshSession = sessions.find(isFreshPoolSlot);
-  if (freshSession) return freshSession;
+  if (freshSession) {
+    debugLog(
+      "acquire",
+      `found fresh slot session=${freshSession.sessionId} poolStatus=${freshSession.poolStatus} status=${freshSession.status}`,
+    );
+    return freshSession;
+  }
 
   // No pool sessions at all — nothing to acquire from
-  if (!sessions.some((s) => s.origin === "pool")) return null;
+  if (poolSessions.length === 0) {
+    debugLog("acquire", "no pool sessions — nothing to acquire");
+    return null;
+  }
 
   // 2. Offload the longest-unused idle session (LRU)
   const idleSessions = sessions
@@ -262,14 +309,24 @@ async function acquireFreshSlot() {
     )
     .sort((a, b) => a.idleTs - b.idleTs);
 
-  if (idleSessions.length === 0) return null; // All slots busy — can't acquire
+  if (idleSessions.length === 0) {
+    debugLog("acquire", "no fresh or idle pool sessions — all busy");
+    return null;
+  }
 
   const victim = idleSessions[0];
+  debugLog("acquire", `offloading LRU idle session=${victim.sessionId}`);
 
   // Find the victim's terminal from pool data (need termId for offload)
   const pool = await window.api.poolRead();
   const victimSlot = pool?.slots.find((s) => s.sessionId === victim.sessionId);
-  if (!victimSlot) return null;
+  if (!victimSlot) {
+    debugLog(
+      "acquire",
+      `victim slot not found in pool for session=${victim.sessionId}`,
+    );
+    return null;
+  }
 
   try {
     await window.api.offloadSession(
@@ -882,15 +939,21 @@ dom.refreshBtn.addEventListener("click", async () => {
 
 let newSessionInProgress = false;
 dom.newSessionBtn.addEventListener("click", async () => {
-  if (newSessionInProgress) return;
+  if (newSessionInProgress) {
+    debugLog("new-session", "skipped — already in progress");
+    return;
+  }
   newSessionInProgress = true;
+  debugLog("new-session", "starting");
   try {
     // Check pool is initialized
     const pool = await window.api.poolRead();
     if (!pool) {
+      debugLog("new-session", "aborted — pool not initialized");
       showNotification("Pool not initialized — open pool settings");
       return;
     }
+    debugLog("new-session", `pool has ${pool.slots.length} slots`);
 
     // Check for setup scripts before acquiring a slot
     let selectedScript = null;
@@ -902,13 +965,22 @@ dom.newSessionBtn.addEventListener("click", async () => {
 
     const freshSlot = await acquireFreshSlot();
     if (!freshSlot) {
+      debugLog("new-session", "aborted — no fresh slot available");
       showNotification(
         "All pool slots are busy — wait for a session to finish or resize pool",
       );
       return;
     }
+    debugLog(
+      "new-session",
+      `acquired fresh slot session=${freshSlot.sessionId} origin=${freshSlot.origin} status=${freshSlot.status} poolStatus=${freshSlot.poolStatus}`,
+    );
 
     await selectSession(freshSlot);
+    debugLog(
+      "new-session",
+      `selectSession complete for ${freshSlot.sessionId}`,
+    );
 
     // Type setup script into the session's terminal
     if (selectedScript) {
@@ -925,6 +997,10 @@ dom.newSessionBtn.addEventListener("click", async () => {
     }
 
     await loadSessions();
+    debugLog("new-session", "done");
+  } catch (err) {
+    debugLog("new-session", `error: ${err.message}`);
+    showNotification(`New session failed: ${err.message}`);
   } finally {
     newSessionInProgress = false;
   }

--- a/src/terminal-manager.js
+++ b/src/terminal-manager.js
@@ -309,12 +309,24 @@ export async function spawnTerminal(cwd, cmd, args, targetLeafId) {
 
 // Attach to an existing pool slot's PTY (no spawn — the Claude TUI is already running)
 export async function attachPoolTerminal(poolTermId) {
+  debugLog("attach", `attaching to pool terminal termId=${poolTermId}`);
   // Fetch the PTY's current dimensions so we can create xterm at the same size.
   // This prevents xterm.js reflow garbling when the replay buffer is written:
   // the buffer was rendered at these dimensions, so writing to a matching-size
   // terminal produces correct output. FitAddon later resizes to window dims.
   const allPtys = await window.api.ptyList();
   const ptyInfo = allPtys.find((p) => p.termId === poolTermId);
+  if (!ptyInfo) {
+    debugLog(
+      "attach",
+      `termId=${poolTermId} NOT FOUND in daemon (${allPtys.length} PTYs, termIds: ${allPtys.map((p) => p.termId).join(",")})`,
+    );
+  } else {
+    debugLog(
+      "attach",
+      `termId=${poolTermId} found: pid=${ptyInfo.pid} exited=${ptyInfo.exited} cols=${ptyInfo.cols} rows=${ptyInfo.rows} buffer=${ptyInfo.buffer ? ptyInfo.buffer.length + " chars" : "empty"} clients=${ptyInfo.clientCount}`,
+    );
+  }
 
   const container = document.createElement("div");
   container.style.cssText = "width:100%;height:100%;";
@@ -351,8 +363,12 @@ export async function attachPoolTerminal(poolTermId) {
   pendingTerminals.set(poolTermId, entry);
   try {
     await window.api.ptyAttach(poolTermId);
+    debugLog("attach", `ptyAttach succeeded for termId=${poolTermId}`);
   } catch (err) {
-    debugLog("pool", `attach failed poolTermId=${poolTermId}`, err.message);
+    debugLog(
+      "attach",
+      `ptyAttach FAILED for termId=${poolTermId}: ${err.message}`,
+    );
     const idx = state.terminals.indexOf(entry);
     if (idx !== -1) state.terminals.splice(idx, 1);
     term.dispose();
@@ -648,9 +664,19 @@ export async function reconnectAllPtys() {
       // Don't detach pool-slot PTYs — they may not have a sessionId yet
       // (trackNewSlot hasn't resolved). Detaching them would orphan the
       // Claude process and break pool status detection.
+      const poolPtys = sessionPtys.filter((p) => p.isPoolTui);
       const orphans = sessionPtys.filter((p) => !p.isPoolTui);
+      if (poolPtys.length > 0) {
+        debugLog(
+          "startup",
+          `skipping ${poolPtys.length} pool PTYs without sessionId (termIds: ${poolPtys.map((p) => p.termId).join(",")})`,
+        );
+      }
       if (orphans.length > 0) {
-        debugLog("startup", `detaching ${orphans.length} orphaned PTYs`);
+        debugLog(
+          "startup",
+          `detaching ${orphans.length} orphaned PTYs (termIds: ${orphans.map((p) => `${p.termId}/pid=${p.pid}`).join(", ")})`,
+        );
         for (const p of orphans) {
           window.api.ptyDetach(p.termId).catch(() => {});
         }
@@ -680,6 +706,11 @@ export async function reconnectAllPtys() {
       lastAccessed: Date.now(),
     });
   }
+
+  debugLog(
+    "startup",
+    `reconnected ${sessionTerminals.size} sessions (${[...sessionTerminals.keys()].map((s) => s.slice(0, 8)).join(", ")})`,
+  );
 
   // Restore the most recent alive session that has terminals
   const sessions = await window.api.getSessions();


### PR DESCRIPTION
## Summary

- **Debug logging** across the entire Cmd+N → acquireFreshSlot → selectSession → attachPoolTerminal flow — every decision point now logs what happened and why
- **User-visible notifications** when pool terminal attach fails or no daemon terminal is found (previously silently fell back to an empty shell with no indication)
- **Orphaned pool process cleanup** during reconcilePool — kills alive Claude processes with `--dangerously-skip-permissions` that aren't tracked by any pool slot (remnants from pool re-creation)
- **Startup reconnection logging** — details about skipped pool PTYs, orphan detachment, and reconnected sessions

## Context

After Cmd+Shift+R relaunch, Cmd+N could produce an empty shell terminal instead of a Claude session. There was zero logging in this path, making diagnosis impossible. Additionally, pool re-creation left behind orphaned Claude processes that appeared as ghost "stale" sessions in the sidebar.

## Test plan

- [x] All 473 existing tests pass
- [ ] Cmd+Shift+R → Cmd+N should show Claude session (or notification explaining failure)
- [ ] Check `~/.open-cockpit/debug.log` for `[new-session]`, `[acquire]`, `[attach]`, `[reconcile]` entries
- [ ] Orphaned pool processes should be killed on next reconcile cycle (30s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)