### PR TITLE
Add .intentions-off toggle to disable intention prompt hooks

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -22,6 +22,15 @@ On every user prompt, diffs the intention file against its last known snapshot. 
 
 Resolves the session ID via the PID mapping written by `session-pid-map.sh`.
 
+### Disabling intention prompts
+
+Both intention hooks exit silently when `~/.open-cockpit/.intentions-off` exists:
+
+```bash
+touch ~/.open-cockpit/.intentions-off   # disable
+rm ~/.open-cockpit/.intentions-off      # re-enable
+```
+
 ## Idle signal hooks → `idle-signal.sh`
 
 Detects when sessions become idle (waiting for user input) or start processing. Writes signal files to `~/.open-cockpit/idle-signals/<PID>`.

--- a/hooks/intention-change-notify.sh
+++ b/hooks/intention-change-notify.sh
@@ -8,6 +8,9 @@
 set -euo pipefail
 source "$(dirname "$0")/common.sh"
 
+# Toggle: `touch ~/.open-cockpit/.intentions-off` disables intention prompts, `rm` re-enables
+[ -f "$OC_DIR/.intentions-off" ] && exit 0
+
 # Skip if session-intention-intro.sh just fired (avoid redundant output on first prompt)
 JUST_FIRED="$MARKER_DIR/.just-fired"
 if [ -f "$JUST_FIRED" ]; then

--- a/hooks/session-intention-intro.sh
+++ b/hooks/session-intention-intro.sh
@@ -8,6 +8,9 @@
 set -euo pipefail
 source "$(dirname "$0")/common.sh"
 
+# Toggle: `touch ~/.open-cockpit/.intentions-off` disables intention prompts, `rm` re-enables
+[ -f "$OC_DIR/.intentions-off" ] && exit 0
+
 # Resolve session_id via PID mapping (written by session-pid-map.sh at SessionStart)
 resolve_session_id
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -124,6 +124,12 @@ describe("session-intention-intro.sh", () => {
     const { stdout } = runHook("session-intention-intro.sh");
     expect(stdout).toBe("");
   });
+
+  it("outputs nothing when .intentions-off toggle exists", () => {
+    fs.writeFileSync(path.join(tmpHome, ".open-cockpit/.intentions-off"), "");
+    const { stdout } = runHook("session-intention-intro.sh");
+    expect(stdout).toBe("");
+  });
 });
 
 describe("intention-change-notify.sh", () => {
@@ -167,6 +173,12 @@ describe("intention-change-notify.sh", () => {
 
   it("exits cleanly when no PID mapping exists", () => {
     fs.unlinkSync(path.join(tmpHome, ".open-cockpit/session-pids", hookPid()));
+    const { stdout } = runHook("intention-change-notify.sh");
+    expect(stdout).toBe("");
+  });
+
+  it("outputs nothing when .intentions-off toggle exists", () => {
+    fs.writeFileSync(path.join(tmpHome, ".open-cockpit/.intentions-off"), "");
     const { stdout } = runHook("intention-change-notify.sh");
     expect(stdout).toBe("");
   });


### PR DESCRIPTION
## Summary
- `session-intention-intro.sh` and `intention-change-notify.sh` exit silently when `~/.open-cockpit/.intentions-off` exists
- `touch ~/.open-cockpit/.intentions-off` disables intention prompts; `rm` re-enables
- Documented in docs/hooks.md, covered by two new tests in test/hooks.test.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)